### PR TITLE
gridFields Improvement

### DIFF
--- a/resources/Qtmodels/PixelControls.qml
+++ b/resources/Qtmodels/PixelControls.qml
@@ -95,6 +95,7 @@ Item {
                     text: rows
                     onEditingFinished: rows = parseInt(text)
                     validator: integerValidator
+                    Layout.fillWidth: true
                 }
                 Label {
                     text: "Row Height: "
@@ -104,6 +105,7 @@ Item {
                     text: row_height
                     onEditingFinished: row_height = parseFloat(editorText)
                     validator: numberValidator
+                    Layout.fillWidth: true
                 }
                 Label {
                     text: "Columns: "
@@ -113,6 +115,7 @@ Item {
                     text: columns
                     onEditingFinished: columns = parseInt(text)
                     validator: integerValidator
+                    Layout.fillWidth: true
                 }
                 Label {
                     text: "Column Width: "
@@ -122,6 +125,7 @@ Item {
                     text: column_width
                     onEditingFinished: column_width = parseFloat(text)
                     validator: numberValidator
+                    Layout.fillWidth: true
                 }
                 Label {
                     text: "First ID: "
@@ -131,6 +135,7 @@ Item {
                     text: first_id
                     onEditingFinished: first_id = parseInt(text)
                     validator: integerValidator
+                    Layout.fillWidth: true
                 }
                 Item {
                     Layout.fillWidth: true

--- a/resources/Qtmodels/PixelControls.qml
+++ b/resources/Qtmodels/PixelControls.qml
@@ -99,6 +99,7 @@ Item {
                 }
                 Label {
                     text: "Row Height: "
+                    Layout.fillWidth: false
                 }
                 TextField {
                     id: rowHeightField
@@ -119,6 +120,7 @@ Item {
                 }
                 Label {
                     text: "Column Width: "
+                    Layout.fillWidth: false
                 }
                 TextField {
                     id: columnWidthField


### PR DESCRIPTION
### Issue

Related to #251 

### Description of work

Just making some text fields fill all the available space so it matches what the other parts of the window are doing.

### Acceptance Criteria 

Open the Add Component window and check that the stuff in the "Pixel grid" pane expands when the window expands.

### UI tests

n/a

### Nominate for Group Code Review

- [ ] Nominate for code review 
