### PR TITLE
250: Fixing PixelControls

### DIFF
--- a/resources/Qtmodels/PixelControls.qml
+++ b/resources/Qtmodels/PixelControls.qml
@@ -8,7 +8,7 @@ Item {
     property var pixelModel
 
     id: pane
-    implicitHeight: pixelLabel.height + viewFrame.implicitHeight
+    implicitHeight: pixelColumn.implicitHeight
     width: viewFrame.width
     implicitWidth: pixelColumn.implicitWidth
     Layout.minimumWidth: pixelColumn.implicitWidth


### PR DESCRIPTION
### Issue

Closes #250 (again)

### Description of work

I just noticed that the `pane` in PixelControls was still using addition despite the presence of a layout so I fixed that.

### Acceptance Criteria 

Same as before: add meshes and select the single ID, face-mapped mesh, and repeatable grid options. Check that it all works the same.

### UI tests

n/a

### Nominate for Group Code Review

- [ ] Nominate for code review 
