### PR TITLE
231: Make sure checkFirstEnabled is called whenever the geometry type changes

### DIFF
--- a/resources/Qtmodels/AddComponentWindow.qml
+++ b/resources/Qtmodels/AddComponentWindow.qml
@@ -79,6 +79,7 @@ ExpandingWindow {
                             onClicked: {
                                 setupPane.geometryState = "OFF"
                                 GeometryFileSelected.geometryFileSelected = false
+                                pixelPane.checkFirstEnabled()
                             }
 
                             checked: true
@@ -89,15 +90,17 @@ ExpandingWindow {
                             text: "Cylinder"
                             onClicked: {
                                 setupPane.geometryState = "Cylinder"
-                                if (mappedMeshRadio.checked) {
-                                    pixelPane.checkFirstEnabled()
-                                }
+                                pixelPane.checkFirstEnabled()
                             }
                         }
                         RadioButton {
                             id: noShapeRadio
                             text: "None"
-                            onClicked: setupPane.geometryState = "None", setupPane.pixelState = ""
+                            onClicked: {
+                                setupPane.geometryState = "None"
+                                setupPane.pixelState = ""
+                                pixelPane.checkFirstEnabled()
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
### Issue

Closes #231

### Description of work

Makes sure that the `checkFirstEnabled` function is called whenever the geometry type changes. Previously it only did this when the component type changed so sometimes it was possible to press continue without setting a pixel type.

### Acceptance Criteria 

Make sure you don't get the problem I described in #231 or anything similar. Try it out with different component types and see that you don't get the same issue.

### UI tests

Didn't write anything as I view this as a fix rather than introducing something new. I can add something if people still want me to though?

### Nominate for Group Code Review

- [ ] Nominate for code review 
