### PR TITLE
Enable MacOS executable build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -166,7 +166,7 @@ node("docker") {
         def builders = [:]
         builders['centos7'] = get_linux_pipeline()
         // disabled for now as the build isn't setup for Mac OS just yet.
-        // builders['macOS'] = get_macos_pipeline()
+        builders['macOS'] = get_macos_pipeline()
         builders['windows10'] = get_win10_pipeline()
 
         parallel builders


### PR DESCRIPTION
### Issue

Closes #88 

### Description of work

Enabling the MacOS build in the jenkinsfile to archive the executables for MacOS

### Acceptance Criteria 

Test that the executable runs on MacOS without any system libraries installed. 
