### PR TITLE
152: Layouts for setupPane in AddComponentWindow

### DIFF
--- a/resources/Qtmodels/AddComponentWindow.qml
+++ b/resources/Qtmodels/AddComponentWindow.qml
@@ -110,14 +110,6 @@ ExpandingWindow {
                 }
                 Pane {
                     id: pixelPane
-                    contentWidth: Math.max(singlePixelRadio.width,
-                                           pixelGridRadio.width,
-                                           mappedMeshRadio.width,
-                                           noPixelRadio.width)
-                    contentHeight:singlePixelRadio.height +
-                                  pixelGridRadio.height +
-                                  mappedMeshRadio.height +
-                                  noPixelRadio.height
                     enabled: !noShapeRadio.checked
 
                     function checkFirstEnabled(){
@@ -129,34 +121,32 @@ ExpandingWindow {
                             }
                         }
                     }
+                    ColumnLayout {
 
-                    RadioButton {
-                        id: singlePixelRadio
-                        anchors.top: parent.top
-                        text: "Single ID"
-                        enabled: setupPane.selectedType.allowSingleID
-                        onCheckedChanged: if (checked) setupPane.pixelState = "SinglePixel"
-                    }
-                    RadioButton {
-                        id: pixelGridRadio
-                        anchors.top: singlePixelRadio.bottom
-                        text: "Repeatable grid"
-                        enabled: setupPane.selectedType.allowPixelGrid
-                        onCheckedChanged: if (checked) setupPane.pixelState = "Grid"
-                    }
-                    RadioButton {
-                        id: mappedMeshRadio
-                        anchors.top: pixelGridRadio.bottom
-                        text: "Face mapped mesh"
-                        enabled: setupPane.selectedType.allowMappedMesh && meshRadio.checked
-                        onCheckedChanged: if (checked) setupPane.pixelState = "Mapping"
-                    }
-                    RadioButton {
-                        id: noPixelRadio
-                        anchors.top: mappedMeshRadio.bottom
-                        text: "None"
-                        enabled: setupPane.selectedType.allowNoPixels
-                        onCheckedChanged: if (checked) setupPane.pixelState = ""
+                        RadioButton {
+                            id: singlePixelRadio
+                            text: "Single ID"
+                            enabled: setupPane.selectedType.allowSingleID
+                            onCheckedChanged: if (checked) setupPane.pixelState = "SinglePixel"
+                        }
+                        RadioButton {
+                            id: pixelGridRadio
+                            text: "Repeatable grid"
+                            enabled: setupPane.selectedType.allowPixelGrid
+                            onCheckedChanged: if (checked) setupPane.pixelState = "Grid"
+                        }
+                        RadioButton {
+                            id: mappedMeshRadio
+                            text: "Face mapped mesh"
+                            enabled: setupPane.selectedType.allowMappedMesh && meshRadio.checked
+                            onCheckedChanged: if (checked) setupPane.pixelState = "Mapping"
+                        }
+                        RadioButton {
+                            id: noPixelRadio
+                            text: "None"
+                            enabled: setupPane.selectedType.allowNoPixels
+                            onCheckedChanged: if (checked) setupPane.pixelState = ""
+                        }
                     }
                 }
 

