### PR TITLE
252: Layout for transformItem in TransformControls

### DIFF
--- a/resources/Qtmodels/TransformControls.qml
+++ b/resources/Qtmodels/TransformControls.qml
@@ -27,6 +27,8 @@ Item {
 
     ColumnLayout {
         id: transformColumn
+        anchors.right: parent.right
+        anchors.left: parent.left
 
         GridLayout {
             id: transformPickerGrid
@@ -36,10 +38,12 @@ Item {
             Label {
                 id: relativeLabel
                 text: "Transform parent:"
+                Layout.fillWidth: false
             }
             ComboBox {
                 id: relativePicker
                 Layout.preferredWidth: 250
+                Layout.fillWidth: true
                 // As the sample is its own transform parent, use an unfiltered model for it to prevent validation errors
                 model: (componentIndex == 0) ? components : filteredModel
                 textRole: "name"
@@ -60,11 +64,13 @@ Item {
             }
             Item {
                 // Spacer Item to force parentTransformPicker to the bottom-right corner of the 4x4 grid
-                Layout.fillWidth: true
+                Layout.preferredWidth: relativeLabel.width
+                Layout.fillWidth: false
             }
             ComboBox {
                 id: parentTransformPicker
                 Layout.preferredWidth: 250
+                Layout.fillWidth: true
                 model: components.get_transform_model(transform_parent_index)
                 textRole: "name"
                 currentIndex: dependent_transform_index
@@ -73,16 +79,19 @@ Item {
         }
         Frame {
             id: transformsListContainer
-            contentWidth: transformsListView.implicitWidth
+            // contentWidth: transformsListView.implicitWidth
             contentHeight: transformsListView.implicitHeight
             visible: contentHeight > 0
             padding: 1
+            Layout.fillWidth: true
 
             ListView {
                 id: transformsListView
                 model: transformModel
                 delegate: transformDelegate
                 implicitHeight: (contentHeight < 250) ? contentHeight : 250
+                anchors.right: parent.right
+                anchors.left: parent.left
                 clip: true
                 boundsBehavior: Flickable.StopAtBounds
                 ScrollBar.vertical: ActiveScrollBar {}
@@ -115,7 +124,7 @@ Item {
         Frame {
             id: transformBox
             contentHeight: transformBoxColumn.height
-            contentWidth: transformBoxColumn.width
+            // contentWidth: transformBoxColumn.width
             anchors.right: parent.right
             anchors.left: parent.left
 
@@ -127,22 +136,27 @@ Item {
 
             ColumnLayout {
                 id: transformBoxColumn
+                anchors.right: parent.right
+                anchors.left: parent.left
 
                 StackLayout {
                     id: transformBoxStack
                     currentIndex: transform_type == "Translate" ? 0 : 1
                     Layout.preferredHeight: currentIndex == 0 ? translatePane.implicitHeight : rotatePane.implicitHeight
+                    Layout.fillWidth: true
 
                     Pane {
                         id: translatePane
                         padding: 0
-                        contentWidth: translatePaneGrid.implicitWidth
+                        // contentWidth: translatePaneGrid.implicitWidth
                         contentHeight: translatePaneGrid.implicitHeight
+                        Layout.fillWidth: true
 
                         GridLayout {
                             id: translatePaneGrid
                             rows: 2
                             columns: 6
+                            Layout.fillWidth: true
 
                             Label {
                                 id: translateLabel
@@ -157,7 +171,7 @@ Item {
                             }
                             TextField {
                                 id: translateNameField
-                                implicitWidth: transformTextFieldWidth
+                                Layout.minimumWidth: transformTextFieldWidth
                                 text: name
                                 selectByMouse: true
                                 onEditingFinished: name = text
@@ -172,7 +186,7 @@ Item {
                             }
                             TextField {
                                 id: xTranslationField
-                                implicitWidth: transformTextFieldWidth
+                                Layout.minimumWidth: transformTextFieldWidth
                                 text: translate_x
                                 selectByMouse: true
                                 validator: numberValidator
@@ -183,7 +197,7 @@ Item {
                             }
                             TextField {
                                 id: yTranslationField
-                                implicitWidth: transformTextFieldWidth
+                                Layout.minimumWidth: transformTextFieldWidth
                                 text: translate_y
                                 selectByMouse: true
                                 validator: numberValidator
@@ -194,7 +208,7 @@ Item {
                             }
                             TextField {
                                 id: zTranslationField
-                                implicitWidth: transformTextFieldWidth
+                                Layout.minimumWidth: transformTextFieldWidth
                                 text: translate_z
                                 selectByMouse: true
                                 validator: numberValidator

--- a/resources/Qtmodels/TransformControls.qml
+++ b/resources/Qtmodels/TransformControls.qml
@@ -124,7 +124,7 @@ Item {
         Frame {
             id: transformBox
             contentHeight: transformBoxColumn.height
-            // contentWidth: transformBoxColumn.width
+            contentWidth: transformBoxColumn.width
             anchors.right: parent.right
             anchors.left: parent.left
 

--- a/resources/Qtmodels/TransformControls.qml
+++ b/resources/Qtmodels/TransformControls.qml
@@ -79,7 +79,7 @@ Item {
         }
         Frame {
             id: transformsListContainer
-            // contentWidth: transformsListView.implicitWidth
+            contentWidth: transformsListView.implicitWidth
             contentHeight: transformsListView.implicitHeight
             visible: contentHeight > 0
             padding: 1

--- a/resources/Qtmodels/TransformControls.qml
+++ b/resources/Qtmodels/TransformControls.qml
@@ -172,7 +172,7 @@ Item {
                             }
                             TextField {
                                 id: translateNameField
-                                Layout.minimumWidth: transformTextFieldWidth
+                                Layout.preferredWidth: transformTextFieldWidth
                                 text: name
                                 selectByMouse: true
                                 onEditingFinished: name = text
@@ -187,7 +187,7 @@ Item {
                             }
                             TextField {
                                 id: xTranslationField
-                                Layout.minimumWidth: transformTextFieldWidth
+                                Layout.preferredWidth: transformTextFieldWidth
                                 text: translate_x
                                 selectByMouse: true
                                 validator: numberValidator
@@ -198,7 +198,7 @@ Item {
                             }
                             TextField {
                                 id: yTranslationField
-                                Layout.minimumWidth: transformTextFieldWidth
+                                Layout.preferredWidth: transformTextFieldWidth
                                 text: translate_y
                                 selectByMouse: true
                                 validator: numberValidator
@@ -209,7 +209,7 @@ Item {
                             }
                             TextField {
                                 id: zTranslationField
-                                Layout.minimumWidth: transformTextFieldWidth
+                                Layout.preferredWidth: transformTextFieldWidth
                                 text: translate_z
                                 selectByMouse: true
                                 validator: numberValidator
@@ -249,7 +249,7 @@ Item {
                                 text: name
                                 selectByMouse: true
                                 onEditingFinished: name = text
-                                Layout.minimumWidth: transformTextFieldWidth
+                                Layout.preferredWidth: transformTextFieldWidth
                                 validator: NameValidator {
                                     model: transformModel
                                     myindex: index
@@ -261,7 +261,7 @@ Item {
                             }
                             TextField {
                                 id: xRotationField
-                                Layout.minimumWidth: transformTextFieldWidth
+                                Layout.preferredWidth: transformTextFieldWidth
                                 text: rotate_x
                                 selectByMouse: true
                                 validator: numberValidator
@@ -272,7 +272,7 @@ Item {
                             }
                             TextField {
                                 id: yRotationField
-                                Layout.minimumWidth: transformTextFieldWidth
+                                Layout.preferredWidth: transformTextFieldWidth
                                 text: rotate_y
                                 selectByMouse: true
                                 validator: numberValidator
@@ -283,7 +283,7 @@ Item {
                             }
                             TextField {
                                 id: zRotationField
-                                Layout.minimumWidth: transformTextFieldWidth
+                                Layout.preferredWidth: transformTextFieldWidth
                                 text: rotate_y
                                 selectByMouse: true
                                 validator: numberValidator
@@ -296,7 +296,7 @@ Item {
                             }
                             TextField {
                                 id: angleField
-                                Layout.minimumWidth: transformTextFieldWidth
+                                Layout.preferredWidth: transformTextFieldWidth
                                 text: rotate_angle
                                 selectByMouse: true
                                 validator: angleValidator

--- a/resources/Qtmodels/TransformControls.qml
+++ b/resources/Qtmodels/TransformControls.qml
@@ -181,6 +181,7 @@ Item {
                                     myindex: index
                                     onValidationFailed: translateNameField.ToolTip.show("A component's transforms must have unique names", 3000)
                                 }
+                                Layout.fillWidth: true
                             }
                             Label {
                                 text: "X: "
@@ -192,6 +193,7 @@ Item {
                                 selectByMouse: true
                                 validator: numberValidator
                                 onEditingFinished: translate_x = parseFloat(text)
+                                Layout.fillWidth: true
                             }
                             Label {
                                 text: "Y: "
@@ -203,6 +205,7 @@ Item {
                                 selectByMouse: true
                                 validator: numberValidator
                                 onEditingFinished: translate_y = parseFloat(text)
+                                Layout.fillWidth: true
                             }
                             Label {
                                 text: "Z: "
@@ -214,6 +217,7 @@ Item {
                                 selectByMouse: true
                                 validator: numberValidator
                                 onEditingFinished: translate_z = parseFloat(text)
+                                Layout.fillWidth: true
                             }
                         }
                     }
@@ -255,6 +259,7 @@ Item {
                                     myindex: index
                                     onValidationFailed: translateNameField.ToolTip.show("A component's transforms must have unique names", 3000)
                                 }
+                                Layout.fillWidth: true
                             }
                             Label {
                                 text: "X: "
@@ -266,6 +271,7 @@ Item {
                                 selectByMouse: true
                                 validator: numberValidator
                                 onEditingFinished: rotate_x = parseFloat(text)
+                                Layout.fillWidth: true
                             }
                             Label {
                                 text: "Y: "
@@ -277,6 +283,7 @@ Item {
                                 selectByMouse: true
                                 validator: numberValidator
                                 onEditingFinished: rotate_y = parseFloat(text)
+                                Layout.fillWidth: true
                             }
                             Label {
                                 text: "Z: "
@@ -288,6 +295,7 @@ Item {
                                 selectByMouse: true
                                 validator: numberValidator
                                 onEditingFinished: rotate_y = parseFloat(text)
+                                Layout.fillWidth: true
                             }
                             Label {
                                 text: "Angle (Degrees): "
@@ -301,6 +309,7 @@ Item {
                                 selectByMouse: true
                                 validator: angleValidator
                                 onEditingFinished: rotate_angle = parseFloat(text)
+                                Layout.fillWidth: true
                             }
                         }
                     }

--- a/resources/Qtmodels/TransformControls.qml
+++ b/resources/Qtmodels/TransformControls.qml
@@ -59,6 +59,7 @@ Item {
                 index: componentIndex
             }
             Item {
+                // Spacer Item to force parentTransformPicker to the bottom-right corner of the 4x4 grid
                 Layout.fillWidth: true
             }
             ComboBox {
@@ -87,17 +88,24 @@ Item {
                 ScrollBar.vertical: ActiveScrollBar {}
             }
         }
+        RowLayout {
+            id: addTransformationButtonsRow
 
-        PaddedButton {
-            id: addTranslate
-            text: "Add translation"
-            onClicked: transformModel.add_translate()
-        }
+            PaddedButton {
+                id: addTranslate
+                text: "Add translation"
+                onClicked: transformModel.add_translate()
+            }
 
-        PaddedButton {
-            id: addRotate
-            text: "Add rotation"
-            onClicked: transformModel.add_rotate()
+            PaddedButton {
+                id: addRotate
+                text: "Add rotation"
+                onClicked: transformModel.add_rotate()
+            }
+            Item {
+                // Spacer Item to force Add Transformation buttons to the LHS
+                Layout.fillWidth: true
+            }
         }
     }
 

--- a/resources/Qtmodels/TransformControls.qml
+++ b/resources/Qtmodels/TransformControls.qml
@@ -19,96 +19,86 @@ import QtQuick.Layouts 1.11
 
 Item {
     id: transformsItem
-
-    implicitHeight: relativePicker.implicitHeight +
-                    parentTransformPicker.implicitHeight +
-                    transformsListContainer.implicitHeight +
-                    addTranslate.implicitHeight
-    implicitWidth: Math.max(relativeLabel.implicitWidth + relativePicker.implicitWidth,
-                            transformsListContainer.implicitWidth,
-                            addTranslate.implicitWidth + addRotate.implicitWidth)
+    implicitWidth: transformColumn.implicitWidth
+    implicitHeight: transformColumn.implicitHeight
     property TransformationModel transformModel
     property int componentIndex
     property var transformTextFieldWidth: 90
 
-    Label {
-        id: relativeLabel
-        anchors.verticalCenter: relativePicker.verticalCenter
-        anchors.left: parent.left
-        text: "Transform parent:"
-    }
-    ComboBox {
-        id: relativePicker
-        anchors.top: parent.top
-        anchors.left: relativeLabel.right
-        anchors.right: parent.right
-        implicitWidth: 250
-        // As the sample is its own transform parent, use an unfiltered model for it to prevent validation errors
-        model: (componentIndex == 0) ? components : filteredModel
-        textRole: "name"
-        currentIndex: (componentIndex == 0) ? transform_parent_index : model.filtered_index(transform_parent_index)
-        validator: parentValidator
-        onActivated: {
-            if(acceptableInput){
-                transform_parent_index = model.source_index(currentIndex)
-            } else {
-                currentIndex = (componentIndex == 0) ? transform_parent_index : model.filtered_index(transform_parent_index)
+    ColumnLayout {
+        id: transformColumn
+
+        GridLayout {
+            id: transformPickerGrid
+            rows: 2
+            columns: 2
+
+            Label {
+                id: relativeLabel
+                text: "Transform parent:"
+            }
+            ComboBox {
+                id: relativePicker
+                Layout.preferredWidth: 250
+                // As the sample is its own transform parent, use an unfiltered model for it to prevent validation errors
+                model: (componentIndex == 0) ? components : filteredModel
+                textRole: "name"
+                currentIndex: (componentIndex == 0) ? transform_parent_index : model.filtered_index(transform_parent_index)
+                validator: parentValidator
+                onActivated: {
+                    if(acceptableInput){
+                        transform_parent_index = model.source_index(currentIndex)
+                    } else {
+                        currentIndex = (componentIndex == 0) ? transform_parent_index : model.filtered_index(transform_parent_index)
+                    }
+                }
+            }
+            ExcludedComponentModel {
+                id: filteredModel
+                model: components
+                index: componentIndex
+            }
+            Item {
+                Layout.fillWidth: true
+            }
+            ComboBox {
+                id: parentTransformPicker
+                Layout.preferredWidth: 250
+                model: components.get_transform_model(transform_parent_index)
+                textRole: "name"
+                currentIndex: dependent_transform_index
+                onActivated: dependent_transform_index = currentIndex
             }
         }
-    }
-    ExcludedComponentModel {
-        id: filteredModel
-        model: components
-        index: componentIndex
-    }
-    ComboBox {
-        id: parentTransformPicker
-        anchors.top: relativePicker.bottom
-        anchors.left: relativePicker.left
-        anchors.right: relativePicker.right
-        model: components.get_transform_model(transform_parent_index)
-        textRole: "name"
-        currentIndex: dependent_transform_index
-        onActivated: dependent_transform_index = currentIndex
-    }
+        Frame {
+            id: transformsListContainer
+            contentWidth: transformsListView.implicitWidth
+            contentHeight: transformsListView.implicitHeight
+            visible: contentHeight > 0
+            padding: 1
 
-    Frame {
-        id: transformsListContainer
-        anchors.top: parentTransformPicker.bottom
-        anchors.bottom: addTranslate.top
-        anchors.left: parent.left
-        anchors.right: parent.right
-        contentWidth: transformsListView.implicitWidth
-        contentHeight: transformsListView.implicitHeight
-        visible: contentHeight > 0
-        padding: 1
-
-        ListView {
-            id: transformsListView
-            anchors.fill: parent
-            model: transformModel
-            delegate: transformDelegate
-            implicitHeight: (contentHeight < 250) ? contentHeight : 250
-            clip: true
-            boundsBehavior: Flickable.StopAtBounds
-            ScrollBar.vertical: ActiveScrollBar {}
+            ListView {
+                id: transformsListView
+                model: transformModel
+                delegate: transformDelegate
+                implicitHeight: (contentHeight < 250) ? contentHeight : 250
+                clip: true
+                boundsBehavior: Flickable.StopAtBounds
+                ScrollBar.vertical: ActiveScrollBar {}
+            }
         }
-    }
 
-    PaddedButton {
-        id: addTranslate
-        anchors.bottom: parent.bottom
-        anchors.left: parent.left
-        text: "Add translation"
-        onClicked: transformModel.add_translate()
-    }
+        PaddedButton {
+            id: addTranslate
+            text: "Add translation"
+            onClicked: transformModel.add_translate()
+        }
 
-    PaddedButton {
-        id: addRotate
-        anchors.top: addTranslate.top
-        anchors.left: addTranslate.right
-        text: "Add rotation"
-        onClicked: transformModel.add_rotate()
+        PaddedButton {
+            id: addRotate
+            text: "Add rotation"
+            onClicked: transformModel.add_rotate()
+        }
     }
 
     Component {

--- a/resources/Qtmodels/TransformControls.qml
+++ b/resources/Qtmodels/TransformControls.qml
@@ -148,7 +148,7 @@ Item {
                     Pane {
                         id: translatePane
                         padding: 0
-                        // contentWidth: translatePaneGrid.implicitWidth
+                        contentWidth: translatePaneGrid.implicitWidth
                         contentHeight: translatePaneGrid.implicitHeight
                         Layout.fillWidth: true
 
@@ -156,7 +156,8 @@ Item {
                             id: translatePaneGrid
                             rows: 2
                             columns: 6
-                            Layout.fillWidth: true
+                            anchors.right: parent.right
+                            anchors.left: parent.left
 
                             Label {
                                 id: translateLabel
@@ -222,11 +223,13 @@ Item {
                         padding: 0
                         contentWidth: rotatePaneGrid.implicitWidth
                         contentHeight: rotatePaneGrid.implicitHeight
+                        Layout.fillWidth: true
                         visible: true
 
                         GridLayout {
                             id: rotatePaneGrid
-                            anchors.fill: parent
+                            anchors.right: parent.right
+                            anchors.left: parent.left
                             rows: 3
                             columns: 6
 
@@ -246,7 +249,7 @@ Item {
                                 text: name
                                 selectByMouse: true
                                 onEditingFinished: name = text
-                                implicitWidth: transformTextFieldWidth
+                                Layout.minimumWidth: transformTextFieldWidth
                                 validator: NameValidator {
                                     model: transformModel
                                     myindex: index
@@ -258,7 +261,7 @@ Item {
                             }
                             TextField {
                                 id: xRotationField
-                                implicitWidth: transformTextFieldWidth
+                                Layout.minimumWidth: transformTextFieldWidth
                                 text: rotate_x
                                 selectByMouse: true
                                 validator: numberValidator
@@ -269,7 +272,7 @@ Item {
                             }
                             TextField {
                                 id: yRotationField
-                                implicitWidth: transformTextFieldWidth
+                                Layout.minimumWidth: transformTextFieldWidth
                                 text: rotate_y
                                 selectByMouse: true
                                 validator: numberValidator
@@ -280,7 +283,7 @@ Item {
                             }
                             TextField {
                                 id: zRotationField
-                                implicitWidth: transformTextFieldWidth
+                                Layout.minimumWidth: transformTextFieldWidth
                                 text: rotate_y
                                 selectByMouse: true
                                 validator: numberValidator
@@ -293,7 +296,7 @@ Item {
                             }
                             TextField {
                                 id: angleField
-                                implicitWidth: transformTextFieldWidth
+                                Layout.minimumWidth: transformTextFieldWidth
                                 text: rotate_angle
                                 selectByMouse: true
                                 validator: angleValidator


### PR DESCRIPTION
### Issue

Close #252

### Description of work

Puts the remaining stuff in the TransformControls file into Layouts. It's now `width = something.width + somethingelse.width + ...` free.

### Acceptance Criteria 

Check that adding and removing different transformations still works in the Add Component menu and the LHS component list.

### UI tests

No international changes to UI behavior.

### Nominate for Group Code Review

- [ ] Nominate for code review 
