### PR TITLE
250: Layout for pane in PixelControls

### DIFF
--- a/resources/Qtmodels/GeometryControls.qml
+++ b/resources/Qtmodels/GeometryControls.qml
@@ -194,7 +194,7 @@ Pane {
                 contentHeight: cylinderFieldGrid.implicitHeight
 
                 GridLayout {
-                    id: cylinderFieldsGrid
+                    id: cylinderFieldGrid
                     columns: 7
                     rows: 3
 

--- a/resources/Qtmodels/PixelControls.qml
+++ b/resources/Qtmodels/PixelControls.qml
@@ -10,47 +10,49 @@ Item {
     id: pane
     implicitHeight: pixelLabel.height + viewFrame.implicitHeight
     width: viewFrame.width
-    implicitWidth: viewFrame.implicitWidth
-
+    implicitWidth: pixelColumn.implicitWidth
+    Layout.minimumWidth: pixelColumn.implicitWidth
     signal layoutChanged()
 
     function restartMapping(geometryModel){
         onGeometryModelChanged: mappingModel.restart_mapping(geometryModel)
     }
 
-    Label {
-        id: pixelLabel
-        anchors.top: parent.top
-        anchors.left: parent.left
-        height: 0
-    }
-
-    Frame {
-        id: viewFrame
-        anchors.top: pixelLabel.bottom
-        anchors.left: parent.left
+    ColumnLayout {
+        id: pixelColumn
         anchors.right: parent.right
-        contentHeight: view.height
-        contentWidth: view.implicitWidth
-        padding: 1
+        anchors.left: parent.left
 
-        ListView {
-            id: view
-            anchors.left: parent.left
-            height: contentHeight
-            width: parent.width
-            interactive: false
-            clip: true
-            ScrollBar.vertical: bar
-            boundsBehavior: Flickable.StopAtBounds
+        Label {
+            id: pixelLabel
+            height: 0
         }
 
-        ActiveScrollBar {
-            id: bar
-            anchors {
-                left: view.right
-                top: view.top
-                bottom: view.bottom
+        Frame {
+            id: viewFrame
+            contentHeight: view.height
+            contentWidth: view.implicitWidth
+            padding: 1
+            Layout.fillWidth: true
+
+            ListView {
+                id: view
+                anchors.left: parent.left
+                height: contentHeight
+                width: parent.width
+                interactive: false
+                clip: true
+                ScrollBar.vertical: bar
+                boundsBehavior: Flickable.StopAtBounds
+            }
+
+            ActiveScrollBar {
+                id: bar
+                anchors {
+                    left: view.right
+                    top: view.top
+                    bottom: view.bottom
+                }
             }
         }
     }


### PR DESCRIPTION
### Issue

Closes #250 

### Description of work

Adds a layout to the pixel pane in the Add Component window. Also fixed a typo Geometry Controls that accidentally found its way to master.

### Acceptance Criteria 

Add geometries with pixel types single ID, repeatable grid, and face-mapped mesh. Check that it looks OK in the Add Component window and the Full Editor window (opened from the LHS pane).

### UI tests

n/a

### Nominate for Group Code Review

- [ ] Nominate for code review 
