### PR TITLE
Rendering issue when hiding the JSON pane and resizing the window to minimum

### DIFF
--- a/resources/Qtmodels/Main.qml
+++ b/resources/Qtmodels/Main.qml
@@ -74,7 +74,7 @@ ApplicationWindow {
     function makeRoomForReturnOfJSONPane() {
         // Force the window to expand if the JSON pane was hidden and has been made visible again
         if (jsonMode == "hidden" && window.width <= window.minimumWidth)
-                window.width += jsonPaneWidth
+            window.width += jsonPaneWidth
     }
     function positionChildWindow(child) {
         // position child window in the center of the main window

--- a/resources/Qtmodels/Main.qml
+++ b/resources/Qtmodels/Main.qml
@@ -16,6 +16,7 @@ ApplicationWindow {
     height: 500
     minimumWidth: centralRow.implicitWidth
     minimumHeight: centralRow.implicitHeight + menuBar.implicitHeight
+    property var jsonPaneWidth: 300
 
     property string jsonMode: "liveFW"
 
@@ -49,6 +50,7 @@ ApplicationWindow {
                 text: "Show Nexus FileWriter JSON"
                 checked: true
                 onClicked: {
+                    makeRoomForReturnOfJSONPane()
                     jsonMode = "liveFW"
                     jsonConnector.request_filewriter_json(components)
                 }
@@ -56,6 +58,7 @@ ApplicationWindow {
             RadioButton {
                 text: "Show Nexus Constructor JSON"
                 onClicked: {
+                    makeRoomForReturnOfJSONPane()
                     jsonMode = "liveGC"
                     jsonConnector.request_nexus_constructor_json(components)
                 }
@@ -64,9 +67,14 @@ ApplicationWindow {
                 text: "Hide JSON display"
                 onClicked: jsonMode = "hidden"
             }
+
         }
     }
 
+    function makeRoomForReturnOfJSONPane() {
+        if (jsonMode == "hidden" && window.width <= window.minimumWidth)
+                window.width += jsonPaneWidth
+    }
     function positionChildWindow(child) {
         // position child window in the center of the main window
         var centralX = window.x + ((window.width - child.width) / 2)
@@ -142,7 +150,7 @@ ApplicationWindow {
 
             JSONPane {
                 id: jsonPane
-                contentWidth: 300
+                contentWidth: jsonPaneWidth
                 Layout.fillHeight: true
                 Layout.fillWidth: false
             }

--- a/resources/Qtmodels/Main.qml
+++ b/resources/Qtmodels/Main.qml
@@ -72,6 +72,7 @@ ApplicationWindow {
     }
 
     function makeRoomForReturnOfJSONPane() {
+        // Force the window to expand if the JSON pane was hidden and has been made visible again
         if (jsonMode == "hidden" && window.width <= window.minimumWidth)
                 window.width += jsonPaneWidth
     }

--- a/resources/Qtmodels/Main.qml
+++ b/resources/Qtmodels/Main.qml
@@ -111,6 +111,8 @@ ApplicationWindow {
 
                 Scene3D {
                     id: scene3d
+                    implicitWidth: 100
+                    implicitHeight: 100
                     anchors.fill: parent
                     focus: true
                     aspects: ["input", "logic"]

--- a/resources/Qtmodels/Main.qml
+++ b/resources/Qtmodels/Main.qml
@@ -92,6 +92,7 @@ ApplicationWindow {
         RowLayout {
             id: centralRow
             anchors.fill: parent
+            Layout.minimumWidth: 100
 
             ComponentControls {
                 id: componentFieldsArea
@@ -111,8 +112,7 @@ ApplicationWindow {
 
                 Scene3D {
                     id: scene3d
-                    implicitWidth: 100
-                    implicitHeight: 100
+
                     anchors.fill: parent
                     focus: true
                     aspects: ["input", "logic"]

--- a/resources/Qtmodels/Main.qml
+++ b/resources/Qtmodels/Main.qml
@@ -112,7 +112,6 @@ ApplicationWindow {
 
                 Scene3D {
                     id: scene3d
-
                     anchors.fill: parent
                     focus: true
                     aspects: ["input", "logic"]


### PR DESCRIPTION
### Issue

Closes #221 

### Description of work

Setting a minimum width for the JSON pane so the view never goes out of display 

there are still QOpenGL errors, but im not sure how to fix these, might be a bug in QML? 

### Acceptance Criteria 

- hide json pane 
- Resize the window to as small as possible
- re enable json pane
- check that window is resized again

### UI tests

Not changed

### Nominate for Group Code Review

- [ ] Nominate for code review 
