### PR TITLE
243: Layout for extendedText in ComponentControls

### DIFF
--- a/resources/Qtmodels/ComponentControls.qml
+++ b/resources/Qtmodels/ComponentControls.qml
@@ -133,14 +133,10 @@ Pane {
                 Item {
                     anchors.left: parent.left
                     anchors.right: parent.right
-                    height: extendedGrid.height
-                    implicitWidth: Math.max(nameField.implicitWidth,
-                                            transformControls.implicitWidth,
-                                            editorButton.implicitWidth + deleteButton.implicitWidth)
-                    id: extendedText
 
                     ColumnLayout {
-                        id: extendedGrid
+                        id: extendedText
+                        implicitWidth: transformControls.implicitWidth
 
                         RowLayout {
                             Label {

--- a/resources/Qtmodels/ComponentControls.qml
+++ b/resources/Qtmodels/ComponentControls.qml
@@ -94,121 +94,131 @@ Pane {
             MouseArea {
                 id: expansionClickArea
                 anchors.fill: parent
-                onClicked: componentBox.state = (componentBox.state == "Extended") ? "": "Extended"
+                onClicked: {
+                    componentDetailsStack.currentIndex = !componentDetailsStack.currentIndex
+
+                    if (componentDetailsStack.currentIndex)
+                        componentBox.contentHeight = extendedContent.implicitHeight
+                    else
+                        componentBox.contentHeight = shortenedContent.implicitHeight
+                }
             }
 
-            RowLayout {
-                id: shortenedContent
-                anchors.fill: parent
-
-                Label {
-                    id: mainNameLabel
-                    text: "Name:" + name
-                }
-                Item {
-                    Layout.fillWidth: true
-                }
-                Image {
-                    id: expansionCaret
-                    Layout.preferredWidth: 20
-                    Layout.preferredHeight: 20
-                    source: "file:resources/images/caret.svg"
-                    transformOrigin: Item.Center
-                    rotation: 0
-                }
-            }
-            ColumnLayout {
-                id: extendedContent
-                implicitWidth: transformControls.implicitWidth
-                anchors.left: parent.left
+            StackLayout {
+                id: componentDetailsStack
+                currentIndex: 0
                 anchors.right: parent.right
-                visible: false
-                // height: 0
+                anchors.left: parent.left
 
                 RowLayout {
+                    id: shortenedContent
+                    Layout.fillWidth: true
+
                     Label {
-                        text: "Name: "
-                    }
-                    TextField {
-                        id: nameField
-                        text: name
-                        onEditingFinished: name = text
-                        validator: NameValidator {
-                            model: components
-                            myindex: index
-                            onValidationFailed: {
-                                nameField.ToolTip.show(ErrorMessages.repeatedComponentName, 3000)
-                            }
-                        }
-                        Layout.fillWidth: true
-                    }
-                    Image {
-                        id: expansionCaret2
-                        Layout.preferredWidth: 20
-                        Layout.preferredHeight: 20
-                        source: "file:resources/images/caret.svg"
-                        transformOrigin: Item.Center
-                        rotation: 180
-                    }
-                }
-                TransformControls {
-                    id: transformControls
-                    transformModel: transform_model
-                    componentIndex: index
-                }
-                Connections {
-                    target: transform_model
-                    onTransformsUpdated: components.transforms_updated(index)
-                }
-                states: State {
-                    name: "hidden"; when: index == 0
-                    PropertyChanges { target: transformControls; height: 0 }
-                    PropertyChanges { target: transformControls; visible: false }
-                }
-
-                RowLayout {
-                    PaddedButton {
-                        id: editorButton
-                        text: "Full editor"
-                        onClicked: {
-                            if (editorLoader.source == ""){
-                                editorLoader.source = "EditComponentWindow.qml"
-                                editorLoader.item.componentIndex = index
-                                window.positionChildWindow(editorLoader.item)
-                                editorLoader.item.show()
-                            } else {
-                                editorLoader.item.requestActivate()
-                            }
-                        }
-                    }
-                    Loader {
-                        id: editorLoader
-                        Connections {
-                            target: editorLoader.item
-                            onClosing: editorLoader.source = ""
-                        }
-                        Connections {
-                            target: window
-                            onClosing: editorLoader.source = ""
-                        }
+                        id: mainNameLabel
+                        text: "Name:" + name
                     }
                     Item {
                         Layout.fillWidth: true
                     }
-                    PaddedButton {
-                        id: deleteButton
-                        text: "Delete"
-                        onClicked: components.remove_component(index)
-                        buttonEnabled: removable
-                        // The sample (at index 0) should never be removed. Don't even show it as an option.
-                        visible: index != 0
-                        ToolTip.visible: hovered & !removable
-                        ToolTip.delay: 400
-                        ToolTip.text: "Cannot remove a component that's in use as a transform parent"
+                    Image {
+                        id: expansionCaret
+                        Layout.preferredWidth: 20
+                        Layout.preferredHeight: 20
+                        source: "file:resources/images/caret.svg"
+                        transformOrigin: Item.Center
+                        rotation: 0
+                    }
+                }
+                ColumnLayout {
+                    id: extendedContent
+                    implicitWidth: transformControls.implicitWidth
+                    Layout.fillWidth: true
+
+                    RowLayout {
+                        Label {
+                            text: "Name: "
+                        }
+                        TextField {
+                            id: nameField
+                            text: name
+                            onEditingFinished: name = text
+                            validator: NameValidator {
+                                model: components
+                                myindex: index
+                                onValidationFailed: {
+                                    nameField.ToolTip.show(ErrorMessages.repeatedComponentName, 3000)
+                                }
+                            }
+                            Layout.fillWidth: true
+                        }
+                        Image {
+                            id: expansionCaret2
+                            Layout.preferredWidth: 20
+                            Layout.preferredHeight: 20
+                            source: "file:resources/images/caret.svg"
+                            transformOrigin: Item.Center
+                            rotation: 180
+                        }
+                    }
+                    TransformControls {
+                        id: transformControls
+                        transformModel: transform_model
+                        componentIndex: index
+                    }
+                    Connections {
+                        target: transform_model
+                        onTransformsUpdated: components.transforms_updated(index)
+                    }
+                    states: State {
+                        name: "hidden"; when: index == 0
+                        PropertyChanges { target: transformControls; height: 0 }
+                        PropertyChanges { target: transformControls; visible: false }
+                    }
+
+                    RowLayout {
+                        PaddedButton {
+                            id: editorButton
+                            text: "Full editor"
+                            onClicked: {
+                                if (editorLoader.source == ""){
+                                    editorLoader.source = "EditComponentWindow.qml"
+                                    editorLoader.item.componentIndex = index
+                                    window.positionChildWindow(editorLoader.item)
+                                    editorLoader.item.show()
+                                } else {
+                                    editorLoader.item.requestActivate()
+                                }
+                            }
+                        }
+                        Loader {
+                            id: editorLoader
+                            Connections {
+                                target: editorLoader.item
+                                onClosing: editorLoader.source = ""
+                            }
+                            Connections {
+                                target: window
+                                onClosing: editorLoader.source = ""
+                            }
+                        }
+                        Item {
+                            Layout.fillWidth: true
+                        }
+                        PaddedButton {
+                            id: deleteButton
+                            text: "Delete"
+                            onClicked: components.remove_component(index)
+                            buttonEnabled: removable
+                            // The sample (at index 0) should never be removed. Don't even show it as an option.
+                            visible: index != 0
+                            ToolTip.visible: hovered & !removable
+                            ToolTip.delay: 400
+                            ToolTip.text: "Cannot remove a component that's in use as a transform parent"
+                        }
                     }
                 }
             }
-
             states: State {
                 name: "Extended"
 

--- a/resources/Qtmodels/ComponentControls.qml
+++ b/resources/Qtmodels/ComponentControls.qml
@@ -81,7 +81,7 @@ Pane {
         Frame {
             id: componentBox
             padding: 5
-            contentHeight: expansionCaret.height
+            contentHeight: nameField.height
             contentWidth: extendedContent.implicitWidth
             width: componentListView.width
 
@@ -103,18 +103,15 @@ Pane {
 
                 Label {
                     id: mainNameLabel
-                    text: "Name:" + name
+                    text: "Name: " + name
                 }
                 Item {
                     Layout.fillWidth: true
                 }
                 Image {
-                    id: expansionCaret
                     Layout.preferredWidth: 20
                     Layout.preferredHeight: 20
                     source: "file:resources/images/caret.svg"
-                    transformOrigin: Item.Center
-                    rotation: 0
                 }
             }
             ColumnLayout {
@@ -123,7 +120,6 @@ Pane {
                 anchors.left: parent.left
                 anchors.right: parent.right
                 visible: false
-                // height: 0
 
                 RowLayout {
                     Label {
@@ -143,7 +139,6 @@ Pane {
                         Layout.fillWidth: true
                     }
                     Image {
-                        id: expansionCaret2
                         Layout.preferredWidth: 20
                         Layout.preferredHeight: 20
                         source: "file:resources/images/caret.svg"
@@ -215,13 +210,9 @@ Pane {
                 PropertyChanges { target: shortenedContent; height: 0 }
                 PropertyChanges { target: shortenedContent; visible: false }
 
-                // PropertyChanges { target: extendedContent; height: extendedCon.height }
                 PropertyChanges { target: extendedContent; visible: true }
 
                 PropertyChanges { target: componentBox; contentHeight: extendedContent.height}
-
-                // PropertyChanges { target: expansionCaret; rotation: 180 }
-                PropertyChanges { target: expansionCaret; visible: false }
             }
         }
     }

--- a/resources/Qtmodels/ComponentControls.qml
+++ b/resources/Qtmodels/ComponentControls.qml
@@ -133,7 +133,7 @@ Pane {
                 Item {
                     anchors.left: parent.left
                     anchors.right: parent.right
-                    height: nameField.height + transformControls.height + editorButton.height
+                    height: extendedGrid.height
                     implicitWidth: Math.max(nameField.implicitWidth,
                                             transformControls.implicitWidth,
                                             editorButton.implicitWidth + deleteButton.implicitWidth)

--- a/resources/Qtmodels/ComponentControls.qml
+++ b/resources/Qtmodels/ComponentControls.qml
@@ -7,6 +7,7 @@ Pane {
 
     contentWidth: componentControlsColumn.implicitWidth
     contentHeight: componentControlsColumn.implicitHeight
+    property var expansionCaretSize: 20
 
     ColumnLayout {
         id: componentControlsColumn
@@ -109,8 +110,8 @@ Pane {
                     Layout.fillWidth: true
                 }
                 Image {
-                    Layout.preferredWidth: 20
-                    Layout.preferredHeight: 20
+                    Layout.preferredWidth: expansionCaretSize
+                    Layout.preferredHeight: expansionCaretSize
                     source: "file:resources/images/caret.svg"
                 }
             }
@@ -139,8 +140,8 @@ Pane {
                         Layout.fillWidth: true
                     }
                     Image {
-                        Layout.preferredWidth: 20
-                        Layout.preferredHeight: 20
+                        Layout.preferredWidth: expansionCaretSize
+                        Layout.preferredHeight: expansionCaretSize
                         source: "file:resources/images/caret.svg"
                         transformOrigin: Item.Center
                         rotation: 180

--- a/resources/Qtmodels/ComponentControls.qml
+++ b/resources/Qtmodels/ComponentControls.qml
@@ -94,132 +94,134 @@ Pane {
             MouseArea {
                 id: expansionClickArea
                 anchors.fill: parent
-                onClicked: {
-                    componentDetailsStack.currentIndex = !componentDetailsStack.currentIndex
-
-                    if (componentDetailsStack.currentIndex)
-                        componentBox.contentHeight = extendedContent.height
-                    else
-                        componentBox.contentHeight = shortenedContent.height
-                }
+                onClicked: componentBox.state = (componentBox.state == "Extended") ? "": "Extended"
             }
 
-            StackLayout {
-                id: componentDetailsStack
-                currentIndex: 0
+            RowLayout {
+                id: shortenedContent
                 anchors.fill: parent
 
-                RowLayout {
-                    id: shortenedContent
+                Label {
+                    id: mainNameLabel
+                    text: "Name:" + name
+                }
+                Item {
                     Layout.fillWidth: true
+                }
+                Image {
+                    id: expansionCaret
+                    Layout.preferredWidth: 20
+                    Layout.preferredHeight: 20
+                    source: "file:resources/images/caret.svg"
+                    transformOrigin: Item.Center
+                    rotation: 0
+                }
+            }
+            ColumnLayout {
+                id: extendedContent
+                implicitWidth: transformControls.implicitWidth
+                anchors.left: parent.left
+                anchors.right: parent.right
+                visible: false
+                // height: 0
 
+                RowLayout {
                     Label {
-                        id: mainNameLabel
-                        text: "Name:" + name
+                        text: "Name: "
                     }
-                    Item {
+                    TextField {
+                        id: nameField
+                        text: name
+                        onEditingFinished: name = text
+                        validator: NameValidator {
+                            model: components
+                            myindex: index
+                            onValidationFailed: {
+                                nameField.ToolTip.show(ErrorMessages.repeatedComponentName, 3000)
+                            }
+                        }
                         Layout.fillWidth: true
                     }
                     Image {
-                        id: expansionCaret
+                        id: expansionCaret2
                         Layout.preferredWidth: 20
                         Layout.preferredHeight: 20
                         source: "file:resources/images/caret.svg"
                         transformOrigin: Item.Center
-                        rotation: 0
+                        rotation: 180
                     }
                 }
-                ColumnLayout {
-                    id: extendedContent
-                    implicitWidth: transformControls.implicitWidth
-                    Layout.fillWidth: true
+                TransformControls {
+                    id: transformControls
+                    transformModel: transform_model
+                    componentIndex: index
+                }
+                Connections {
+                    target: transform_model
+                    onTransformsUpdated: components.transforms_updated(index)
+                }
+                states: State {
+                    name: "hidden"; when: index == 0
+                    PropertyChanges { target: transformControls; height: 0 }
+                    PropertyChanges { target: transformControls; visible: false }
+                }
 
-                    RowLayout {
-                        Label {
-                            text: "Name: "
-                        }
-                        TextField {
-                            id: nameField
-                            text: name
-                            onEditingFinished: name = text
-                            validator: NameValidator {
-                                model: components
-                                myindex: index
-                                onValidationFailed: {
-                                    nameField.ToolTip.show(ErrorMessages.repeatedComponentName, 3000)
-                                }
-                            }
-                            Layout.fillWidth: true
-                        }
-                        Image {
-                            id: expansionCaret2
-                            Layout.preferredWidth: 20
-                            Layout.preferredHeight: 20
-                            source: "file:resources/images/caret.svg"
-                            transformOrigin: Item.Center
-                            rotation: 180
-                        }
-                    }
-                    TransformControls {
-                        id: transformControls
-                        transformModel: transform_model
-                        componentIndex: index
-                    }
-                    Connections {
-                        target: transform_model
-                        onTransformsUpdated: {
-                            components.transforms_updated(index)
-                            componentBox.contentHeight = extendedContent.height
-                        }
-                    }
-                    states: State {
-                        name: "hidden"; when: index == 0
-                        PropertyChanges { target: transformControls; height: 0 }
-                        PropertyChanges { target: transformControls; visible: false }
-                    }
-
-                    RowLayout {
-                        PaddedButton {
-                            id: editorButton
-                            text: "Full editor"
-                            onClicked: {
-                                if (editorLoader.source == ""){
-                                    editorLoader.source = "EditComponentWindow.qml"
-                                    editorLoader.item.componentIndex = index
-                                    window.positionChildWindow(editorLoader.item)
-                                    editorLoader.item.show()
-                                } else {
-                                    editorLoader.item.requestActivate()
-                                }
+                RowLayout {
+                    PaddedButton {
+                        id: editorButton
+                        text: "Full editor"
+                        onClicked: {
+                            if (editorLoader.source == ""){
+                                editorLoader.source = "EditComponentWindow.qml"
+                                editorLoader.item.componentIndex = index
+                                window.positionChildWindow(editorLoader.item)
+                                editorLoader.item.show()
+                            } else {
+                                editorLoader.item.requestActivate()
                             }
                         }
-                        Loader {
-                            id: editorLoader
-                            Connections {
-                                target: editorLoader.item
-                                onClosing: editorLoader.source = ""
-                            }
-                            Connections {
-                                target: window
-                                onClosing: editorLoader.source = ""
-                            }
+                    }
+                    Loader {
+                        id: editorLoader
+                        Connections {
+                            target: editorLoader.item
+                            onClosing: editorLoader.source = ""
                         }
-                        Item {
-                            Layout.fillWidth: true
+                        Connections {
+                            target: window
+                            onClosing: editorLoader.source = ""
                         }
-                        PaddedButton {
-                            id: deleteButton
-                            text: "Delete"
-                            onClicked: components.remove_component(index)
-                            buttonEnabled: removable
-                            // The sample (at index 0) should never be removed. Don't even show it as an option.
-                            visible: index != 0
-                            ToolTip.visible: hovered & !removable
-                            ToolTip.delay: 400
-                            ToolTip.text: "Cannot remove a component that's in use as a transform parent"
-                        }
+                    }
+                    Item {
+                        Layout.fillWidth: true
+                    }
+                    PaddedButton {
+                        id: deleteButton
+                        text: "Delete"
+                        onClicked: components.remove_component(index)
+                        buttonEnabled: removable
+                        // The sample (at index 0) should never be removed. Don't even show it as an option.
+                        visible: index != 0
+                        ToolTip.visible: hovered & !removable
+                        ToolTip.delay: 400
+                        ToolTip.text: "Cannot remove a component that's in use as a transform parent"
                     }
                 }
+            }
+
+            states: State {
+                name: "Extended"
+
+                PropertyChanges { target: shortenedContent; height: 0 }
+                PropertyChanges { target: shortenedContent; visible: false }
+
+                // PropertyChanges { target: extendedContent; height: extendedCon.height }
+                PropertyChanges { target: extendedContent; visible: true }
+
+                PropertyChanges { target: componentBox; contentHeight: extendedContent.height}
+
+                // PropertyChanges { target: expansionCaret; rotation: 180 }
+                PropertyChanges { target: expansionCaret; visible: false }
             }
         }
     }

--- a/resources/Qtmodels/ComponentControls.qml
+++ b/resources/Qtmodels/ComponentControls.qml
@@ -139,78 +139,91 @@ Pane {
                                             editorButton.implicitWidth + deleteButton.implicitWidth)
                     id: extendedText
 
-                    LabeledTextField {
-                        id: nameField
-                        labelText: "Name:"
-                        editorWidth: 200
-                        editorText: name
-                        onEditingFinished: name = editorText
-                        validator: NameValidator {
-                            model: components
-                            myindex: index
-                            onValidationFailed: {
-                                nameField.ToolTip.show(ErrorMessages.repeatedComponentName, 3000)
+                    ColumnLayout {
+                        id: extendedGrid
+
+                        RowLayout {
+                            Label {
+                                text: "Name: "
+                            }
+                            TextField {
+                                id: nameField
+                                text: name
+                                onEditingFinished: name = text
+                                validator: NameValidator {
+                                    model: components
+                                    myindex: index
+                                    onValidationFailed: {
+                                        nameField.ToolTip.show(ErrorMessages.repeatedComponentName, 3000)
+                                    }
+                                }
+                                Layout.fillWidth: true
+                            }
+                            Image {
+                                id: expansionCaret2
+                                Layout.preferredWidth: 20
+                                Layout.preferredHeight: 20
+                                source: "file:resources/images/caret.svg"
+                                transformOrigin: Item.Center
+                                rotation: 180
                             }
                         }
-                    }
+                        TransformControls {
+                            id: transformControls
+                            transformModel: transform_model
+                            componentIndex: index
+                        }
+                        Connections {
+                            target: transform_model
+                            onTransformsUpdated: components.transforms_updated(index)
+                        }
+                        states: State {
+                            name: "hidden"; when: index == 0
+                            PropertyChanges { target: transformControls; height: 0 }
+                            PropertyChanges { target: transformControls; visible: false }
+                        }
 
-                    TransformControls {
-                        id: transformControls
-                        transformModel: transform_model
-                        componentIndex: index
-                        anchors.top: nameField.bottom
-                        anchors.left: parent.left
-                        anchors.right: parent.right
-                    }
-                    Connections {
-                        target: transform_model
-                        onTransformsUpdated: components.transforms_updated(index)
-                    }
-                    states: State {
-                        name: "hidden"; when: index == 0
-                        PropertyChanges { target: transformControls; height: 0 }
-                        PropertyChanges { target: transformControls; visible: false }
-                    }
-
-                    PaddedButton {
-                        id: editorButton
-                        anchors.top: transformControls.bottom
-                        anchors.left: parent.left
-                        text: "Full editor"
-                        onClicked: {
-                            if (editorLoader.source == ""){
-                                editorLoader.source = "EditComponentWindow.qml"
-                                editorLoader.item.componentIndex = index
-                                window.positionChildWindow(editorLoader.item)
-                                editorLoader.item.show()
-                            } else {
-                                editorLoader.item.requestActivate()
+                        RowLayout {
+                            PaddedButton {
+                                id: editorButton
+                                text: "Full editor"
+                                onClicked: {
+                                    if (editorLoader.source == ""){
+                                        editorLoader.source = "EditComponentWindow.qml"
+                                        editorLoader.item.componentIndex = index
+                                        window.positionChildWindow(editorLoader.item)
+                                        editorLoader.item.show()
+                                    } else {
+                                        editorLoader.item.requestActivate()
+                                    }
+                                }
+                            }
+                            Loader {
+                                id: editorLoader
+                                Connections {
+                                    target: editorLoader.item
+                                    onClosing: editorLoader.source = ""
+                                }
+                                Connections {
+                                    target: window
+                                    onClosing: editorLoader.source = ""
+                                }
+                            }
+                            Item {
+                                Layout.fillWidth: true
+                            }
+                            PaddedButton {
+                                id: deleteButton
+                                text: "Delete"
+                                onClicked: components.remove_component(index)
+                                buttonEnabled: removable
+                                // The sample (at index 0) should never be removed. Don't even show it as an option.
+                                visible: index != 0
+                                ToolTip.visible: hovered & !removable
+                                ToolTip.delay: 400
+                                ToolTip.text: "Cannot remove a component that's in use as a transform parent"
                             }
                         }
-                    }
-                    Loader {
-                        id: editorLoader
-                        Connections {
-                            target: editorLoader.item
-                            onClosing: editorLoader.source = ""
-                        }
-                        Connections {
-                            target: window
-                            onClosing: editorLoader.source = ""
-                        }
-                    }
-                    PaddedButton {
-                        id: deleteButton
-                        anchors.top: editorButton.top
-                        anchors.right: parent.right
-                        text: "Delete"
-                        onClicked: components.remove_component(index)
-                        buttonEnabled: removable
-                        // The sample (at index 0) should never be removed. Don't even show it as an option.
-                        visible: index != 0
-                        ToolTip.visible: hovered & !removable
-                        ToolTip.delay: 400
-                        ToolTip.text: "Cannot remove a component that's in use as a transform parent"
                     }
                 }
             }
@@ -226,7 +239,8 @@ Pane {
 
                 PropertyChanges { target: componentBox; contentHeight: extendedContent.height}
 
-                PropertyChanges { target: expansionCaret; rotation: 180 }
+                // PropertyChanges { target: expansionCaret; rotation: 180 }
+                PropertyChanges { target: expansionCaret; visible: false }
             }
         }
     }

--- a/resources/Qtmodels/ComponentControls.qml
+++ b/resources/Qtmodels/ComponentControls.qml
@@ -81,7 +81,7 @@ Pane {
         Frame {
             id: componentBox
             padding: 5
-            contentHeight: Math.max(mainContent.height, expansionCaret.height)
+            contentHeight: expansionCaret.height
             contentWidth: extendedContent.implicitWidth
             width: componentListView.width
 
@@ -97,35 +97,29 @@ Pane {
                 onClicked: componentBox.state = (componentBox.state == "Extended") ? "": "Extended"
             }
 
-            Image {
-                id: expansionCaret
-                width: 20; height: 20;
-                anchors.right: parent.right
-                anchors.top: parent.top
-                source: "file:resources/images/caret.svg"
-                transformOrigin: Item.Center
-                rotation: 0
-            }
+            RowLayout {
+                id: shortenedContent
+                anchors.fill: parent
 
-            Item {
-                id: mainContent
-                anchors.left: parent.left
-                anchors.right: parent.right
-                height: mainNameLabel.height
-                implicitWidth: mainNameLabel.width + expansionCaret.width
-                visible: true
                 Label {
                     id: mainNameLabel
-                    anchors.left: parent.left
-                    anchors.top: parent.top
                     text: "Name:" + name
                 }
+                Item {
+                    Layout.fillWidth: true
+                }
+                Image {
+                    id: expansionCaret
+                    Layout.preferredWidth: 20
+                    Layout.preferredHeight: 20
+                    source: "file:resources/images/caret.svg"
+                    transformOrigin: Item.Center
+                    rotation: 0
+                }
             }
-
             ColumnLayout {
                 id: extendedContent
                 implicitWidth: transformControls.implicitWidth
-                anchors.top: mainContent.bottom
                 anchors.left: parent.left
                 anchors.right: parent.right
                 visible: false
@@ -218,8 +212,8 @@ Pane {
             states: State {
                 name: "Extended"
 
-                PropertyChanges { target: mainContent; height: 0 }
-                PropertyChanges { target: mainContent; visible: false }
+                PropertyChanges { target: shortenedContent; height: 0 }
+                PropertyChanges { target: shortenedContent; visible: false }
 
                 // PropertyChanges { target: extendedContent; height: extendedCon.height }
                 PropertyChanges { target: extendedContent; visible: true }

--- a/resources/Qtmodels/ComponentControls.qml
+++ b/resources/Qtmodels/ComponentControls.qml
@@ -107,8 +107,7 @@ Pane {
             StackLayout {
                 id: componentDetailsStack
                 currentIndex: 0
-                anchors.right: parent.right
-                anchors.left: parent.left
+                anchors.fill: parent
 
                 RowLayout {
                     id: shortenedContent
@@ -218,20 +217,6 @@ Pane {
                         }
                     }
                 }
-            }
-            states: State {
-                name: "Extended"
-
-                PropertyChanges { target: shortenedContent; height: 0 }
-                PropertyChanges { target: shortenedContent; visible: false }
-
-                // PropertyChanges { target: extendedContent; height: extendedCon.height }
-                PropertyChanges { target: extendedContent; visible: true }
-
-                PropertyChanges { target: componentBox; contentHeight: extendedContent.height}
-
-                // PropertyChanges { target: expansionCaret; rotation: 180 }
-                PropertyChanges { target: expansionCaret; visible: false }
             }
         }
     }

--- a/resources/Qtmodels/ComponentControls.qml
+++ b/resources/Qtmodels/ComponentControls.qml
@@ -98,9 +98,9 @@ Pane {
                     componentDetailsStack.currentIndex = !componentDetailsStack.currentIndex
 
                     if (componentDetailsStack.currentIndex)
-                        componentBox.contentHeight = extendedContent.implicitHeight
+                        componentBox.contentHeight = extendedContent.height
                     else
-                        componentBox.contentHeight = shortenedContent.implicitHeight
+                        componentBox.contentHeight = shortenedContent.height
                 }
             }
 
@@ -167,7 +167,10 @@ Pane {
                     }
                     Connections {
                         target: transform_model
-                        onTransformsUpdated: components.transforms_updated(index)
+                        onTransformsUpdated: {
+                            components.transforms_updated(index)
+                            componentBox.contentHeight = extendedContent.height
+                        }
                     }
                     states: State {
                         name: "hidden"; when: index == 0

--- a/resources/Qtmodels/ComponentControls.qml
+++ b/resources/Qtmodels/ComponentControls.qml
@@ -82,7 +82,7 @@ Pane {
             id: componentBox
             padding: 5
             contentHeight: Math.max(mainContent.height, expansionCaret.height)
-            contentWidth: Math.max(mainContent.implicitWidth, extendedContent.implicitWidth)
+            contentWidth: extendedContent.implicitWidth
             width: componentListView.width
 
             onImplicitWidthChanged: {
@@ -130,95 +130,90 @@ Pane {
                 height: 0
                 implicitWidth: extendedText.implicitWidth
                 visible: false
-                Item {
-                    anchors.left: parent.left
-                    anchors.right: parent.right
+                ColumnLayout {
+                    id: extendedText
+                    implicitWidth: transformControls.implicitWidth
 
-                    ColumnLayout {
-                        id: extendedText
-                        implicitWidth: transformControls.implicitWidth
+                    RowLayout {
+                        Label {
+                            text: "Name: "
+                        }
+                        TextField {
+                            id: nameField
+                            text: name
+                            onEditingFinished: name = text
+                            validator: NameValidator {
+                                model: components
+                                myindex: index
+                                onValidationFailed: {
+                                    nameField.ToolTip.show(ErrorMessages.repeatedComponentName, 3000)
+                                }
+                            }
+                            Layout.fillWidth: true
+                        }
+                        Image {
+                            id: expansionCaret2
+                            Layout.preferredWidth: 20
+                            Layout.preferredHeight: 20
+                            source: "file:resources/images/caret.svg"
+                            transformOrigin: Item.Center
+                            rotation: 180
+                        }
+                    }
+                    TransformControls {
+                        id: transformControls
+                        transformModel: transform_model
+                        componentIndex: index
+                    }
+                    Connections {
+                        target: transform_model
+                        onTransformsUpdated: components.transforms_updated(index)
+                    }
+                    states: State {
+                        name: "hidden"; when: index == 0
+                        PropertyChanges { target: transformControls; height: 0 }
+                        PropertyChanges { target: transformControls; visible: false }
+                    }
 
-                        RowLayout {
-                            Label {
-                                text: "Name: "
-                            }
-                            TextField {
-                                id: nameField
-                                text: name
-                                onEditingFinished: name = text
-                                validator: NameValidator {
-                                    model: components
-                                    myindex: index
-                                    onValidationFailed: {
-                                        nameField.ToolTip.show(ErrorMessages.repeatedComponentName, 3000)
-                                    }
-                                }
-                                Layout.fillWidth: true
-                            }
-                            Image {
-                                id: expansionCaret2
-                                Layout.preferredWidth: 20
-                                Layout.preferredHeight: 20
-                                source: "file:resources/images/caret.svg"
-                                transformOrigin: Item.Center
-                                rotation: 180
-                            }
-                        }
-                        TransformControls {
-                            id: transformControls
-                            transformModel: transform_model
-                            componentIndex: index
-                        }
-                        Connections {
-                            target: transform_model
-                            onTransformsUpdated: components.transforms_updated(index)
-                        }
-                        states: State {
-                            name: "hidden"; when: index == 0
-                            PropertyChanges { target: transformControls; height: 0 }
-                            PropertyChanges { target: transformControls; visible: false }
-                        }
-
-                        RowLayout {
-                            PaddedButton {
-                                id: editorButton
-                                text: "Full editor"
-                                onClicked: {
-                                    if (editorLoader.source == ""){
-                                        editorLoader.source = "EditComponentWindow.qml"
-                                        editorLoader.item.componentIndex = index
-                                        window.positionChildWindow(editorLoader.item)
-                                        editorLoader.item.show()
-                                    } else {
-                                        editorLoader.item.requestActivate()
-                                    }
+                    RowLayout {
+                        PaddedButton {
+                            id: editorButton
+                            text: "Full editor"
+                            onClicked: {
+                                if (editorLoader.source == ""){
+                                    editorLoader.source = "EditComponentWindow.qml"
+                                    editorLoader.item.componentIndex = index
+                                    window.positionChildWindow(editorLoader.item)
+                                    editorLoader.item.show()
+                                } else {
+                                    editorLoader.item.requestActivate()
                                 }
                             }
-                            Loader {
-                                id: editorLoader
-                                Connections {
-                                    target: editorLoader.item
-                                    onClosing: editorLoader.source = ""
-                                }
-                                Connections {
-                                    target: window
-                                    onClosing: editorLoader.source = ""
-                                }
+                        }
+                        Loader {
+                            id: editorLoader
+                            Connections {
+                                target: editorLoader.item
+                                onClosing: editorLoader.source = ""
                             }
-                            Item {
-                                Layout.fillWidth: true
+                            Connections {
+                                target: window
+                                onClosing: editorLoader.source = ""
                             }
-                            PaddedButton {
-                                id: deleteButton
-                                text: "Delete"
-                                onClicked: components.remove_component(index)
-                                buttonEnabled: removable
-                                // The sample (at index 0) should never be removed. Don't even show it as an option.
-                                visible: index != 0
-                                ToolTip.visible: hovered & !removable
-                                ToolTip.delay: 400
-                                ToolTip.text: "Cannot remove a component that's in use as a transform parent"
-                            }
+                        }
+                        Item {
+                            Layout.fillWidth: true
+                        }
+                        PaddedButton {
+                            id: deleteButton
+                            text: "Delete"
+                            onClicked: components.remove_component(index)
+                            buttonEnabled: removable
+                            // The sample (at index 0) should never be removed. Don't even show it as an option.
+                            visible: index != 0
+                            ToolTip.visible: hovered & !removable
+                            ToolTip.delay: 400
+                            ToolTip.text: "Cannot remove a component that's in use as a transform parent"
                         }
                     }
                 }

--- a/resources/Qtmodels/ComponentControls.qml
+++ b/resources/Qtmodels/ComponentControls.qml
@@ -7,7 +7,9 @@ Pane {
 
     contentWidth: componentControlsColumn.implicitWidth
     contentHeight: componentControlsColumn.implicitHeight
+
     property var expansionCaretSize: 20
+    property var expansionCaretLocation: "file:resources/images/caret.svg"
 
     ColumnLayout {
         id: componentControlsColumn
@@ -112,7 +114,7 @@ Pane {
                 Image {
                     Layout.preferredWidth: expansionCaretSize
                     Layout.preferredHeight: expansionCaretSize
-                    source: "file:resources/images/caret.svg"
+                    source: expansionCaretLocation
                 }
             }
             ColumnLayout {
@@ -142,7 +144,7 @@ Pane {
                     Image {
                         Layout.preferredWidth: expansionCaretSize
                         Layout.preferredHeight: expansionCaretSize
-                        source: "file:resources/images/caret.svg"
+                        source: expansionCaretLocation
                         transformOrigin: Item.Center
                         rotation: 180
                     }

--- a/resources/Qtmodels/ComponentControls.qml
+++ b/resources/Qtmodels/ComponentControls.qml
@@ -122,99 +122,95 @@ Pane {
                 }
             }
 
-            Item {
+            ColumnLayout {
                 id: extendedContent
+                implicitWidth: transformControls.implicitWidth
                 anchors.top: mainContent.bottom
                 anchors.left: parent.left
                 anchors.right: parent.right
-                height: 0
-                implicitWidth: extendedText.implicitWidth
                 visible: false
-                ColumnLayout {
-                    id: extendedText
-                    implicitWidth: transformControls.implicitWidth
+                // height: 0
 
-                    RowLayout {
-                        Label {
-                            text: "Name: "
-                        }
-                        TextField {
-                            id: nameField
-                            text: name
-                            onEditingFinished: name = text
-                            validator: NameValidator {
-                                model: components
-                                myindex: index
-                                onValidationFailed: {
-                                    nameField.ToolTip.show(ErrorMessages.repeatedComponentName, 3000)
-                                }
+                RowLayout {
+                    Label {
+                        text: "Name: "
+                    }
+                    TextField {
+                        id: nameField
+                        text: name
+                        onEditingFinished: name = text
+                        validator: NameValidator {
+                            model: components
+                            myindex: index
+                            onValidationFailed: {
+                                nameField.ToolTip.show(ErrorMessages.repeatedComponentName, 3000)
                             }
-                            Layout.fillWidth: true
                         }
-                        Image {
-                            id: expansionCaret2
-                            Layout.preferredWidth: 20
-                            Layout.preferredHeight: 20
-                            source: "file:resources/images/caret.svg"
-                            transformOrigin: Item.Center
-                            rotation: 180
-                        }
+                        Layout.fillWidth: true
                     }
-                    TransformControls {
-                        id: transformControls
-                        transformModel: transform_model
-                        componentIndex: index
+                    Image {
+                        id: expansionCaret2
+                        Layout.preferredWidth: 20
+                        Layout.preferredHeight: 20
+                        source: "file:resources/images/caret.svg"
+                        transformOrigin: Item.Center
+                        rotation: 180
                     }
-                    Connections {
-                        target: transform_model
-                        onTransformsUpdated: components.transforms_updated(index)
-                    }
-                    states: State {
-                        name: "hidden"; when: index == 0
-                        PropertyChanges { target: transformControls; height: 0 }
-                        PropertyChanges { target: transformControls; visible: false }
-                    }
+                }
+                TransformControls {
+                    id: transformControls
+                    transformModel: transform_model
+                    componentIndex: index
+                }
+                Connections {
+                    target: transform_model
+                    onTransformsUpdated: components.transforms_updated(index)
+                }
+                states: State {
+                    name: "hidden"; when: index == 0
+                    PropertyChanges { target: transformControls; height: 0 }
+                    PropertyChanges { target: transformControls; visible: false }
+                }
 
-                    RowLayout {
-                        PaddedButton {
-                            id: editorButton
-                            text: "Full editor"
-                            onClicked: {
-                                if (editorLoader.source == ""){
-                                    editorLoader.source = "EditComponentWindow.qml"
-                                    editorLoader.item.componentIndex = index
-                                    window.positionChildWindow(editorLoader.item)
-                                    editorLoader.item.show()
-                                } else {
-                                    editorLoader.item.requestActivate()
-                                }
+                RowLayout {
+                    PaddedButton {
+                        id: editorButton
+                        text: "Full editor"
+                        onClicked: {
+                            if (editorLoader.source == ""){
+                                editorLoader.source = "EditComponentWindow.qml"
+                                editorLoader.item.componentIndex = index
+                                window.positionChildWindow(editorLoader.item)
+                                editorLoader.item.show()
+                            } else {
+                                editorLoader.item.requestActivate()
                             }
                         }
-                        Loader {
-                            id: editorLoader
-                            Connections {
-                                target: editorLoader.item
-                                onClosing: editorLoader.source = ""
-                            }
-                            Connections {
-                                target: window
-                                onClosing: editorLoader.source = ""
-                            }
+                    }
+                    Loader {
+                        id: editorLoader
+                        Connections {
+                            target: editorLoader.item
+                            onClosing: editorLoader.source = ""
                         }
-                        Item {
-                            Layout.fillWidth: true
+                        Connections {
+                            target: window
+                            onClosing: editorLoader.source = ""
                         }
-                        PaddedButton {
-                            id: deleteButton
-                            text: "Delete"
-                            onClicked: components.remove_component(index)
-                            buttonEnabled: removable
-                            // The sample (at index 0) should never be removed. Don't even show it as an option.
-                            visible: index != 0
-                            ToolTip.visible: hovered & !removable
-                            ToolTip.delay: 400
-                            ToolTip.text: "Cannot remove a component that's in use as a transform parent"
-                        }
+                    }
+                    Item {
+                        Layout.fillWidth: true
+                    }
+                    PaddedButton {
+                        id: deleteButton
+                        text: "Delete"
+                        onClicked: components.remove_component(index)
+                        buttonEnabled: removable
+                        // The sample (at index 0) should never be removed. Don't even show it as an option.
+                        visible: index != 0
+                        ToolTip.visible: hovered & !removable
+                        ToolTip.delay: 400
+                        ToolTip.text: "Cannot remove a component that's in use as a transform parent"
                     }
                 }
             }
@@ -225,7 +221,7 @@ Pane {
                 PropertyChanges { target: mainContent; height: 0 }
                 PropertyChanges { target: mainContent; visible: false }
 
-                PropertyChanges { target: extendedContent; height: extendedText.height }
+                // PropertyChanges { target: extendedContent; height: extendedCon.height }
                 PropertyChanges { target: extendedContent; visible: true }
 
                 PropertyChanges { target: componentBox; contentHeight: extendedContent.height}


### PR DESCRIPTION
### Issue

Closes #243 
Closes #244 
Closes #152 

### Description of work

Adds some Layouts for the competent info stuff on the LHS of the main window. Both the expanded and shortened stuff are now in layouts. I tried to switch between them with a `StackLayout` but this seemed to cause problems so I opted to do without it. This change required using two expansion carets rather than rotating a single one but I think the end result looks neater.

### Acceptance Criteria 

Add and delete components and add and delete transformations. Check that the stuff in the component list is still doing the right thing. Also check that expanding and shrinking works correctly.

### UI tests

n/a

### Nominate for Group Code Review

- [ ] Nominate for code review 
