### PR TITLE
254: Layout for translatePane in TransformControls

### DIFF
--- a/resources/Qtmodels/TransformControls.qml
+++ b/resources/Qtmodels/TransformControls.qml
@@ -152,6 +152,7 @@ Item {
                         id: translateNameField
                         implicitWidth: transformTextFieldWidth
                         text: name
+                        selectByMouse: true
                         onEditingFinished: name = text
                         validator: NameValidator {
                             model: transformModel
@@ -166,6 +167,7 @@ Item {
                         id: xTranslationField
                         implicitWidth: transformTextFieldWidth
                         text: translate_x
+                        selectByMouse: true
                         validator: numberValidator
                         onEditingFinished: translate_x = parseFloat(text)
                     }
@@ -176,6 +178,7 @@ Item {
                         id: yTranslationField
                         implicitWidth: transformTextFieldWidth
                         text: translate_y
+                        selectByMouse: true
                         validator: numberValidator
                         onEditingFinished: translate_y = parseFloat(text)
                     }
@@ -186,6 +189,7 @@ Item {
                         id: zTranslationField
                         implicitWidth: transformTextFieldWidth
                         text: translate_z
+                        selectByMouse: true
                         validator: numberValidator
                         onEditingFinished: translate_z = parseFloat(text)
                     }
@@ -218,6 +222,7 @@ Item {
                     TextField {
                         id: rotateNameField
                         text: name
+                        selectByMouse: true
                         onEditingFinished: name = text
                         implicitWidth: transformTextFieldWidth
                         validator: NameValidator {
@@ -233,6 +238,7 @@ Item {
                         id: xRotationField
                         implicitWidth: transformTextFieldWidth
                         text: rotate_x
+                        selectByMouse: true
                         validator: numberValidator
                         onEditingFinished: rotate_x = parseFloat(text)
                     }
@@ -243,6 +249,7 @@ Item {
                         id: yRotationField
                         implicitWidth: transformTextFieldWidth
                         text: rotate_y
+                        selectByMouse: true
                         validator: numberValidator
                         onEditingFinished: rotate_y = parseFloat(text)
                     }
@@ -253,6 +260,7 @@ Item {
                         id: zRotationField
                         implicitWidth: transformTextFieldWidth
                         text: rotate_y
+                        selectByMouse: true
                         validator: numberValidator
                         onEditingFinished: rotate_y = parseFloat(text)
                     }
@@ -265,6 +273,7 @@ Item {
                         id: angleField
                         implicitWidth: transformTextFieldWidth
                         text: rotate_angle
+                        selectByMouse: true
                         validator: angleValidator
                         onEditingFinished: rotate_angle = parseFloat(text)
                     }

--- a/resources/Qtmodels/TransformControls.qml
+++ b/resources/Qtmodels/TransformControls.qml
@@ -132,55 +132,92 @@ Item {
                 contentWidth: xField.implicitWidth + yField.implicitWidth + zField.implicitWidth
                 contentHeight: translateNameField.height + xField.height
 
-                Label {
-                    id: translateLabel
-                    anchors.verticalCenter: translateNameField.verticalCenter
-                    anchors.left: parent.left
-                    text: "Translation"
-                }
-                LabeledTextField {
-                    id: translateNameField
-                    anchors.top: parent.top
-                    anchors.right: parent.right
-                    anchors.left: yField.left
-                    anchoredEditor: true
-                    labelText: "Name:"
-                    editorText: name
-                    onEditingFinished: name = editorText
-                    validator: NameValidator {
-                        model: transformModel
-                        myindex: index
-                        onValidationFailed: translateNameField.ToolTip.show("A component's transforms must have unique names", 3000)
+                GridLayout {
+                    id: translatePaneGrid
+                    rows: 2
+                    columns: 6
+
+                    Label {
+                        id: translateLabel
+                        text: "Translation"
+                        Layout.columnSpan: 2
+                    }
+                    Label {
+                        text: "Name: "
+                        Layout.columnSpan: 3
+                        Layout.alignment: Qt.AlignRight
+                    }
+                    TextField {
+                        id: translateNameField
+                        implicitWidth: transformTextFieldWidth
+                    }
+                    Label {
+                        text: "X: "
+                    }
+                    TextField {
+                        id: translateXField
+                        implicitWidth: transformTextFieldWidth
+                    }
+                    Label {
+                        text: "Y: "
+                    }
+                    TextField {
+                        id: translateYField
+                        implicitWidth: transformTextFieldWidth
+                    }
+                    Label {
+                        text: "Z: "
+                    }
+                    TextField {
+                        id: translateZField
+                        implicitWidth: transformTextFieldWidth
                     }
                 }
+                /*
+                LabeledTextField {
 
-                LabeledTextField {
-                    id: xField
-                    anchors.top: translateNameField.bottom
-                    anchors.left: parent.left
-                    labelText: "x:"
-                    editorText: translate_x
-                    validator: numberValidator
-                    onEditingFinished: translate_x = parseFloat(editorText)
-                }
-                LabeledTextField {
-                    id: yField
-                    anchors.top: xField.top
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    labelText: "y:"
-                    editorText: translate_y
-                    validator: numberValidator
-                    onEditingFinished: translate_y = parseFloat(editorText)
-                }
-                LabeledTextField {
-                    id: zField
-                    anchors.top: xField.top
-                    anchors.right: parent.right
-                    labelText: "z:"
-                    editorText: translate_z
-                    validator: numberValidator
-                    onEditingFinished: translate_z = parseFloat(editorText)
-                }
+                        anchors.top: parent.top
+                        anchors.right: parent.right
+                        anchors.left: yField.left
+                        anchoredEditor: true
+                        labelText: "Name:"
+                        editorText: name
+                        onEditingFinished: name = editorText
+                        validator: NameValidator {
+                            model: transformModel
+                            myindex: index
+                            onValidationFailed: translateNameField.ToolTip.show("A component's transforms must have unique names", 3000)
+                        }
+                    }
+
+                    LabeledTextField {
+                        id: xField
+                        anchors.top: translateNameField.bottom
+                        anchors.left: parent.left
+                        labelText: "x:"
+                        editorText: translate_x
+                        validator: numberValidator
+                        onEditingFinished: translate_x = parseFloat(editorText)
+                    }
+                    LabeledTextField {
+                        id: yField
+                        anchors.top: xField.top
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        labelText: "y:"
+                        editorText: translate_y
+                        validator: numberValidator
+                        onEditingFinished: translate_y = parseFloat(editorText)
+                    }
+                    LabeledTextField {
+                        id: zField
+                        anchors.top: xField.top
+                        anchors.right: parent.right
+                        labelText: "z:"
+                        editorText: translate_z
+                        validator: numberValidator
+                        onEditingFinished: translate_z = parseFloat(editorText)
+                    }
+                    */
             }
 
             Pane {

--- a/resources/Qtmodels/TransformControls.qml
+++ b/resources/Qtmodels/TransformControls.qml
@@ -143,6 +143,7 @@ Item {
                         Layout.columnSpan: 2
                     }
                     Label {
+                        id: translateNameLabel
                         text: "Name: "
                         Layout.columnSpan: 3
                         Layout.alignment: Qt.AlignRight
@@ -162,7 +163,7 @@ Item {
                         text: "X: "
                     }
                     TextField {
-                        id: translateXField
+                        id: xTranslationField
                         implicitWidth: transformTextFieldWidth
                         text: translate_x
                         validator: numberValidator
@@ -172,7 +173,7 @@ Item {
                         text: "Y: "
                     }
                     TextField {
-                        id: translateYField
+                        id: yTranslationField
                         implicitWidth: transformTextFieldWidth
                         text: translate_y
                         validator: numberValidator
@@ -182,7 +183,7 @@ Item {
                         text: "Z: "
                     }
                     TextField {
-                        id: translateZField
+                        id: zTranslationField
                         implicitWidth: transformTextFieldWidth
                         text: translate_z
                         validator: numberValidator

--- a/resources/Qtmodels/TransformControls.qml
+++ b/resources/Qtmodels/TransformControls.qml
@@ -150,6 +150,13 @@ Item {
                     TextField {
                         id: translateNameField
                         implicitWidth: transformTextFieldWidth
+                        text: name
+                        onEditingFinished: name = text
+                        validator: NameValidator {
+                            model: transformModel
+                            myindex: index
+                            onValidationFailed: translateNameField.ToolTip.show("A component's transforms must have unique names", 3000)
+                        }
                     }
                     Label {
                         text: "X: "
@@ -157,6 +164,9 @@ Item {
                     TextField {
                         id: translateXField
                         implicitWidth: transformTextFieldWidth
+                        text: translate_x
+                        validator: numberValidator
+                        onEditingFinished: translate_x = parseFloat(text)
                     }
                     Label {
                         text: "Y: "
@@ -164,6 +174,9 @@ Item {
                     TextField {
                         id: translateYField
                         implicitWidth: transformTextFieldWidth
+                        text: translate_y
+                        validator: numberValidator
+                        onEditingFinished: translate_y = parseFloat(text)
                     }
                     Label {
                         text: "Z: "
@@ -171,53 +184,11 @@ Item {
                     TextField {
                         id: translateZField
                         implicitWidth: transformTextFieldWidth
+                        text: translate_z
+                        validator: numberValidator
+                        onEditingFinished: translate_z = parseFloat(text)
                     }
                 }
-                /*
-                LabeledTextField {
-
-                        anchors.top: parent.top
-                        anchors.right: parent.right
-                        anchors.left: yField.left
-                        anchoredEditor: true
-                        labelText: "Name:"
-                        editorText: name
-                        onEditingFinished: name = editorText
-                        validator: NameValidator {
-                            model: transformModel
-                            myindex: index
-                            onValidationFailed: translateNameField.ToolTip.show("A component's transforms must have unique names", 3000)
-                        }
-                    }
-
-                    LabeledTextField {
-                        id: xField
-                        anchors.top: translateNameField.bottom
-                        anchors.left: parent.left
-                        labelText: "x:"
-                        editorText: translate_x
-                        validator: numberValidator
-                        onEditingFinished: translate_x = parseFloat(editorText)
-                    }
-                    LabeledTextField {
-                        id: yField
-                        anchors.top: xField.top
-                        anchors.horizontalCenter: parent.horizontalCenter
-                        labelText: "y:"
-                        editorText: translate_y
-                        validator: numberValidator
-                        onEditingFinished: translate_y = parseFloat(editorText)
-                    }
-                    LabeledTextField {
-                        id: zField
-                        anchors.top: xField.top
-                        anchors.right: parent.right
-                        labelText: "z:"
-                        editorText: translate_z
-                        validator: numberValidator
-                        onEditingFinished: translate_z = parseFloat(editorText)
-                    }
-                    */
             }
 
             Pane {

--- a/resources/Qtmodels/TransformControls.qml
+++ b/resources/Qtmodels/TransformControls.qml
@@ -129,8 +129,8 @@ Item {
             Pane {
                 id: translatePane
                 padding: 0
-                contentWidth: xField.implicitWidth + yField.implicitWidth + zField.implicitWidth
-                contentHeight: translateNameField.height + xField.height
+                contentWidth: translatePaneGrid.implicitWidth
+                contentHeight: translatePaneGrid.implicitHeight
 
                 GridLayout {
                     id: translatePaneGrid


### PR DESCRIPTION
### Issue

Closes #254

### Description of work

Places the translation-related components in a `GridLayout`. 

### Acceptance Criteria 

Make sure that everything looks good in the places where the translation fields appear (Add Component menu + LHS pane). Also make sure translations still work.

### UI tests

No intentional changes to UI behavior.

### Nominate for Group Code Review

- [ ] Nominate for code review 
