### PR TITLE
208: Move requirements forward

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,18 @@
-attrs==18.2.0
-PySide2==5.12.2
-pytest==4.3.0
-pytest-cov==2.6.1
-h5py==2.8.0
-flake8==3.5.0
+# In general libraries should not be pinned to specific versions
+attrs
+pytest
+pytest-cov
+h5py
+flake8
+git+https://github.com/ess-dmsc/python-nexus-utilities@6f5d2c7f1ca66063227aad2a111a2cc567d573f6#egg=nexusutils
+jsonschema
+numpy-stl
+pre-commit
+pint
 
 # cx_Freeze is used for packaging, the pypi version does not have a fix for Python 3.7 on Windows 10 (https://github.com/anthony-tuininga/cx_Freeze/issues/407)
 git+https://github.com/anthony-tuininga/cx_Freeze.git@master
 
-git+https://github.com/ess-dmsc/python-nexus-utilities@6f5d2c7f1ca66063227aad2a111a2cc567d573f6#egg=nexusutils
-jsonschema==2.6.0
-numpy-stl==2.7.0
-pre-commit
-pint
+# PySide2 has had some issues with new versions and packaging so we will pin it
+PySide2==5.12.2
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,10 @@ pytest==4.3.0
 pytest-cov==2.6.1
 h5py==2.8.0
 flake8==3.5.0
-cx_Freeze==5.1.1
+
+# cx_Freeze is used for packaging, the pypi version does not have a fix for Python 3.7 on Windows 10 (https://github.com/anthony-tuininga/cx_Freeze/issues/407)
+git+https://github.com/anthony-tuininga/cx_Freeze.git@master
+
 git+https://github.com/ess-dmsc/python-nexus-utilities@6f5d2c7f1ca66063227aad2a111a2cc567d573f6#egg=nexusutils
 jsonschema==2.6.0
 numpy-stl==2.7.0


### PR DESCRIPTION
### Issue

Closes #208

### Description of work

Moved all the the modules we depend on forward to latest versions.

### Acceptance Criteria 
To test after uninstalling and reinstalling all requirements:
- Program runs as normal
- Tests run
- Can still build a package
- Can run in Python 3.7 under Windows 10 (Would be good to double check but if no one else has this setup that's fine)

### Nominate for Group Code Review

- [ ] Nominate for code review 
