### PR TITLE
Using ActiveScrollBar for PixelMapping

### DIFF
--- a/resources/Qtmodels/PixelControls.qml
+++ b/resources/Qtmodels/PixelControls.qml
@@ -37,20 +37,15 @@ Item {
             id: view
             anchors.left: parent.left
             height: contentHeight
-            width: view.contentHeight > view.height ? parent.width - 10 : parent.width
+            width: parent.width
             interactive: false
             clip: true
             ScrollBar.vertical: bar
             boundsBehavior: Flickable.StopAtBounds
         }
 
-        ScrollBar {
-
+        ActiveScrollBar {
             id: bar
-
-            active: true
-            policy: view.contentHeight > view.height ? ScrollBar.AlwaysOn : ScrollBar.AlwaysOff
-
             anchors {
                 left: view.right
                 top: view.top


### PR DESCRIPTION
### Issue

Closes #167

### Description of work

Uses the `ActiveScrollBar` for the pixel mapping stuff rather than comparing the height of the listview to the height of its contents.

### Acceptance Criteria 


### Nominate for Group Code Review

- [ ] Nominate for code review 
