### PR TITLE
Hide JSON pane by default - causes mesh loading to hang

### DIFF
--- a/resources/Qtmodels/Main.qml
+++ b/resources/Qtmodels/Main.qml
@@ -17,7 +17,7 @@ ApplicationWindow {
     minimumHeight: centralRow.implicitHeight + menuBar.implicitHeight
     property var jsonPaneWidth: 300
 
-    property string jsonMode: "liveFW"
+    property string jsonMode: "hidden"
 
     menuBar: MenuBar {
         Menu {


### PR DESCRIPTION
### Issue

None, horrible workaround

### Description of work

Hide the JSON pane as loading mesh files and then adding them causes the program to hang if the json pane is displayed. 

### Acceptance Criteria 

None

### UI tests

None

### Nominate for Group Code Review

- [ ] Nominate for code review 
