### PR TITLE
Fixing StackLayout

### DIFF
--- a/resources/Qtmodels/TransformControls.qml
+++ b/resources/Qtmodels/TransformControls.qml
@@ -129,7 +129,6 @@ Item {
 
             ColumnLayout {
                 id: transformBoxColumn
-                anchors.fill: parent
 
                 StackLayout {
                     id: transformBoxStack


### PR DESCRIPTION
### Issue

Fix the damage caused by my most recent PR.

### Description of work

Using `anchors.fill: parent` in `transformBoxColumn` caused everything to go haywire and I didn't notice, so I'm reversing that change.

### Acceptance Criteria 

Check that transformations look normal again.

### UI tests

n/a

### Nominate for Group Code Review

- [ ] Nominate for code review 
