### PR TITLE
Only creating executables on pr builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,96 +22,95 @@ return {
     node('windows10') {
       // Use custom location to avoid Win32 path length issues
       ws('c:\\jenkins\\') {
-      cleanWs()
-      dir("${project}") {
-        stage("win10: Checkout") {
-          scm_vars = checkout scm
-        }  // stage
-
-	stage("win10: Setup") {
-          bat """python -m pip install --user -r requirements.txt
-	    """
-	} // stage
-        stage("win10: Build Executable") {
-          bat """
-	    python setup.py build_exe"""
-        }  // stage
-    stage('win10: Archive Executable'){
-        def git_commit_short = scm_vars.GIT_COMMIT.take(7)
-        powershell label: 'Archiving build folder', script: "Compress-Archive -Path .\\build -DestinationPath nexus-constructor_windows_${git_commit_short}.zip"
-        archiveArtifacts 'nexus-constructor*.zip'
-    } // stage
-
-      }  // dir
+          cleanWs()
+          dir("${project}") {
+            stage("Checkout") {
+              scm_vars = checkout scm
+            }  // stage
+            stage("Setup") {
+                  bat """python -m pip install --user -r requirements.txt
+                """
+            } // stage
+            stage("Run tests") {
+                bat """python -m pytest . -s
+                """
+            } // stage
+            if (env.CHANGE_ID) {
+                stage("Build Executable") {
+                    bat """
+                    python setup.py build_exe"""
+                } // stage
+                stage('Archive Executable') {
+                    def git_commit_short = scm_vars.GIT_COMMIT.take(7)
+                    powershell label: 'Archiving build folder', script: "Compress-Archive -Path .\\build -DestinationPath nexus-constructor_windows_${git_commit_short}.zip"
+                    archiveArtifacts 'nexus-constructor*.zip'
+                } // stage
+            } // if
+          } // dir
       } //ws
-} // node
-} // return
+    } // node
+  } // return
 } // def
 
 def get_macos_pipeline() {
-return {
-node('macos') {
-
-cleanWs()
-dir("${project}") {
-
- stage('Checkout') {
- try {
-    checkout scm
- } catch (e) {
-    failure_function(e, 'MacOSX / Checkout failed')
- }
- }
-
- stage('Setup'){
-    sh "python3 -m pip install --user -r requirements.txt"
- }
-
- stage('Build Executable') {
-    sh "python3 setup.py build_exe"
- }
- // archive as well
-} // dir
-} // node
-} // return
+    return {
+        node('macos') {
+            cleanWs()
+            dir("${project}") {
+                stage('Checkout') {
+                    try {
+                        checkout scm
+                    } catch (e) {
+                        failure_function(e, 'MacOSX / Checkout failed')
+                    } // catch
+                } // stage
+                stage('Setup') {
+                    sh "python3 -m pip install --user -r requirements.txt"
+                } // stage
+                stage('Build Executable') {
+                    sh "python3 setup.py build_exe"
+                } // stage
+                 // archive as well
+            } // dir
+        } // node
+    } // return
 } // def
 
 def get_linux_pipeline() {
-return {
-stage("Create virtualenv") {
+    return {
+        stage("Create virtualenv") {
             sh """docker exec ${container_name} ${sh_cmd} -c \"
                 cd ${project}
                 python3.6 -m venv build_env
             \""""
-        }
-stage("Install requirements") {
-    sh """docker exec ${container_name} ${sh_cmd} -c \"
-        cd ${project}
-        build_env/bin/pip --proxy ${https_proxy} install --upgrade pip
-        build_env/bin/pip --proxy ${https_proxy} install -r requirements.txt
-        build_env/bin/pip --proxy ${https_proxy} install codecov==2.0.15 black
-        \""""
-}
-
-stage("Check formatting") {
+        } // stage
+        stage("Install requirements") {
+            sh """docker exec ${container_name} ${sh_cmd} -c \"
+                cd ${project}
+                build_env/bin/pip --proxy ${https_proxy} install --upgrade pip
+                build_env/bin/pip --proxy ${https_proxy} install -r requirements.txt
+                build_env/bin/pip --proxy ${https_proxy} install codecov==2.0.15 black
+                \""""
+        } // stage
+        stage("Check formatting") {
             sh """docker exec ${container_name} ${sh_cmd} -c \"
                 cd ${project}
                 build_env/bin/python -m black . --check --exclude=build_env/
             \""""
-                              }
-stage("Run Linter") {
-        sh """docker exec ${container_name} ${sh_cmd} -c \"
-                cd ${project}
-                build_env/bin/flake8
-            \""""
-}
-stage("Run tests") {
+        } // stage
+        stage("Run Linter") {
+            sh """docker exec ${container_name} ${sh_cmd} -c \"
+                    cd ${project}
+                    build_env/bin/flake8
+                \""""
+        } // stage
+        stage("Run tests") {
             def testsError = null
             try {
-                sh """docker exec ${container_name} ${sh_cmd} -c \"
-                    cd ${project}
-                    build_env/bin/python -m pytest -s ./tests --ignore=build_env --junit-xml=/home/jenkins/${project}/test_results.xml --assert=plain --cov=nexus_constructor --cov-report=xml
-                \""""
+                    sh """docker exec ${container_name} ${sh_cmd} -c \"
+                        cd ${project}
+                        build_env/bin/python -m pytest -s ./tests --ignore=build_env --junit-xml=/home/jenkins/${project}/test_results.xml --assert=plain --cov=nexus_constructor --cov-report=xml
+                    \""""
                 }
                 catch(err) {
                     testsError = err
@@ -125,18 +124,18 @@ stage("Run tests") {
             }
             sh "docker cp ${container_name}:/home/jenkins/${project}/test_results.xml test_results.xml"
             junit "test_results.xml"
-        }
-if (env.CHANGE_ID) {
-    stage('Build Executable'){
-        sh "docker exec ${container_name} ${sh_cmd} -c \" cd ${project} && build_env/bin/python setup.py build_exe  \" "
-    }
-    stage('Archive Executable') {
-        def git_commit_short = scm_vars.GIT_COMMIT.take(7)
-        sh "docker cp ${container_name}:/home/jenkins/${project}/build/ ./build && tar czvf nexus-constructor_linux_${git_commit_short}.tar.gz ./build "
-        archiveArtifacts artifacts: 'nexus-constructor*.tar.gz', fingerprint: true
-    } // stage
-} // if
-} // return
+        } // stage
+        if (env.CHANGE_ID) {
+            stage('Build Executable'){
+                sh "docker exec ${container_name} ${sh_cmd} -c \" cd ${project} && build_env/bin/python setup.py build_exe  \" "
+            }
+            stage('Archive Executable') {
+                def git_commit_short = scm_vars.GIT_COMMIT.take(7)
+                sh "docker cp ${container_name}:/home/jenkins/${project}/build/ ./build && tar czvf nexus-constructor_linux_${git_commit_short}.tar.gz ./build "
+                archiveArtifacts artifacts: 'nexus-constructor*.tar.gz', fingerprint: true
+            } // stage
+        } // if
+    } // return
 } // def
 
 node("docker") {
@@ -166,11 +165,8 @@ node("docker") {
         // builders['macOS'] = get_macos_pipeline()
 
         // Only build executables on windows if it is a PR build
-        if (env.CHANGE_ID) {
-            builders['windows10'] = get_win10_pipeline()
-        }
+        builders['windows10'] = get_win10_pipeline()
         parallel builders
-
     } finally {
         container.stop()
     }


### PR DESCRIPTION
### Issue

None

### Description of work

Previously on branch builds the windows node would be used to create the executables but not build it. This removes the windows build if it's not a PR build as there is no point in running unit tests twice. 



### Acceptance Criteria 
- Executables should still be built and archived on PR builds
- The windows build steps should not appear in the jenkins interface on the branch build. 

### Nominate for Group Code Review

- [ ] Nominate for code review 
