### PR TITLE
Scrollbar for transformations

### DIFF
--- a/resources/Qtmodels/TransformControls.qml
+++ b/resources/Qtmodels/TransformControls.qml
@@ -89,14 +89,7 @@ Item {
             implicitHeight: (contentHeight < 250) ? contentHeight : 250
             clip: true
             boundsBehavior: Flickable.StopAtBounds
-            ScrollBar.vertical: ScrollBar {
-                    policy: ScrollBar.AsNeeded
-                    active: true
-                    onActiveChanged: {
-                        if (!active)
-                            active = true;
-                    }
-                }
+            ScrollBar.vertical: ActiveScrollBar {}
         }
     }
 

--- a/resources/Qtmodels/TransformControls.qml
+++ b/resources/Qtmodels/TransformControls.qml
@@ -90,8 +90,13 @@ Item {
             clip: true
             boundsBehavior: Flickable.StopAtBounds
             ScrollBar.vertical: ScrollBar {
-                policy: transformsListView.contentHeight > transformsListView.height ? ScrollBar.AlwaysOn : ScrollBar.AlwaysOff
-            }
+                    policy: ScrollBar.AsNeeded
+                    active: true
+                    onActiveChanged: {
+                        if (!active)
+                            active = true;
+                    }
+                }
         }
     }
 

--- a/resources/Qtmodels/TransformControls.qml
+++ b/resources/Qtmodels/TransformControls.qml
@@ -89,6 +89,9 @@ Item {
             implicitHeight: (contentHeight < 250) ? contentHeight : 250
             clip: true
             boundsBehavior: Flickable.StopAtBounds
+            ScrollBar.vertical: ScrollBar {
+                policy: transformsListView.contentHeight > transformsListView.height ? ScrollBar.AlwaysOn : ScrollBar.AlwaysOff
+            }
         }
     }
 


### PR DESCRIPTION
### Issue

Closes #132 

### Description of work

Adds a scrollbar to the transformation pane when its contents are too large. Removes it when enough transformations are deleted.

### Acceptance Criteria 

Add a component with multiple transformations and check that a scrollbar appears. Check that deleting enough transformations causes the scrollbar to vanish.

### Nominate for Group Code Review

- [ ] Nominate for code review 
