### PR TITLE
174 pint throws an exception if you type in the file selection box

### DIFF
--- a/resources/Qtmodels/GeometryControls.qml
+++ b/resources/Qtmodels/GeometryControls.qml
@@ -8,6 +8,7 @@ import GeometryValidator 1.0
 
 Pane {
     property var geometryModel: noShapeModel
+    property string fileLocation
 
     id: pane
     padding: 0
@@ -63,7 +64,6 @@ Pane {
                 labelText: "Geometry file:"
                 editorText: file_url
                 anchoredEditor: true
-                onEditingFinished: file_url = editorText
                 readOnly: true
             }
             PaddedButton {
@@ -125,7 +125,6 @@ Pane {
 
                     LabeledTextField {
                         id: unitInput
-                        // labelText: "Geometry file:"
                         editorText: units
                         Layout.fillWidth: true
                         anchoredEditor: true

--- a/resources/Qtmodels/GeometryControls.qml
+++ b/resources/Qtmodels/GeometryControls.qml
@@ -8,7 +8,6 @@ import GeometryValidator 1.0
 
 Pane {
     property var geometryModel: noShapeModel
-    property string fileLocation
 
     id: pane
     padding: 0


### PR DESCRIPTION
### Issue

Closes #174

### Description of work

Pint translates an empty string to "dimensionless" units so this change should prevent that from happening by only setting the filename (and creating the Geometry) after choosing units.

### Acceptance Criteria 

Try to type some things into the filename box and then click in a different part of the window. The error should no longer appear. File loading should also work just the same as before.

### Nominate for Group Code Review

- [ ] Nominate for code review 
