### PR TITLE
Fixing another regex warning in json_model.py

### DIFF
--- a/nexus_constructor/qml_models/json_model.py
+++ b/nexus_constructor/qml_models/json_model.py
@@ -197,7 +197,7 @@ class JsonModel(QAbstractListModel):
                     store_collection(collapse=True)
                     collecting = False
                 # list isn't just numbers
-                elif not re.match("^-?\d*\.?\d*,?$", line.strip()):
+                elif not re.match(r"^-?\d*\.?\d*,?$", line.strip()):
                     store_collection()
                     collecting = False
             else:


### PR DESCRIPTION
### Issue

None

### Description of work

These effectively work fine already but cause a deprecationWarning when running the tests. 
I have replaced the \d escape sequence with a raw string. This should not affect anything besides just getting rid of the warning. 

### Acceptance Criteria 

unit tests still pass but this time with no warnings

### Nominate for Group Code Review

- [ ] Nominate for code review 
