### PR TITLE
251: Layout for gridFields in PixelControls

### DIFF
--- a/resources/Qtmodels/PixelControls.qml
+++ b/resources/Qtmodels/PixelControls.qml
@@ -74,17 +74,6 @@ Item {
         Pane {
             id: gridFields
             width: view.width
-            /*
-            contentHeight: rowsField.height +
-                columnsField.height +
-                firstIdField.height +
-                cornerPicker.height +
-                directionPicker.height
-            contentWidth: Math.max(
-                rowsField.implicitWidth + rowHeightField.implicitWidth,
-                columnsField.implicitWidth + columnWidthField.implicitWidth
-            )
-            */
             contentHeight: pixelGrid.implicitHeight
             contentWidth: pixelGrid.implicitWidth
 

--- a/resources/Qtmodels/PixelControls.qml
+++ b/resources/Qtmodels/PixelControls.qml
@@ -97,12 +97,46 @@ Item {
                 columns: 4
 
                 Label {
+                    text: "Row: "
+                }
+                TextField {
+                }
+                Label {
+                    text: "Row Height: "
+                }
+                TextField {
+                }
+                Label {
+                    text: "Columns: "
+                }
+                TextField {
+                }
+                Label {
+                    text: "Column Width: "
+                }
+                TextField {
+                }
+                Label {
+                    text: "First ID: "
+                }
+                TextField {
+                }
+                Item {
+                    Layout.fillWidth: true
+                }
+                Item {
+                    Layout.fillWidth: true
+                }
+                Label {
                     id: cornerLabel
                     text: "Start counting ID's from:"
+                    Layout.columnSpan: 2
                 }
                 ComboBox {
                     id: cornerPicker
                     textRole: "key"
+                    Layout.columnSpan: 2
+                    Layout.fillWidth: true
                     model: ListModel {
                         ListElement { key: "Bottom left"; value: "BOTTOM_LEFT" }
                         ListElement { key: "Bottom right"; value: "BOTTOM_RIGHT" }
@@ -115,10 +149,13 @@ Item {
                 Label {
                     id: directionLabel
                     text: "Count first along:"
+                    Layout.columnSpan: 2
                 }
                 ComboBox {
                     id: directionPicker
                     textRole: "key"
+                    Layout.columnSpan: 2
+                    Layout.fillWidth: true
                     model: ListModel {
                         ListElement { key: "Rows"; value: "ROW" }
                         ListElement { key: "Columns"; value: "COLUMN" }

--- a/resources/Qtmodels/PixelControls.qml
+++ b/resources/Qtmodels/PixelControls.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.11
 import QtQuick.Controls 2.4
+import QtQuick.Layouts 1.11
 import MyModels 1.0
 import MyValidators 1.0
 
@@ -73,6 +74,7 @@ Item {
         Pane {
             id: gridFields
             width: view.width
+            /*
             contentHeight: rowsField.height +
                 columnsField.height +
                 firstIdField.height +
@@ -82,94 +84,97 @@ Item {
                 rowsField.implicitWidth + rowHeightField.implicitWidth,
                 columnsField.implicitWidth + columnWidthField.implicitWidth
             )
+            */
+            contentHeight: pixelGrid.implicitHeight
+            contentWidth: pixelGrid.implicitWidth
 
             Component.onCompleted: view.implicitWidth = gridFields.implicitWidth
 
-            LabeledTextField {
-                id: rowsField
-                anchors.top: parent.top
-                anchors.right: columnsField.right
-                labelText: "Rows:"
-                editorText: rows
-                onEditingFinished: rows = parseInt(editorText)
-                validator: integerValidator
-            }
-            LabeledTextField {
-                id: rowHeightField
-                anchors.top: rowsField.top
-                anchors.right: columnWidthField.right
-                labelText: "Row height:"
-                editorText: row_height
-                onEditingFinished: row_height = parseFloat(editorText)
-                validator: numberValidator
-            }
+            GridLayout {
+                id: pixelGrid
+                anchors.fill: parent
+                rows: 5
+                columns: 4
 
-            LabeledTextField {
-                id: columnsField
-                anchors.top: rowHeightField.bottom
-                anchors.left: parent.left
-                labelText: "Columns:"
-                editorText: columns
-                onEditingFinished: columns = parseInt(editorText)
-                validator: integerValidator
-            }
-            LabeledTextField {
-                id: columnWidthField
-                anchors.top: columnsField.top
-                anchors.left: columnsField.right
-                labelText: "Column width:"
-                editorText: column_width
-                onEditingFinished: column_width = parseFloat(editorText)
-                validator: numberValidator
-            }
-
-            LabeledTextField {
-                id: firstIdField
-                anchors.top: columnWidthField.bottom
-                anchors.right: columnsField.right
-                labelText: "First ID:"
-                editorText: first_id
-                onEditingFinished: first_id = parseInt(editorText)
-                validator: integerValidator
-            }
-
-            Label {
-                id: cornerLabel
-                anchors.verticalCenter: cornerPicker.verticalCenter
-                anchors.left: parent.left
-                text: "Start counting ID's from:"
-            }
-            ComboBox {
-                id: cornerPicker
-                anchors.top: firstIdField.bottom
-                anchors.left: cornerLabel.right
-                textRole: "key"
-                model: ListModel {
-                    ListElement { key: "Bottom left"; value: "BOTTOM_LEFT" }
-                    ListElement { key: "Bottom right"; value: "BOTTOM_RIGHT" }
-                    ListElement { key: "Top left"; value: "TOP_LEFT" }
-                    ListElement { key: "Top right"; value: "TOP_RIGHT" }
+                Label {
+                    id: cornerLabel
+                    text: "Start counting ID's from:"
                 }
-                onActivated: initial_count_corner = model.get(currentIndex).value
-            }
-
-            Label {
-                id: directionLabel
-                anchors.verticalCenter: directionPicker.verticalCenter
-                anchors.right: cornerLabel.right
-                text: "Count first along:"
-            }
-            ComboBox {
-                id: directionPicker
-                anchors.top: cornerPicker.bottom
-                anchors.left: cornerPicker.left
-                textRole: "key"
-                model: ListModel {
-                    ListElement { key: "Rows"; value: "ROW" }
-                    ListElement { key: "Columns"; value: "COLUMN" }
+                ComboBox {
+                    id: cornerPicker
+                    textRole: "key"
+                    model: ListModel {
+                        ListElement { key: "Bottom left"; value: "BOTTOM_LEFT" }
+                        ListElement { key: "Bottom right"; value: "BOTTOM_RIGHT" }
+                        ListElement { key: "Top left"; value: "TOP_LEFT" }
+                        ListElement { key: "Top right"; value: "TOP_RIGHT" }
+                    }
+                    onActivated: initial_count_corner = model.get(currentIndex).value
                 }
-                onActivated: count_direction = model.get(currentIndex).value
+
+                Label {
+                    id: directionLabel
+                    text: "Count first along:"
+                }
+                ComboBox {
+                    id: directionPicker
+                    textRole: "key"
+                    model: ListModel {
+                        ListElement { key: "Rows"; value: "ROW" }
+                        ListElement { key: "Columns"; value: "COLUMN" }
+                    }
+                    onActivated: count_direction = model.get(currentIndex).value
+                }
             }
+            /*
+            LabeledTextField {
+                    id: rowsField
+                    anchors.top: parent.top
+                    anchors.right: columnsField.right
+                    labelText: "Rows:"
+                    editorText: rows
+                    onEditingFinished: rows = parseInt(editorText)
+                    validator: integerValidator
+                }
+                LabeledTextField {
+                    id: rowHeightField
+                    anchors.top: rowsField.top
+                    anchors.right: columnWidthField.right
+                    labelText: "Row height:"
+                    editorText: row_height
+                    onEditingFinished: row_height = parseFloat(editorText)
+                    validator: numberValidator
+                }
+
+                LabeledTextField {
+                    id: columnsField
+                    anchors.top: rowHeightField.bottom
+                    anchors.left: parent.left
+                    labelText: "Columns:"
+                    editorText: columns
+                    onEditingFinished: columns = parseInt(editorText)
+                    validator: integerValidator
+                }
+                LabeledTextField {
+                    id: columnWidthField
+                    anchors.top: columnsField.top
+                    anchors.left: columnsField.right
+                    labelText: "Column width:"
+                    editorText: column_width
+                    onEditingFinished: column_width = parseFloat(editorText)
+                    validator: numberValidator
+                }
+
+                LabeledTextField {
+                    id: firstIdField
+                    anchors.top: columnWidthField.bottom
+                    anchors.right: columnsField.right
+                    labelText: "First ID:"
+                    editorText: first_id
+                    onEditingFinished: first_id = parseInt(editorText)
+                    validator: integerValidator
+                }
+                */
         }
     }
 

--- a/resources/Qtmodels/PixelControls.qml
+++ b/resources/Qtmodels/PixelControls.qml
@@ -100,26 +100,46 @@ Item {
                     text: "Row: "
                 }
                 TextField {
+                    id: rowsField
+                    text: rows
+                    onEditingFinished: rows = parseInt(text)
+                    validator: integerValidator
                 }
                 Label {
                     text: "Row Height: "
                 }
                 TextField {
+                    id: rowHeightField
+                    text: row_height
+                    onEditingFinished: row_height = parseFloat(editorText)
+                    validator: numberValidator
                 }
                 Label {
                     text: "Columns: "
                 }
                 TextField {
+                    id: columnsField
+                    text: columns
+                    onEditingFinished: columns = parseInt(text)
+                    validator: integerValidator
                 }
                 Label {
                     text: "Column Width: "
                 }
                 TextField {
+                    id: columnWidthField
+                    text: column_width
+                    onEditingFinished: column_width = parseFloat(text)
+                    validator: numberValidator
                 }
                 Label {
                     text: "First ID: "
                 }
                 TextField {
+                    id: firstIdField
+                    text: first_id
+                    onEditingFinished: first_id = parseInt(text)
+                    validator: integerValidator
                 }
                 Item {
                     Layout.fillWidth: true
@@ -163,55 +183,6 @@ Item {
                     onActivated: count_direction = model.get(currentIndex).value
                 }
             }
-            /*
-            LabeledTextField {
-                    id: rowsField
-                    anchors.top: parent.top
-                    anchors.right: columnsField.right
-                    labelText: "Rows:"
-                    editorText: rows
-                    onEditingFinished: rows = parseInt(editorText)
-                    validator: integerValidator
-                }
-                LabeledTextField {
-                    id: rowHeightField
-                    anchors.top: rowsField.top
-                    anchors.right: columnWidthField.right
-                    labelText: "Row height:"
-                    editorText: row_height
-                    onEditingFinished: row_height = parseFloat(editorText)
-                    validator: numberValidator
-                }
-
-                LabeledTextField {
-                    id: columnsField
-                    anchors.top: rowHeightField.bottom
-                    anchors.left: parent.left
-                    labelText: "Columns:"
-                    editorText: columns
-                    onEditingFinished: columns = parseInt(editorText)
-                    validator: integerValidator
-                }
-                LabeledTextField {
-                    id: columnWidthField
-                    anchors.top: columnsField.top
-                    anchors.left: columnsField.right
-                    labelText: "Column width:"
-                    editorText: column_width
-                    onEditingFinished: column_width = parseFloat(editorText)
-                    validator: numberValidator
-                }
-
-                LabeledTextField {
-                    id: firstIdField
-                    anchors.top: columnWidthField.bottom
-                    anchors.right: columnsField.right
-                    labelText: "First ID:"
-                    editorText: first_id
-                    onEditingFinished: first_id = parseInt(editorText)
-                    validator: integerValidator
-                }
-                */
         }
     }
 


### PR DESCRIPTION
### Issue

Closes #251 

### Description of work

Adds the items in the pixel grid pane to a 'GridLayout'.

### Acceptance Criteria 

Add a mesh and select the repeatable grid option. Check that everything looks OK.

### UI tests

No intentional changes to UI behavior.

### Nominate for Group Code Review

- [ ] Nominate for code review 
