### PR TITLE
Create codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+ignore:
+  - "tests"
+
+comment:
+  layout: "header, diff, tree, changes, sunburst"
+  require_changes: false
+  
+coverage:
+  status:
+    patch: off
+project: off


### PR DESCRIPTION
adding a file to stop those stupid patch labels that are prone to go wrong and disallow merging if they think coverage has dropped from the previous commit 

Closes #83 