### PR TITLE
123 remove bounce when scrolling through components and translations

### DIFF
--- a/resources/Qtmodels/ComponentControls.qml
+++ b/resources/Qtmodels/ComponentControls.qml
@@ -66,6 +66,7 @@ Pane {
             anchors.top: parent.top
             anchors.bottom: parent.bottom
             clip: true
+            boundsBehavior: Flickable.StopAtBounds
         }
     }
 

--- a/resources/Qtmodels/TransformControls.qml
+++ b/resources/Qtmodels/TransformControls.qml
@@ -88,6 +88,7 @@ Item {
             delegate: transformDelegate
             implicitHeight: (contentHeight < 250) ? contentHeight : 250
             clip: true
+            boundsBehavior: Flickable.StopAtBounds
         }
     }
 


### PR DESCRIPTION
### Issue

Closes #123 

### Description of work

Removes the bounce from the components list and transformation list.

### Acceptance Criteria 

Add several components and several transformations. Check that scrolling through them doesn't cause bouncing.

### Nominate for Group Code Review

- [ ] Nominate for code review 
