### PR TITLE
Fix add component bug where transform parent could not be found by index

### DIFF
--- a/nexus_constructor/qml_models/instrument_model.py
+++ b/nexus_constructor/qml_models/instrument_model.py
@@ -324,7 +324,17 @@ class InstrumentModel(QAbstractListModel):
 
     @Slot(int, result="QVariant")
     def get_transform_model(self, index: int):
-        return self.transform_models[index]
+        """
+        Returns the transform model for the component.
+        The list is 1-based due to the 0 being no parent, so we have to use index-1 here
+        unless the component has no transform parent (for example the sample)
+        :param index: The component's transform parents index.
+        :return: The transform model for the component.
+        """
+        if index == 0:
+            return self.transform_models[index]
+        else:
+            return self.transform_models[index - 1]
 
     @Slot(str, result=str)
     def generate_component_name(self, base):


### PR DESCRIPTION
### Issue

Closes #112 
Closes #86 

### Description of work

Fixes the bug where due to the sample not having a transform parent the indexes for getting the parents are incorrect and off by one. 

Previously when adding a component and then adding a transform dependent on a parent it would throw an exception saying the transform parent was out of range in the list. 

this checks if the index is 0 and if not returns the index-1 from the transform_parent list

### Acceptance Criteria 

Test that transforms still work as expected, add a few transforms and base other transforms in other components off those transforms. 

### Nominate for Group Code Review

- [ ] Nominate for code review 
