### PR TITLE
Monospace font for JSON pane

### DIFF
--- a/resources/Qtmodels/Main.qml
+++ b/resources/Qtmodels/Main.qml
@@ -179,6 +179,7 @@ ApplicationWindow {
                     Label {
                         id: jsonText
                         text: (collapsed ? collapsed_text : full_text)
+                        font.family: "Courier New"
                         wrapMode: Text.Wrap
                         width: parent.width
                         MouseArea {


### PR DESCRIPTION
### Issue

Closes #115

### Description of work

Makes the JSON pane use a monospace font.

### Acceptance Criteria 

You're satisfied that Courier New is an appropriate font choice that will work on different systems.

### Nominate for Group Code Review

- [ ] Nominate for code review 
