### PR TITLE
261: StackLayout for TransformControls

### DIFF
--- a/resources/Qtmodels/TransformControls.qml
+++ b/resources/Qtmodels/TransformControls.qml
@@ -116,7 +116,7 @@ Item {
 
         Frame {
             id: transformBox
-            contentHeight: transformBoxStack.height + transformButtons.implicitHeight
+            contentHeight: transformBoxColumn.height
             contentWidth: Math.max(translatePane.implicitWidth, rotatePane.implicitWidth, transformButtons.implicitWidth)
             anchors.right: parent.right
             anchors.left: parent.left

--- a/resources/Qtmodels/TransformControls.qml
+++ b/resources/Qtmodels/TransformControls.qml
@@ -117,7 +117,6 @@ Item {
         Frame {
             id: transformBox
             contentHeight: transformBoxColumn.height
-            // contentWidth: Math.max(translatePane.implicitWidth, rotatePane.implicitWidth, transformButtons.implicitWidth)
             contentWidth: transformBoxColumn.width
             anchors.right: parent.right
             anchors.left: parent.left

--- a/resources/Qtmodels/TransformControls.qml
+++ b/resources/Qtmodels/TransformControls.qml
@@ -116,211 +116,221 @@ Item {
 
         Frame {
             id: transformBox
-            width: transformsListView.width
-            contentHeight: translatePane.height + rotatePane.height + transformButtons.height
+            // width: transformsListView.width
+            // contentHeight: translatePane.height + rotatePane.height + transformButtons.height
+            contentHeight: transformBoxStack.implicitHeight + transformButtons.implicitHeight
             contentWidth: Math.max(translatePane.implicitWidth, rotatePane.implicitWidth, transformButtons.implicitWidth)
 
             Component.onCompleted: {
                 if (transformsListView.implicitWidth < transformBox.implicitWidth) {
                     transformsListView.implicitWidth = transformBox.implicitWidth
                 }
+                console.log(transformBoxStack.implicitHeight)
             }
 
-            Pane {
-                id: translatePane
-                padding: 0
-                contentWidth: translatePaneGrid.implicitWidth
-                contentHeight: translatePaneGrid.implicitHeight
+            ColumnLayout {
+                id: transformBoxColumn
 
-                GridLayout {
-                    id: translatePaneGrid
-                    rows: 2
-                    columns: 6
+                StackLayout {
+                    id: transformBoxStack
+                    currentIndex: transform_type == "Translate" ? 0 : 1
+                    Layout.preferredHeight: currentIndex == 0 ? translatePane.implicitHeight : rotatePane.implicitHeight
 
-                    Label {
-                        id: translateLabel
-                        text: "Translation"
-                        Layout.columnSpan: 2
-                    }
-                    Label {
-                        id: translateNameLabel
-                        text: "Name: "
-                        Layout.columnSpan: 3
-                        Layout.alignment: Qt.AlignRight
-                    }
-                    TextField {
-                        id: translateNameField
-                        implicitWidth: transformTextFieldWidth
-                        text: name
-                        selectByMouse: true
-                        onEditingFinished: name = text
-                        validator: NameValidator {
-                            model: transformModel
-                            myindex: index
-                            onValidationFailed: translateNameField.ToolTip.show("A component's transforms must have unique names", 3000)
+                    Pane {
+                        id: translatePane
+                        padding: 0
+                        contentWidth: translatePaneGrid.implicitWidth
+                        contentHeight: translatePaneGrid.implicitHeight
+                        visible: true
+
+                        GridLayout {
+                            id: translatePaneGrid
+                            rows: 2
+                            columns: 6
+
+                            Label {
+                                id: translateLabel
+                                text: "Translation"
+                                Layout.columnSpan: 2
+                            }
+                            Label {
+                                id: translateNameLabel
+                                text: "Name: "
+                                Layout.columnSpan: 3
+                                Layout.alignment: Qt.AlignRight
+                            }
+                            TextField {
+                                id: translateNameField
+                                implicitWidth: transformTextFieldWidth
+                                text: name
+                                selectByMouse: true
+                                onEditingFinished: name = text
+                                validator: NameValidator {
+                                    model: transformModel
+                                    myindex: index
+                                    onValidationFailed: translateNameField.ToolTip.show("A component's transforms must have unique names", 3000)
+                                }
+                            }
+                            Label {
+                                text: "X: "
+                            }
+                            TextField {
+                                id: xTranslationField
+                                implicitWidth: transformTextFieldWidth
+                                text: translate_x
+                                selectByMouse: true
+                                validator: numberValidator
+                                onEditingFinished: translate_x = parseFloat(text)
+                            }
+                            Label {
+                                text: "Y: "
+                            }
+                            TextField {
+                                id: yTranslationField
+                                implicitWidth: transformTextFieldWidth
+                                text: translate_y
+                                selectByMouse: true
+                                validator: numberValidator
+                                onEditingFinished: translate_y = parseFloat(text)
+                            }
+                            Label {
+                                text: "Z: "
+                            }
+                            TextField {
+                                id: zTranslationField
+                                implicitWidth: transformTextFieldWidth
+                                text: translate_z
+                                selectByMouse: true
+                                validator: numberValidator
+                                onEditingFinished: translate_z = parseFloat(text)
+                            }
                         }
                     }
-                    Label {
-                        text: "X: "
-                    }
-                    TextField {
-                        id: xTranslationField
-                        implicitWidth: transformTextFieldWidth
-                        text: translate_x
-                        selectByMouse: true
-                        validator: numberValidator
-                        onEditingFinished: translate_x = parseFloat(text)
-                    }
-                    Label {
-                        text: "Y: "
-                    }
-                    TextField {
-                        id: yTranslationField
-                        implicitWidth: transformTextFieldWidth
-                        text: translate_y
-                        selectByMouse: true
-                        validator: numberValidator
-                        onEditingFinished: translate_y = parseFloat(text)
-                    }
-                    Label {
-                        text: "Z: "
-                    }
-                    TextField {
-                        id: zTranslationField
-                        implicitWidth: transformTextFieldWidth
-                        text: translate_z
-                        selectByMouse: true
-                        validator: numberValidator
-                        onEditingFinished: translate_z = parseFloat(text)
-                    }
-                }
-            }
 
-            Pane {
-                id: rotatePane
-                padding: 0
-                contentWidth: rotatePaneGrid.implicitWidth
-                contentHeight: rotatePaneGrid.implicitHeight
+                    Pane {
+                        id: rotatePane
+                        padding: 0
+                        contentWidth: rotatePaneGrid.implicitWidth
+                        contentHeight: rotatePaneGrid.implicitHeight
+                        visible: true
 
-                GridLayout {
-                    id: rotatePaneGrid
-                    anchors.fill: parent
-                    rows: 3
-                    columns: 6
+                        GridLayout {
+                            id: rotatePaneGrid
+                            anchors.fill: parent
+                            rows: 3
+                            columns: 6
 
-                    Label {
-                        id: rotateLabel
-                        text: "Rotation"
-                        Layout.columnSpan: 2
-                    }
-                    Label {
-                        id: rotateNameLabel
-                        text: "Name: "
-                        Layout.alignment: Qt.AlignRight
-                        Layout.columnSpan: 3
-                    }
-                    TextField {
-                        id: rotateNameField
-                        text: name
-                        selectByMouse: true
-                        onEditingFinished: name = text
-                        implicitWidth: transformTextFieldWidth
-                        validator: NameValidator {
-                            model: transformModel
-                            myindex: index
-                            onValidationFailed: translateNameField.ToolTip.show("A component's transforms must have unique names", 3000)
+                            Label {
+                                id: rotateLabel
+                                text: "Rotation"
+                                Layout.columnSpan: 2
+                            }
+                            Label {
+                                id: rotateNameLabel
+                                text: "Name: "
+                                Layout.alignment: Qt.AlignRight
+                                Layout.columnSpan: 3
+                            }
+                            TextField {
+                                id: rotateNameField
+                                text: name
+                                selectByMouse: true
+                                onEditingFinished: name = text
+                                implicitWidth: transformTextFieldWidth
+                                validator: NameValidator {
+                                    model: transformModel
+                                    myindex: index
+                                    onValidationFailed: translateNameField.ToolTip.show("A component's transforms must have unique names", 3000)
+                                }
+                            }
+                            Label {
+                                text: "X: "
+                            }
+                            TextField {
+                                id: xRotationField
+                                implicitWidth: transformTextFieldWidth
+                                text: rotate_x
+                                selectByMouse: true
+                                validator: numberValidator
+                                onEditingFinished: rotate_x = parseFloat(text)
+                            }
+                            Label {
+                                text: "Y: "
+                            }
+                            TextField {
+                                id: yRotationField
+                                implicitWidth: transformTextFieldWidth
+                                text: rotate_y
+                                selectByMouse: true
+                                validator: numberValidator
+                                onEditingFinished: rotate_y = parseFloat(text)
+                            }
+                            Label {
+                                text: "Z: "
+                            }
+                            TextField {
+                                id: zRotationField
+                                implicitWidth: transformTextFieldWidth
+                                text: rotate_y
+                                selectByMouse: true
+                                validator: numberValidator
+                                onEditingFinished: rotate_y = parseFloat(text)
+                            }
+                            Label {
+                                text: "Angle (Degrees): "
+                                Layout.alignment: Qt.AlignRight
+                                Layout.columnSpan: 5
+                            }
+                            TextField {
+                                id: angleField
+                                implicitWidth: transformTextFieldWidth
+                                text: rotate_angle
+                                selectByMouse: true
+                                validator: angleValidator
+                                onEditingFinished: rotate_angle = parseFloat(text)
+                            }
                         }
                     }
-                    Label {
-                        text: "X: "
-                    }
-                    TextField {
-                        id: xRotationField
-                        implicitWidth: transformTextFieldWidth
-                        text: rotate_x
-                        selectByMouse: true
-                        validator: numberValidator
-                        onEditingFinished: rotate_x = parseFloat(text)
-                    }
-                    Label {
-                        text: "Y: "
-                    }
-                    TextField {
-                        id: yRotationField
-                        implicitWidth: transformTextFieldWidth
-                        text: rotate_y
-                        selectByMouse: true
-                        validator: numberValidator
-                        onEditingFinished: rotate_y = parseFloat(text)
-                    }
-                    Label {
-                        text: "Z: "
-                    }
-                    TextField {
-                        id: zRotationField
-                        implicitWidth: transformTextFieldWidth
-                        text: rotate_y
-                        selectByMouse: true
-                        validator: numberValidator
-                        onEditingFinished: rotate_y = parseFloat(text)
-                    }
-                    Label {
-                        text: "Angle (Degrees): "
-                        Layout.alignment: Qt.AlignRight
-                        Layout.columnSpan: 5
-                    }
-                    TextField {
-                        id: angleField
-                        implicitWidth: transformTextFieldWidth
-                        text: rotate_angle
-                        selectByMouse: true
-                        validator: angleValidator
-                        onEditingFinished: rotate_angle = parseFloat(text)
+                }
+                Pane {
+                    id: transformButtons
+                    contentWidth: transformButtonsRow.implicitWidth
+                    contentHeight: transformButtonsRow.implicitHeight
+
+                    RowLayout {
+                        id: transformButtonsRow
+                        anchors.fill: parent
+
+                        PaddedButton {
+                            id: moveUpButton
+                            Layout.fillWidth: false
+                            text: "Move up"
+                            onClicked: transformModel.change_position(index, index - 1)
+                        }
+                        PaddedButton {
+                            id: moveDownButton
+                            Layout.fillWidth: false
+                            text: "Move down"
+                            onClicked: transformModel.change_position(index, index + 1)
+                        }
+                        Item {
+                            // Spacer item to force deleteButton to the right
+                            Layout.fillWidth: true
+                        }
+                        PaddedButton {
+                            id: deleteButton
+                            Layout.fillWidth: false
+                            text: "Delete"
+                            onClicked: transformModel.delete_transform(index)
+                            buttonEnabled: deletable
+                            ToolTip.visible: hovered & !deletable
+                            ToolTip.delay: 400
+                            ToolTip.text: "Cannot remove a transform that's in use as a transform parent"
+                        }
                     }
                 }
             }
-
-            Pane {
-                id: transformButtons
-                anchors.bottom: parent.bottom
-                anchors.left: parent.left
-                anchors.right: parent.right
-                contentWidth: transformButtonsRow.implicitWidth
-                contentHeight: transformButtonsRow.implicitHeight
-
-                RowLayout {
-                    id: transformButtonsRow
-                    anchors.fill: parent
-
-                    PaddedButton {
-                        id: moveUpButton
-                        Layout.fillWidth: false
-                        text: "Move up"
-                        onClicked: transformModel.change_position(index, index - 1)
-                    }
-                    PaddedButton {
-                        id: moveDownButton
-                        Layout.fillWidth: false
-                        text: "Move down"
-                        onClicked: transformModel.change_position(index, index + 1)
-                    }
-                    Item {
-                        // Spacer item to force deleteButton to the right
-                        Layout.fillWidth: true
-                    }
-                    PaddedButton {
-                        id: deleteButton
-                        Layout.fillWidth: false
-                        text: "Delete"
-                        onClicked: transformModel.delete_transform(index)
-                        buttonEnabled: deletable
-                        ToolTip.visible: hovered & !deletable
-                        ToolTip.delay: 400
-                        ToolTip.text: "Cannot remove a transform that's in use as a transform parent"
-                    }
-                }
-            }
-
+            /*
             states: [
                 State {
                     name: "Translate"; when: transform_type == "Translate"
@@ -333,6 +343,7 @@ Item {
                     PropertyChanges { target: translatePane; height: 0 }
                 }
             ]
+            */
         }
     }
 

--- a/resources/Qtmodels/TransformControls.qml
+++ b/resources/Qtmodels/TransformControls.qml
@@ -141,7 +141,6 @@ Item {
                         padding: 0
                         contentWidth: translatePaneGrid.implicitWidth
                         contentHeight: translatePaneGrid.implicitHeight
-                        visible: true
 
                         GridLayout {
                             id: translatePaneGrid

--- a/resources/Qtmodels/TransformControls.qml
+++ b/resources/Qtmodels/TransformControls.qml
@@ -117,7 +117,8 @@ Item {
         Frame {
             id: transformBox
             contentHeight: transformBoxColumn.height
-            contentWidth: Math.max(translatePane.implicitWidth, rotatePane.implicitWidth, transformButtons.implicitWidth)
+            // contentWidth: Math.max(translatePane.implicitWidth, rotatePane.implicitWidth, transformButtons.implicitWidth)
+            contentWidth: transformBoxColumn.width
             anchors.right: parent.right
             anchors.left: parent.left
 

--- a/resources/Qtmodels/TransformControls.qml
+++ b/resources/Qtmodels/TransformControls.qml
@@ -329,20 +329,6 @@ Item {
                     }
                 }
             }
-            /*
-            states: [
-                State {
-                    name: "Translate"; when: transform_type == "Translate"
-                    PropertyChanges { target: rotatePane; visible: false }
-                    PropertyChanges { target: rotatePane; height: 0 }
-                },
-                State {
-                    name: "Rotate"; when: transform_type == "Rotate"
-                    PropertyChanges { target: translatePane; visible: false }
-                    PropertyChanges { target: translatePane; height: 0 }
-                }
-            ]
-            */
         }
     }
 

--- a/resources/Qtmodels/TransformControls.qml
+++ b/resources/Qtmodels/TransformControls.qml
@@ -129,7 +129,7 @@ Item {
 
             ColumnLayout {
                 id: transformBoxColumn
-                anchors.fill: parents
+                anchors.fill: parent
 
                 StackLayout {
                     id: transformBoxStack

--- a/resources/Qtmodels/TransformControls.qml
+++ b/resources/Qtmodels/TransformControls.qml
@@ -116,20 +116,20 @@ Item {
 
         Frame {
             id: transformBox
-            // width: transformsListView.width
-            // contentHeight: translatePane.height + rotatePane.height + transformButtons.height
             contentHeight: transformBoxStack.height + transformButtons.implicitHeight
             contentWidth: Math.max(translatePane.implicitWidth, rotatePane.implicitWidth, transformButtons.implicitWidth)
+            anchors.right: parent.right
+            anchors.left: parent.left
 
             Component.onCompleted: {
                 if (transformsListView.implicitWidth < transformBox.implicitWidth) {
                     transformsListView.implicitWidth = transformBox.implicitWidth
                 }
-                console.log(transformBoxStack.implicitHeight)
             }
 
             ColumnLayout {
                 id: transformBoxColumn
+                anchors.fill: parents
 
                 StackLayout {
                     id: transformBoxStack

--- a/resources/Qtmodels/TransformControls.qml
+++ b/resources/Qtmodels/TransformControls.qml
@@ -118,7 +118,7 @@ Item {
             id: transformBox
             // width: transformsListView.width
             // contentHeight: translatePane.height + rotatePane.height + transformButtons.height
-            contentHeight: transformBoxStack.implicitHeight + transformButtons.implicitHeight
+            contentHeight: transformBoxStack.height + transformButtons.implicitHeight
             contentWidth: Math.max(translatePane.implicitWidth, rotatePane.implicitWidth, transformButtons.implicitWidth)
 
             Component.onCompleted: {
@@ -296,6 +296,7 @@ Item {
                     id: transformButtons
                     contentWidth: transformButtonsRow.implicitWidth
                     contentHeight: transformButtonsRow.implicitHeight
+                    Layout.fillWidth: true
 
                     RowLayout {
                         id: transformButtonsRow
@@ -314,13 +315,12 @@ Item {
                             onClicked: transformModel.change_position(index, index + 1)
                         }
                         Item {
-                            // Spacer item to force deleteButton to the right
                             Layout.fillWidth: true
                         }
                         PaddedButton {
                             id: deleteButton
-                            Layout.fillWidth: false
                             text: "Delete"
+                            Layout.alignment: Qt.AlignRight
                             onClicked: transformModel.delete_transform(index)
                             buttonEnabled: deletable
                             ToolTip.visible: hovered & !deletable


### PR DESCRIPTION
### Issue

Closes #261 

### Description of work

Uses a `StackLayout` to manage the switch between the rotation stuff and the transformation stuff. The `StackLayout` is also bundled into a `ColumnLayout` with `transformButtons` (where the move up/down and delete buttons are kept). The result is that the height of the surrounding pane can now have its size set by using the height/width of `transformBoxColumn` instead of adding things up.
```qml
contentHeight: transformBoxColumn.height
contentWidth: transformBoxColumn.width
```

Also the `StackLayout` doesn't check if `transform_type` is "Rotate" in order to make the switch. It just assumes that a value that isn't "Translate" must be "Rotate." Perhaps not the best way to implement this but I couldn't see another way...

```qml
currentIndex: transform_type == "Translate" ? 0 : 1
Layout.preferredHeight: currentIndex == 0 ? translatePane.implicitHeight : rotatePane.implicitHeight
```

### Acceptance Criteria 

Add multiple different transformation types to a component and make sure the switch works correctly. Also make sure that transformations get a slightly smaller box compared to rotations.

### UI tests

No intentional changes to UI behavior.

### Nominate for Group Code Review

- [ ] Nominate for code review 
