### PR TITLE
Fixing regex warning in helpers.py

### DIFF
--- a/nexus_constructor/qml_models/helpers.py
+++ b/nexus_constructor/qml_models/helpers.py
@@ -29,7 +29,7 @@ def generate_unique_name(base: str, items: list):
     :param base: The generated name will be the base string, followed by a number if required
     :param items: The named items to avoid generating a matching name with. Each must have a 'name' attribute
     """
-    regex = "^{}\d*$".format(re.escape(base))
+    regex = f"^{re.escape(base)}\\d*$"
     similar_names = [item.name for item in items if re.match(regex, item.name)]
 
     if len(similar_names) == 0 or base not in similar_names:


### PR DESCRIPTION
### Issue

Closes #202 

### Description of work

- Fixing regex by adding an escape character in the sequence
- Converting to use format string (`f"{}"`)

### Acceptance Criteria 
Tests are in place for the function that was causing the warning, so check that tests still pass. 

### Nominate for Group Code Review

- [ ] Nominate for code review 