--- a/resources/Qtmodels/AddComponentWindow.qml
+++ b/resources/Qtmodels/AddComponentWindow.qml
@@ -30,20 +30,8 @@ ExpandingWindow {
 
         Pane {
             id: setupPane
-            contentHeight: typeLabel.height +
-                           typePane.height +
-                           geometryLabel.height +
-                           geometryPane.height +
-                           pixelLabel.height +
-                           pixelPane.height +
-                           continueButton.height
-            contentWidth: Math.max(typeLabel.width,
-                                   typePane.width,
-                                   geometryLabel.width,
-                                   geometryPane.width,
-                                   pixelLabel.width,
-                                   pixelPane.width,
-                                   250)
+            height: childrenRect.height
+            width: childrenRect.width
 
             property var selectedType
             property string geometryState
@@ -81,40 +69,37 @@ ExpandingWindow {
                 }
                 Pane {
                     id: geometryPane
-                    contentWidth: meshRadio.width + cylinderRadio.width
-                    contentHeight: Math.max(meshRadio.height, cylinderRadio.height)
+                    Layout.fillWidth: true
 
-                    RadioButton {
-                        id: meshRadio
-                        anchors.left: parent.left
-                        anchors.top: parent.top
-                        text: "Mesh"
-                        onClicked: {
-                            setupPane.geometryState = "OFF"
-                            GeometryFileSelected.geometryFileSelected = false
+                    RowLayout {
+                        id: radioButtonRow
+
+                        RadioButton {
+                            id: meshRadio
+                            text: "Mesh"
+                            onClicked: {
+                                setupPane.geometryState = "OFF"
+                                GeometryFileSelected.geometryFileSelected = false
+                            }
+
+                            checked: true
+                            Component.onCompleted: setupPane.geometryState = "OFF"
                         }
-
-                        checked: true
-                        Component.onCompleted: setupPane.geometryState = "OFF"
-                    }
-                    RadioButton {
-                        id: cylinderRadio
-                        anchors.left: meshRadio.right
-                        anchors.top: meshRadio.top
-                        text: "Cylinder"
-                        onClicked: {
-                            setupPane.geometryState = "Cylinder"
-                            if (mappedMeshRadio.checked) {
-                                pixelPane.checkFirstEnabled()
+                        RadioButton {
+                            id: cylinderRadio
+                            text: "Cylinder"
+                            onClicked: {
+                                setupPane.geometryState = "Cylinder"
+                                if (mappedMeshRadio.checked) {
+                                    pixelPane.checkFirstEnabled()
+                                }
                             }
                         }
-                    }
-                    RadioButton {
-                        id: noShapeRadio
-                        anchors.left: cylinderRadio.right
-                        anchors.top: cylinderRadio.top
-                        text: "None"
-                        onClicked: setupPane.geometryState = "None", setupPane.pixelState = ""
+                        RadioButton {
+                            id: noShapeRadio
+                            text: "None"
+                            onClicked: setupPane.geometryState = "None", setupPane.pixelState = ""
+                        }
                     }
                 }
 

--- a/resources/Qtmodels/AddComponentWindow.qml
+++ b/resources/Qtmodels/AddComponentWindow.qml
@@ -38,7 +38,6 @@ ExpandingWindow {
             property string pixelState
 
             ColumnLayout {
-                id: mainCol
                 anchors.fill: parent
 
                 Label {
@@ -295,7 +294,7 @@ ExpandingWindow {
                 text: "Add"
                 buttonEnabled: {
                     // Grey-out the Add button for Cylinder geometries if the units are invalid
-                    (setupPane.geometryState == "Cylinder" && ValidUnits.validCylinderUnits) || setupPane.geometryState != "Cylinder"
+                    setupPane.geometryState != "Cylinder" || (setupPane.geometryState == "Cylinder" && ValidUnits.validCylinderUnits)
                 }
                 onClicked: {
                     if (setupPane.geometryState == "OFF" && GeometryFileSelected.geometryFileSelected == false) {

--- a/resources/Qtmodels/AddComponentWindow.qml
+++ b/resources/Qtmodels/AddComponentWindow.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.4
 import MyModels 1.0
 import MyValidators 1.0
 import QtQuick.Dialogs 1.3
+import QtQuick.Layouts 1.11
 
 ExpandingWindow {
 
@@ -48,196 +49,187 @@ ExpandingWindow {
             property string geometryState
             property string pixelState
 
-            Label {
-                id: typeLabel
-                anchors.left: parent.left
-                anchors.top: parent.top
-                text: "Component type:"
-            }
+            ColumnLayout {
+                id: mainCol
+                anchors.fill: parent
 
-            Pane {
-                id: typePane
-                anchors.top: typeLabel.bottom
-                anchors.left: parent.left
-
-                ComboBox {
-                    id: typePicker
-                    model: componentTypeModel
-                    textRole: "name"
-                    onActivated: updateBackend()
-                    Component.onCompleted: updateBackend()
-
-                    function updateBackend() {
-                        setupPane.selectedType = componentTypeModel.get(typePicker.currentIndex)
-                        pixelPane.checkFirstEnabled()
-                    }
+                Label {
+                    id: typeLabel
+                    text: "Component type:"
                 }
-            }
 
-            Label {
-                id: geometryLabel
-                anchors.left: parent.left
-                anchors.top: typePane.bottom
-                text: "Geometry:"
-            }
-            Pane {
-                id: geometryPane
-                anchors.left: parent.left
-                anchors.top: geometryLabel.bottom
-                contentWidth: meshRadio.width + cylinderRadio.width
-                contentHeight: Math.max(meshRadio.height, cylinderRadio.height)
+                Pane {
+                    id: typePane
 
-                RadioButton {
-                    id: meshRadio
-                    anchors.left: parent.left
-                    anchors.top: parent.top
-                    text: "Mesh"
-                    onClicked: {
-                        setupPane.geometryState = "OFF"
-                        GeometryFileSelected.geometryFileSelected = false
-                    }
+                    ComboBox {
+                        id: typePicker
+                        model: componentTypeModel
+                        textRole: "name"
+                        onActivated: updateBackend()
+                        Component.onCompleted: updateBackend()
 
-                    checked: true
-                    Component.onCompleted: setupPane.geometryState = "OFF"
-                }
-                RadioButton {
-                    id: cylinderRadio
-                    anchors.left: meshRadio.right
-                    anchors.top: meshRadio.top
-                    text: "Cylinder"
-                    onClicked: {
-                        setupPane.geometryState = "Cylinder"
-                        if (mappedMeshRadio.checked) {
+                        function updateBackend() {
+                            setupPane.selectedType = componentTypeModel.get(typePicker.currentIndex)
                             pixelPane.checkFirstEnabled()
                         }
                     }
                 }
-                RadioButton {
-                    id: noShapeRadio
-                    anchors.left: cylinderRadio.right
-                    anchors.top: cylinderRadio.top
-                    text: "None"
-                    onClicked: setupPane.geometryState = "None", setupPane.pixelState = ""
+
+                Label {
+                    id: geometryLabel
+                    text: "Geometry:"
                 }
-            }
+                Pane {
+                    id: geometryPane
+                    contentWidth: meshRadio.width + cylinderRadio.width
+                    contentHeight: Math.max(meshRadio.height, cylinderRadio.height)
 
-            Label {
-                id: pixelLabel
-                anchors.left: parent.left
-                anchors.top: geometryPane.bottom
-                text: "Pixels:"
-                enabled: !noShapeRadio.checked
-            }
-            Pane {
-                id: pixelPane
-                anchors.left: parent.left
-                anchors.top: pixelLabel.bottom
-                contentWidth: Math.max(singlePixelRadio.width,
-                                       pixelGridRadio.width,
-                                       mappedMeshRadio.width,
-                                       noPixelRadio.width)
-                contentHeight:singlePixelRadio.height +
-                              pixelGridRadio.height +
-                              mappedMeshRadio.height +
-                              noPixelRadio.height
-                enabled: !noShapeRadio.checked
-
-                function checkFirstEnabled(){
-                    var buttons = [singlePixelRadio, pixelGridRadio, mappedMeshRadio, noPixelRadio]
-                    for (var i = 0; i < buttons.length; i++) {
-                        if (buttons[i].enabled){
-                            buttons[i].checked = true
-                            return
+                    RadioButton {
+                        id: meshRadio
+                        anchors.left: parent.left
+                        anchors.top: parent.top
+                        text: "Mesh"
+                        onClicked: {
+                            setupPane.geometryState = "OFF"
+                            GeometryFileSelected.geometryFileSelected = false
                         }
+
+                        checked: true
+                        Component.onCompleted: setupPane.geometryState = "OFF"
+                    }
+                    RadioButton {
+                        id: cylinderRadio
+                        anchors.left: meshRadio.right
+                        anchors.top: meshRadio.top
+                        text: "Cylinder"
+                        onClicked: {
+                            setupPane.geometryState = "Cylinder"
+                            if (mappedMeshRadio.checked) {
+                                pixelPane.checkFirstEnabled()
+                            }
+                        }
+                    }
+                    RadioButton {
+                        id: noShapeRadio
+                        anchors.left: cylinderRadio.right
+                        anchors.top: cylinderRadio.top
+                        text: "None"
+                        onClicked: setupPane.geometryState = "None", setupPane.pixelState = ""
                     }
                 }
 
-                RadioButton {
-                    id: singlePixelRadio
-                    anchors.top: parent.top
-                    text: "Single ID"
-                    enabled: setupPane.selectedType.allowSingleID
-                    onCheckedChanged: if (checked) setupPane.pixelState = "SinglePixel"
+                Label {
+                    id: pixelLabel
+                    text: "Pixels:"
+                    enabled: !noShapeRadio.checked
                 }
-                RadioButton {
-                    id: pixelGridRadio
-                    anchors.top: singlePixelRadio.bottom
-                    text: "Repeatable grid"
-                    enabled: setupPane.selectedType.allowPixelGrid
-                    onCheckedChanged: if (checked) setupPane.pixelState = "Grid"
-                }
-                RadioButton {
-                    id: mappedMeshRadio
-                    anchors.top: pixelGridRadio.bottom
-                    text: "Face mapped mesh"
-                    enabled: setupPane.selectedType.allowMappedMesh && meshRadio.checked
-                    onCheckedChanged: if (checked) setupPane.pixelState = "Mapping"
-                }
-                RadioButton {
-                    id: noPixelRadio
-                    anchors.top: mappedMeshRadio.bottom
-                    text: "None"
-                    enabled: setupPane.selectedType.allowNoPixels
-                    onCheckedChanged: if (checked) setupPane.pixelState = ""
-                }
-            }
+                Pane {
+                    id: pixelPane
+                    contentWidth: Math.max(singlePixelRadio.width,
+                                           pixelGridRadio.width,
+                                           mappedMeshRadio.width,
+                                           noPixelRadio.width)
+                    contentHeight:singlePixelRadio.height +
+                                  pixelGridRadio.height +
+                                  mappedMeshRadio.height +
+                                  noPixelRadio.height
+                    enabled: !noShapeRadio.checked
 
-            PaddedButton {
-                id: continueButton
-                anchors.top: pixelPane.bottom
-                anchors.left: parent.left
-                text: "Continue"
-                onClicked: {
-                    componentType = setupPane.selectedType.name
-                    pixelControls.state = setupPane.pixelState
-                    geometryControls.state = setupPane.geometryState
-                    contentPane.state = "EnterDetails"
-                }
-            }
+                    function checkFirstEnabled(){
+                        var buttons = [singlePixelRadio, pixelGridRadio, mappedMeshRadio, noPixelRadio]
+                        for (var i = 0; i < buttons.length; i++) {
+                            if (buttons[i].enabled){
+                                buttons[i].checked = true
+                                return
+                            }
+                        }
+                    }
 
-            ListModel {
-                id: componentTypeModel
-                ListElement {
-                    name: "Detector"
-                    allowSingleID: false
-                    allowPixelGrid: true
-                    allowMappedMesh: true
-                    allowNoPixels: false
+                    RadioButton {
+                        id: singlePixelRadio
+                        anchors.top: parent.top
+                        text: "Single ID"
+                        enabled: setupPane.selectedType.allowSingleID
+                        onCheckedChanged: if (checked) setupPane.pixelState = "SinglePixel"
+                    }
+                    RadioButton {
+                        id: pixelGridRadio
+                        anchors.top: singlePixelRadio.bottom
+                        text: "Repeatable grid"
+                        enabled: setupPane.selectedType.allowPixelGrid
+                        onCheckedChanged: if (checked) setupPane.pixelState = "Grid"
+                    }
+                    RadioButton {
+                        id: mappedMeshRadio
+                        anchors.top: pixelGridRadio.bottom
+                        text: "Face mapped mesh"
+                        enabled: setupPane.selectedType.allowMappedMesh && meshRadio.checked
+                        onCheckedChanged: if (checked) setupPane.pixelState = "Mapping"
+                    }
+                    RadioButton {
+                        id: noPixelRadio
+                        anchors.top: mappedMeshRadio.bottom
+                        text: "None"
+                        enabled: setupPane.selectedType.allowNoPixels
+                        onCheckedChanged: if (checked) setupPane.pixelState = ""
+                    }
                 }
-                ListElement {
-                    name: "Monitor"
-                    allowSingleID: true
-                    allowPixelGrid: false
-                    allowMappedMesh: false
-                    allowNoPixels: false
+
+                PaddedButton {
+                    id: continueButton
+                    text: "Continue"
+                    onClicked: {
+                        componentType = setupPane.selectedType.name
+                        pixelControls.state = setupPane.pixelState
+                        geometryControls.state = setupPane.geometryState
+                        contentPane.state = "EnterDetails"
+                    }
                 }
-                ListElement {
-                    name: "Source"
-                    allowSingleID: false
-                    allowPixelGrid: false
-                    allowMappedMesh: false
-                    allowNoPixels: true
-                }
-                ListElement {
-                    name: "Slit"
-                    allowSingleID: false
-                    allowPixelGrid: false
-                    allowMappedMesh: false
-                    allowNoPixels: true
-                }
-                ListElement {
-                    name: "Moderator"
-                    allowSingleID: false
-                    allowPixelGrid: false
-                    allowMappedMesh: false
-                    allowNoPixels: true
-                }
-                ListElement {
-                    name: "Disk Chopper"
-                    allowSingleID: false
-                    allowPixelGrid: false
-                    allowMappedMesh: false
-                    allowNoPixels: true
+
+                ListModel {
+                    id: componentTypeModel
+                    ListElement {
+                        name: "Detector"
+                        allowSingleID: false
+                        allowPixelGrid: true
+                        allowMappedMesh: true
+                        allowNoPixels: false
+                    }
+                    ListElement {
+                        name: "Monitor"
+                        allowSingleID: true
+                        allowPixelGrid: false
+                        allowMappedMesh: false
+                        allowNoPixels: false
+                    }
+                    ListElement {
+                        name: "Source"
+                        allowSingleID: false
+                        allowPixelGrid: false
+                        allowMappedMesh: false
+                        allowNoPixels: true
+                    }
+                    ListElement {
+                        name: "Slit"
+                        allowSingleID: false
+                        allowPixelGrid: false
+                        allowMappedMesh: false
+                        allowNoPixels: true
+                    }
+                    ListElement {
+                        name: "Moderator"
+                        allowSingleID: false
+                        allowPixelGrid: false
+                        allowMappedMesh: false
+                        allowNoPixels: true
+                    }
+                    ListElement {
+                        name: "Disk Chopper"
+                        allowSingleID: false
+                        allowPixelGrid: false
+                        allowMappedMesh: false
+                        allowNoPixels: true
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Issue

Progresses #152

### Description of work

Adds some Layouts to the `setupPane` in AddComponentWindow.qml and attempts to do away with  setting window width/height by adding up content sizes. Using [childrenRect](https://doc.qt.io/qt-5/qml-qtquick-item.html#childrenRect-prop) seems to be the way to go about doing this.

### Acceptance Criteria 

You can try tinkering with the QML yourself and adding things to/removing things from the `setupPane` to see that changing the window size is done for you without all the addition stuff. Also go through the [UI Tests](https://github.com/ess-dmsc/nexus-constructor/blob/master/tests/UITests.md#adding-components-and-transforms).

### UI tests

No intentional changes made to UI behavior.

### Nominate for Group Code Review

- [ ] Nominate for code review 
