### PR TITLE
Fix unit conversion for mesh load

### DIFF
--- a/nexus_constructor/unit_converter.py
+++ b/nexus_constructor/unit_converter.py
@@ -1,7 +1,7 @@
 import pint
 
 
-def calculate_unit_conversion_factor(units):
+def calculate_unit_conversion_factor(units: str):
     """
     Determines the factor for multiplying the geometry file points in order to convert it from its original units to
     metres.
@@ -10,6 +10,5 @@ def calculate_unit_conversion_factor(units):
     :return: A float value for converting between metres and the unit argument.
     """
     ureg = pint.UnitRegistry()
-    units = ureg(units)
-    units = ureg.m.from_(units)
-    return units.magnitude
+    input_quantity = 1.0 * ureg.parse_expression(units)
+    return input_quantity.to(ureg.m).magnitude

--- a/resources/Qtmodels/GeometryControls.qml
+++ b/resources/Qtmodels/GeometryControls.qml
@@ -153,8 +153,9 @@ Pane {
                             text: "OK"
                             onClicked: {
                                 // Close the box
-                                offModel.file_url = filePicker.fileUrl
+                                // Must set units before the file_url as units are converted when file is loaded
                                 offModel.units = unitInput.editorText
+                                offModel.file_url = filePicker.fileUrl
                                 GeometryFileSelected.geometryFileSelected = true
                                 unitSelection.close()
                             }


### PR DESCRIPTION
### Issue
Closes #288

### Description of work

Set units in geometry model before loading the mesh from file so that they are used in the unit conversion.
Also made the unit conversion code a little easier to read.

