### PR TITLE
234: Red cross for repeated component names

### DIFF
--- a/nexus_constructor/validators.py
+++ b/nexus_constructor/validators.py
@@ -205,4 +205,8 @@ class NameValidator(ValidatorOnListModel):
                 if name_at_index == input:
                     self.validationFailed.emit()
                     return QValidator.Invalid
+
+        self.validationSuccess.emit()
         return QValidator.Acceptable
+
+    validationSuccess = Signal()

--- a/resources/Qtmodels/AddComponentWindow.qml
+++ b/resources/Qtmodels/AddComponentWindow.qml
@@ -228,7 +228,7 @@ ExpandingWindow {
 
                     GridLayout {
                         rows: 2
-                        columns: 2
+                        columns: 3
                         Layout.fillWidth: true
                         Label {
                             text: "Name: "
@@ -243,11 +243,18 @@ ExpandingWindow {
                                 model: components
                                 myindex: -1
                                 onValidationFailed: {
-                                    nameField.ToolTip.show(ErrorMessages.repeatedComponentName, 3000)
+                                    repeatedNameCross.opacity = 1
+                                }
+                                onValidationSuccess: {
+                                    repeatedNameCross.opacity = 0
                                 }
                             }
                         }
-
+                        InvalidInputCross {
+                            id: repeatedNameCross
+                            toolTipMessage: ErrorMessages.repeatedComponentName
+                            Layout.fillWidth: false
+                        }
                         Label {
                             text: "Description: "
                         }

--- a/resources/Qtmodels/ComponentControls.qml
+++ b/resources/Qtmodels/ComponentControls.qml
@@ -84,7 +84,7 @@ Pane {
         Frame {
             id: componentBox
             padding: 5
-            contentHeight: nameField.height
+            contentHeight: repeatedNameCross.height
             contentWidth: extendedContent.implicitWidth
             width: componentListView.width
 

--- a/resources/Qtmodels/ComponentControls.qml
+++ b/resources/Qtmodels/ComponentControls.qml
@@ -136,10 +136,18 @@ Pane {
                             model: components
                             myindex: index
                             onValidationFailed: {
-                                nameField.ToolTip.show(ErrorMessages.repeatedComponentName, 3000)
+                                repeatedNameCross.opacity = 1
+                            }
+                            onValidationSuccess: {
+                                repeatedNameCross.opacity = 0
                             }
                         }
                         Layout.fillWidth: true
+                    }
+                    InvalidInputCross {
+                        id: repeatedNameCross
+                        toolTipMessage: ErrorMessages.repeatedComponentName
+                        Layout.fillWidth: false
                     }
                     Image {
                         Layout.preferredWidth: expansionCaretSize

--- a/resources/Qtmodels/EditComponentWindow.qml
+++ b/resources/Qtmodels/EditComponentWindow.qml
@@ -51,7 +51,7 @@ ExpandingWindow {
                 columns: 3
 
                 Label {
-                    text: "Name: "
+                    text: "Name : "
                 }
                 TextField {
                     id: nameField
@@ -87,12 +87,12 @@ ExpandingWindow {
                 Label {
                     id: transformLabel
                     text: "Transform:"
-                    Layout.columnSpan: 3
+                    Layout.columnSpan: parent.columns
                 }
 
                 Frame {
                     id: transformFrame
-                    Layout.columnSpan: 3
+                    Layout.columnSpan: parent.columns
                     contentHeight: transformControls.implicitHeight
                     contentWidth: transformControls.implicitWidth
                     Layout.fillWidth: true
@@ -118,7 +118,7 @@ ExpandingWindow {
                 GeometryControls {
                     id: geometryControls
                     state: geometry_state
-                    Layout.columnSpan: 3
+                    Layout.columnSpan: parent.columns
                     Layout.fillWidth: true
                     Component.onCompleted: {
                         geometryControls.geometryModel.set_geometry(componentIndex, components)
@@ -133,7 +133,7 @@ ExpandingWindow {
                     id: pixelControls
                     state: pixel_state
                     visible: pixel_state != ""
-                    Layout.columnSpan: 3
+                    Layout.columnSpan: parent.columns
                     Layout.fillWidth: true
 
                     Component.onCompleted:{

--- a/resources/Qtmodels/EditComponentWindow.qml
+++ b/resources/Qtmodels/EditComponentWindow.qml
@@ -83,7 +83,6 @@ ExpandingWindow {
                     Layout.fillWidth: true
                     text: description
                     onEditingFinished: description = text
-                    // Layout.columnSpan: 2
                 }
                 Label {
                     id: transformLabel

--- a/resources/Qtmodels/EditComponentWindow.qml
+++ b/resources/Qtmodels/EditComponentWindow.qml
@@ -48,7 +48,7 @@ ExpandingWindow {
                 id: editorColumn
                 anchors.fill: parent
                 rows: 5
-                columns: 2
+                columns: 3
 
                 Label {
                     text: "Name: "
@@ -63,9 +63,17 @@ ExpandingWindow {
                         model: components
                         myindex: componentIndex
                         onValidationFailed: {
-                            nameField.ToolTip.show(ErrorMessages.repeatedComponentName, 3000)
+                            repeatedNameCross.opacity = 1
+                        }
+                        onValidationSuccess: {
+                            repeatedNameCross.opacity = 0
                         }
                     }
+                }
+                InvalidInputCross {
+                    id: repeatedNameCross
+                    toolTipMessage: ErrorMessages.repeatedComponentName
+                    Layout.fillWidth: false
                 }
                 Label {
                     text: "Description: "
@@ -75,16 +83,17 @@ ExpandingWindow {
                     Layout.fillWidth: true
                     text: description
                     onEditingFinished: description = text
+                    Layout.columnSpan: 2
                 }
                 Label {
                     id: transformLabel
                     text: "Transform:"
-                    Layout.columnSpan: 2
+                    Layout.columnSpan: 3
                 }
 
                 Frame {
                     id: transformFrame
-                    Layout.columnSpan: 2
+                    Layout.columnSpan: 3
                     contentHeight: transformControls.implicitHeight
                     contentWidth: transformControls.implicitWidth
                     Layout.fillWidth: true
@@ -110,7 +119,7 @@ ExpandingWindow {
                 GeometryControls {
                     id: geometryControls
                     state: geometry_state
-                    Layout.columnSpan: 2
+                    Layout.columnSpan: 3
                     Layout.fillWidth: true
                     Component.onCompleted: {
                         geometryControls.geometryModel.set_geometry(componentIndex, components)
@@ -125,7 +134,7 @@ ExpandingWindow {
                     id: pixelControls
                     state: pixel_state
                     visible: pixel_state != ""
-                    Layout.columnSpan: 2
+                    Layout.columnSpan: 3
                     Layout.fillWidth: true
 
                     Component.onCompleted:{

--- a/resources/Qtmodels/EditComponentWindow.qml
+++ b/resources/Qtmodels/EditComponentWindow.qml
@@ -83,7 +83,7 @@ ExpandingWindow {
                     Layout.fillWidth: true
                     text: description
                     onEditingFinished: description = text
-                    Layout.columnSpan: 2
+                    // Layout.columnSpan: 2
                 }
                 Label {
                     id: transformLabel

--- a/resources/Qtmodels/InvalidInputCross.qml
+++ b/resources/Qtmodels/InvalidInputCross.qml
@@ -18,6 +18,6 @@ Text {
     ToolTip {
         id: toolTip
         parent: mouseArea
-        visible: cross.visible && mouseArea.containsMouse
+        visible: cross.visible && cross.opacity && mouseArea.containsMouse
     }
 }

--- a/tests/UITests.md
+++ b/tests/UITests.md
@@ -70,7 +70,7 @@ Reset the sample's name to 'Sample'.
 Press the 'Add component' button.
 - The "Add component" window should appear.
 - It should contain a selector for component type.
-- It should contain a pair of radio buttons for component geometry, 'Mesh', 'Cylinder' and 'None'.
+- It should contain the following radio buttons for component geometry: 'Mesh', 'Cylinder' and 'None'.
 - It should contain a set of radio buttons for pixel layout, 'Single ID', 'Repeatable grid', 'Face
 mapped mesh' and 'None'.
 - It should contain a 'Continue' button at the bottom.
@@ -138,13 +138,21 @@ Click the 'Add component' button.
 Select a Cylinder geometry and leave the other options untouched.  
 Try to name this new component "Sample".
 - The text field will accept the name "Sampl"  
-- Once you try to type in the remaining "e" a red cross will appear
-- Placing your mouse over the cross will show a message saying that component names must be unique
+- Once you try to type in the remaining "e" a red cross will appear.
+- Placing your mouse over the cross will show a message saying that component names must be unique.
 
-Remove focus from the text field by selecting a different field or moving the mouse away
+Remove focus from the text field by selecting a different field or by moving the mouse out of the window.
 - The red cross disappear and the message will no longer be accessible.
-- The component name will still be "Sampl"
+- The component name will still be "Sampl".
 
+Change the name back to its default and click "Add" without changing any of the other options.  
+Expand the component details box in the left-hand-side of the main window.  
+- Repeat the steps above and you should observe the same behaviour.
+
+Change the name back to its default again.  
+Expand the component details box.  
+Click the 'Full editor' button.  
+- Repeat the steps above and you should observe the same behaviour.
 
 ## Validating Units 
 

--- a/tests/UITests.md
+++ b/tests/UITests.md
@@ -132,6 +132,20 @@ the red sample cube, with center in the rear upper corner.
 - The cylinders radius should intersect the upper edges of the cubes front faces, and the rear edges
 of the cubes bottom faces.
 
+## Validating Component Names
+
+Click the 'Add component' button.  
+Select a Cylinder geometry and leave the other options untouched.  
+Try to name this new component "Sample".
+- The text field will accept the name "Sampl"  
+- Once you try to type in the remaining "e" a red cross will appear
+- Placing your mouse over the cross will show a message saying that component names must be unique
+
+Remove focus from the text field by selecting a different field or moving the mouse away
+- The red cross disappear and the message will no longer be accessible.
+- The component name will still be "Sampl"
+
+
 ## Validating Units 
 
 Click the 'Add component' button.  
@@ -183,7 +197,7 @@ Rename the transform in 'Cube detector' to just 'translate'.
 - The name change should be reflected in 'Monitor's second transform parent dropdown.
 
 Set the monitors 'transform parent' to 'Sample'.
-- The graphic of the cylinder should allign its right face with the right face of the sample cube.
+- The graphic of the cylinder should align its right face with the right face of the sample cube.
 - The delete buttons of 'Cube detector' and its transform should no longer be greyed out or show
 tooltips on hover.
 
@@ -227,12 +241,6 @@ Click the new rotations delete button in the main window.
 Set the radius of the cylinder to 2.
 - The cylinder's visualisation in the main window should double in radius.
 
-Attempt to set the components name to 'Sample'.
-- It should not be possible to enter the final character.
-- A tooltip should appear saying that names must be unique.
-
-Reset its name to 'Monitor'.
-
 ## Saving to file
 
 Close the editor window.
@@ -268,7 +276,7 @@ Set Monitor's transform parent to 'Cube Detector'.
 - Cube Detector's delete button should grey out, and clicking it result in nothing.
 
 Click Monitor's delete button.
-- Monitor should vanish from the componets list.
+- Monitor should vanish from the components list.
 - The cylinder in the 3D view should vanish too.
 - Cube Detector's delete button should be enabled.
 


### PR DESCRIPTION
### Issue

Closes #234 

### Description of work

Fixed an issue that caused the bad units mouse-over message to be accessible even when the cross isn't visible. Added `InvalidInputCross` in places where it's possible to enter a component name which required adding a success signal to the `NameValidator`.

### Acceptance Criteria 

Check that mouse-over message can't be accessed when the cross is invisible. Try to give a component a repeated name and check that the cross appears/disappears when it should. Also go through UI tests.

### UI tests

Added a section about [validating component names](https://github.com/ess-dmsc/nexus-constructor/blob/234_Red_cross_for_repeated_component_names/tests/UITests.md#validating-component-names). Also removed the old test for this as it's out-of-date.

### Nominate for Group Code Review

- [ ] Nominate for code review 
