### PR TITLE
Add not enabled when cylinder units are invalid

### DIFF
--- a/resources/Qtmodels/AddComponentWindow.qml
+++ b/resources/Qtmodels/AddComponentWindow.qml
@@ -331,15 +331,10 @@ ExpandingWindow {
                     (setupPane.geometryState == "Cylinder" && ValidUnits.validCylinderUnits) || setupPane.geometryState != "Cylinder"
                 }
                 onClicked: {
-                    if (setupPane.geometryState == "OFF" && GeometryFileSelected.geometryFileSelected == false)
-                    {
+                    if (setupPane.geometryState == "OFF" && GeometryFileSelected.geometryFileSelected == false) {
                         noGeometryFileDialog.open()
                     }
-                    // Check that the cylinder was given a valid unit argument
-                    else if (setupPane.geometryState == "Cylinder" && !ValidUnits.validCylinderUnits) {
-                        // Bad units given - Show the bad unit message without creating the geometry
-                        ValidUnits.showCylinderUnitMessage = true
-                    } else {
+                    else {
                         components.add_component(componentType, name, description, transform_parent_index, dependent_transform_index,
                                                  geometryControls.geometryModel,
                                                  pixelControls.pixelModel,
@@ -382,7 +377,6 @@ ExpandingWindow {
     function resetUnitChecks() {
         ValidUnits.validMeshUnits = false
         ValidUnits.validCylinderUnits = false
-        ValidUnits.showCylinderUnitMessage = false
     }
 
     onClosing: {

--- a/resources/Qtmodels/AddComponentWindow.qml
+++ b/resources/Qtmodels/AddComponentWindow.qml
@@ -326,6 +326,10 @@ ExpandingWindow {
                 anchors.left: parent.left
                 leftPadding: 0
                 text: "Add"
+                buttonEnabled: {
+                    // Grey-out the Add button for Cylinder geometries if the units are invalid
+                    (setupPane.geometryState == "Cylinder" && ValidUnits.validCylinderUnits) || setupPane.geometryState != "Cylinder"
+                }
                 onClicked: {
                     if (setupPane.geometryState == "OFF" && GeometryFileSelected.geometryFileSelected == false)
                     {
@@ -347,7 +351,6 @@ ExpandingWindow {
                         resetUnitChecks()
 
                     }
-
                 }
             }
             MessageDialog {

--- a/resources/Qtmodels/GeometryControls.qml
+++ b/resources/Qtmodels/GeometryControls.qml
@@ -200,7 +200,6 @@ Pane {
                 contentWidth: Math.max(heightField.implicitWidth + radiusField.implicitWidth + unitsField.implicitWidth + invalidUnitCross.implicitWidth,
                                        axisXField.implicitWidth + axisYField.implicitWidth + axisZField.implicitWidth)
                 contentHeight: heightField.implicitHeight + directionLabel.implicitHeight + axisXField.implicitHeight
-                               + invalidCylinderUnitWarning.implicitHeight
 
                 LabeledTextField {
                     id: heightField
@@ -251,21 +250,9 @@ Pane {
                     }
                 }
 
-                Text {
-
-                    // Blank invalid unit warning - only set to contain text if unit validation function returns false
-                    // and user presses "Add" button
-                    id: invalidCylinderUnitWarning
-                    anchors.top: unitsField.bottom
-                    text: ValidUnits.showCylinderUnitMessage ? ValidUnits.invalidUnitsText : ""
-                    color: "red"
-                    Layout.fillWidth: true
-                    visible: true
-                 }
-
                 Label {
                     id: directionLabel
-                    anchors.top: invalidCylinderUnitWarning.bottom
+                    anchors.top: heightField.bottom
                     anchors.left: parent.left
                     text: "axis direction:"
                 }

--- a/resources/Qtmodels/GeometryControls.qml
+++ b/resources/Qtmodels/GeometryControls.qml
@@ -246,7 +246,7 @@ Pane {
                     MouseArea {
                         anchors.fill: parent
                         hoverEnabled: true
-                        ToolTip.visible: invalidUnitCross.visible && hovered
+                        ToolTip.visible: invalidUnitCross.visible && containsMouse
                         ToolTip.text: ValidUnits.invalidUnitsText
                     }
                 }

--- a/resources/Qtmodels/GeometryControls.qml
+++ b/resources/Qtmodels/GeometryControls.qml
@@ -197,7 +197,7 @@ Pane {
                 anchors.top: cylinderLabel.bottom
                 anchors.left: parent.left
                 anchors.right: parent.right
-                contentWidth: Math.max(heightField.implicitWidth + radiusField.implicitWidth + unitsField.implicitWidth,
+                contentWidth: Math.max(heightField.implicitWidth + radiusField.implicitWidth + unitsField.implicitWidth + invalidUnitCross.implicitWidth,
                                        axisXField.implicitWidth + axisYField.implicitWidth + axisZField.implicitWidth)
                 contentHeight: heightField.implicitHeight + directionLabel.implicitHeight + axisXField.implicitHeight
                                + invalidCylinderUnitWarning.implicitHeight
@@ -233,6 +233,15 @@ Pane {
                                     onValidationFailed: { ValidUnits.validCylinderUnits = false }
                                     onValidationSuccess: { ValidUnits.validCylinderUnits = true }
                                }
+                }
+                Text {
+                    id: invalidUnitCross
+                    anchors.left: unitsField.right
+                    anchors.right: parent.right
+                    text: "❌"
+                    color: "red"
+                    font.pointSize: 18
+                    visible: !ValidUnits.validCylinderUnits
                 }
 
                 Text {

--- a/resources/Qtmodels/GeometryControls.qml
+++ b/resources/Qtmodels/GeometryControls.qml
@@ -237,9 +237,11 @@ Pane {
                     id: invalidUnitCross
                     anchors.left: unitsField.right
                     anchors.right: parent.right
-                    text: "✖"
+                    anchors.top: unitsField.top
+                    text: "×"
+                    font.bold: true
                     color: "red"
-                    font.pointSize: 18
+                    font.pointSize: 17
                     visible: !ValidUnits.validCylinderUnits
 
                     MouseArea {

--- a/resources/Qtmodels/GeometryControls.qml
+++ b/resources/Qtmodels/GeometryControls.qml
@@ -242,6 +242,13 @@ Pane {
                     color: "red"
                     font.pointSize: 18
                     visible: !ValidUnits.validCylinderUnits
+
+                    MouseArea {
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        ToolTip.visible: invalidUnitCross.visible && hovered
+                        ToolTip.text: ValidUnits.invalidUnitsText
+                    }
                 }
 
                 Text {

--- a/resources/Qtmodels/GeometryControls.qml
+++ b/resources/Qtmodels/GeometryControls.qml
@@ -237,7 +237,7 @@ Pane {
                     id: invalidUnitCross
                     anchors.left: unitsField.right
                     anchors.right: parent.right
-                    text: "❌"
+                    text: "✖"
                     color: "red"
                     font.pointSize: 18
                     visible: !ValidUnits.validCylinderUnits

--- a/resources/Qtmodels/ValidUnits.qml
+++ b/resources/Qtmodels/ValidUnits.qml
@@ -4,6 +4,5 @@ QtObject {
     // Booleans to indicate that the units provided for loading a geometry or creating a cylinder were valid
     property bool validMeshUnits: false
     property bool validCylinderUnits: false
-    property bool showCylinderUnitMessage: false
     readonly property string invalidUnitsText: "Units not recognised. Please enter a different type."
 }


### PR DESCRIPTION
### Issue

Closes #197

### Description of work

Causes the Add button to be grayed-out if a cylinder's units aren't valid. Also makes a red cross appear next to the units field that displays a message when the mouse hovers over it. This replaces the warning text that would appear beneath the units field after pressing Add.

### Acceptance Criteria 

Add a Cylinder and enter valid/invalid units to check that the button and warning message behave correctly.

### Nominate for Group Code Review

- [ ] Nominate for code review 
