### PR TITLE
283: h5py error when creating a component that shares its name with a deleted component

### DIFF
--- a/nexus_constructor/component.py
+++ b/nexus_constructor/component.py
@@ -48,6 +48,9 @@ def create_component(
     )
 
 
+def delete_component():
+    pass
+
 @attr.s
 class Component:
     """Components of an instrument"""

--- a/nexus_constructor/component.py
+++ b/nexus_constructor/component.py
@@ -4,7 +4,11 @@ from nexus_constructor.transformations import Transformation
 from nexus_constructor.pixel_data import PixelData
 from nexus_constructor.geometry_types import Geometry
 from typing import List
-from nexus_constructor.nexus_model import create_group, delete_group, get_nx_class_for_component
+from nexus_constructor.nexus_model import (
+    create_group,
+    delete_group,
+    get_nx_class_for_component,
+)
 
 
 def create_component(

--- a/nexus_constructor/component.py
+++ b/nexus_constructor/component.py
@@ -4,7 +4,7 @@ from nexus_constructor.transformations import Transformation
 from nexus_constructor.pixel_data import PixelData
 from nexus_constructor.geometry_types import Geometry
 from typing import List
-from nexus_constructor.nexus_model import create_group, get_nx_class_for_component
+from nexus_constructor.nexus_model import create_group, delete_group, get_nx_class_for_component
 
 
 def create_component(
@@ -48,9 +48,6 @@ def create_component(
     )
 
 
-def delete_component():
-    pass
-
 @attr.s
 class Component:
     """Components of an instrument"""
@@ -64,3 +61,6 @@ class Component:
     geometry = attr.ib(default=None, type=Geometry)
     pixel_data = attr.ib(default=None, type=PixelData)
     component_group = attr.ib(default=None)
+
+    def delete_component_group(self):
+        pass

--- a/nexus_constructor/component.py
+++ b/nexus_constructor/component.py
@@ -67,4 +67,8 @@ class Component:
     component_group = attr.ib(default=None)
 
     def delete_component_group(self, parent):
+        """
+        Delete the group in the HDF5 file that corresponds with this component.
+        :param parent: The parent HDF group that the component belongs to.
+        """
         delete_group(self.name, parent)

--- a/nexus_constructor/component.py
+++ b/nexus_constructor/component.py
@@ -62,5 +62,5 @@ class Component:
     pixel_data = attr.ib(default=None, type=PixelData)
     component_group = attr.ib(default=None)
 
-    def delete_component_group(self):
-        pass
+    def delete_component_group(self, parent):
+        delete_group(self.name, parent)

--- a/nexus_constructor/nexus_model.py
+++ b/nexus_constructor/nexus_model.py
@@ -18,7 +18,13 @@ def create_group(name, nx_class, parent):
 
 
 def delete_group(name, parent):
-    pass
+    """
+     Given a name, an nx class and a parent group, create a group under the parent
+    :param name: The name of the group to be deleted.
+    :param parent: The parent HDF group to delete the group from.
+    """
+
+    del parent[name]
 
 
 def get_nx_class_for_component(component_type):

--- a/nexus_constructor/nexus_model.py
+++ b/nexus_constructor/nexus_model.py
@@ -17,6 +17,10 @@ def create_group(name, nx_class, parent):
     return group
 
 
+def delete_group(name, parent):
+    pass
+
+
 def get_nx_class_for_component(component_type):
     """
     Returns the NX class for a given component.

--- a/nexus_constructor/nexus_model.py
+++ b/nexus_constructor/nexus_model.py
@@ -19,11 +19,10 @@ def create_group(name, nx_class, parent):
 
 def delete_group(name, parent):
     """
-     Given a name, an nx class and a parent group, create a group under the parent
+     Delete a HDF group given a name and a parent.
     :param name: The name of the group to be deleted.
     :param parent: The parent HDF group to delete the group from.
     """
-
     del parent[name]
 
 

--- a/nexus_constructor/qml_models/instrument_model.py
+++ b/nexus_constructor/qml_models/instrument_model.py
@@ -275,7 +275,7 @@ class InstrumentModel(QAbstractListModel):
         if self.is_removable(index):
             self.beginRemoveRows(QModelIndex(), index, index)
             component = self.components.pop(index)
-            component.delete_component_group()
+            component.delete_component_group(self.instrument_group)
             self.transform_models.pop(index)
             self.endRemoveRows()
             self.update_removable()

--- a/nexus_constructor/qml_models/instrument_model.py
+++ b/nexus_constructor/qml_models/instrument_model.py
@@ -274,7 +274,8 @@ class InstrumentModel(QAbstractListModel):
     def remove_component(self, index):
         if self.is_removable(index):
             self.beginRemoveRows(QModelIndex(), index, index)
-            self.components.pop(index)
+            component = self.components.pop(index)
+            component.delete_component_group()
             self.transform_models.pop(index)
             self.endRemoveRows()
             self.update_removable()

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ git+https://github.com/ess-dmsc/python-nexus-utilities@6f5d2c7f1ca66063227aad2a1
 numpy-stl
 pre-commit
 pint
+mock
 
 # newer versions of jsonschema don't work with the executables built by cx_Freeze
 jsonschema==2.6.0

--- a/tests/test_instrument_model.py
+++ b/tests/test_instrument_model.py
@@ -84,7 +84,7 @@ def test_GIVEN_component_index_WHEN_calling_remove_component_THEN_component_call
     model.append_component_to_list(mock_component)
 
     model.remove_component(1)
-    mock_component.delete_component_group.assert_called_once()
+    mock_component.delete_component_group.assert_called_once_with(model.instrument_group)
 
 
 def test_GIVEN_nothing_WHEN_calling_create_instrument_group_THEN_instrument_group_is_created_and_added_to_model():

--- a/tests/test_instrument_model.py
+++ b/tests/test_instrument_model.py
@@ -78,12 +78,16 @@ def test_GIVEN_component_index_WHEN_calling_remove_component_THEN_component_call
     model = InstrumentModel()
     model.initialise(NexusModel().getEntryGroup())
 
+    # Create a mock component and add this to the InstrumentModel
     mock_component = Mock()
     mock_component.transforms = []
     mock_component.transform_parent = None
     model.append_component_to_list(mock_component)
 
+    # Remove the mock component which will be located at index 1
     model.remove_component(1)
+
+    # Check that this leads to the component's delete_component_group being called with the expected parent argument
     mock_component.delete_component_group.assert_called_once_with(
         model.instrument_group
     )

--- a/tests/test_instrument_model.py
+++ b/tests/test_instrument_model.py
@@ -87,7 +87,7 @@ def test_GIVEN_component_index_WHEN_calling_remove_component_THEN_component_call
     # Remove the mock component which will be located at index 1
     model.remove_component(1)
 
-    # Check that this leads to the component's delete_component_group being called with the expected parent argument
+    # Check that this leads to the component's delete_component_group method being called with the expected parent argument
     mock_component.delete_component_group.assert_called_once_with(
         model.instrument_group
     )

--- a/tests/test_instrument_model.py
+++ b/tests/test_instrument_model.py
@@ -73,6 +73,10 @@ def test_remove_component():
     assert model.components[0].component_type == ComponentType.SAMPLE
 
 
+def test_GIVEN_component_index_WHEN_calling_remove_component_THEN_component_calls_delete_component():
+    pass
+
+
 def test_GIVEN_nothing_WHEN_calling_create_instrument_group_THEN_instrument_group_is_created_and_added_to_model():
     model = InstrumentModel()
     model.initialise(NexusModel().getEntryGroup())

--- a/tests/test_instrument_model.py
+++ b/tests/test_instrument_model.py
@@ -17,6 +17,7 @@ from nexus_constructor.qml_models.instrument_model import (
 from nexus_constructor.nexus_model import NexusModel, h5py
 from nexus_constructor.pixel_data import PixelMapping, PixelGrid, SinglePixelId
 from PySide2.QtGui import QMatrix4x4, QVector3D
+from mock import Mock
 
 
 def test_GIVEN_different_attribute_WHEN_change_value_called_THEN_changes_attribute_to_new_value():
@@ -74,7 +75,16 @@ def test_remove_component():
 
 
 def test_GIVEN_component_index_WHEN_calling_remove_component_THEN_component_calls_delete_component():
-    pass
+    model = InstrumentModel()
+    model.initialise(NexusModel().getEntryGroup())
+
+    mock_component = Mock()
+    mock_component.transforms = []
+    mock_component.transform_parent = None
+    model.append_component_to_list(mock_component)
+
+    model.remove_component(1)
+    mock_component.delete_component.assert_called_once()
 
 
 def test_GIVEN_nothing_WHEN_calling_create_instrument_group_THEN_instrument_group_is_created_and_added_to_model():

--- a/tests/test_instrument_model.py
+++ b/tests/test_instrument_model.py
@@ -84,7 +84,9 @@ def test_GIVEN_component_index_WHEN_calling_remove_component_THEN_component_call
     model.append_component_to_list(mock_component)
 
     model.remove_component(1)
-    mock_component.delete_component_group.assert_called_once_with(model.instrument_group)
+    mock_component.delete_component_group.assert_called_once_with(
+        model.instrument_group
+    )
 
 
 def test_GIVEN_nothing_WHEN_calling_create_instrument_group_THEN_instrument_group_is_created_and_added_to_model():

--- a/tests/test_instrument_model.py
+++ b/tests/test_instrument_model.py
@@ -74,7 +74,7 @@ def test_remove_component():
     assert model.components[0].component_type == ComponentType.SAMPLE
 
 
-def test_GIVEN_component_index_WHEN_calling_remove_component_THEN_component_calls_delete_component():
+def test_GIVEN_component_index_WHEN_calling_remove_component_THEN_component_calls_delete_component_group():
     model = InstrumentModel()
     model.initialise(NexusModel().getEntryGroup())
 

--- a/tests/test_instrument_model.py
+++ b/tests/test_instrument_model.py
@@ -84,7 +84,7 @@ def test_GIVEN_component_index_WHEN_calling_remove_component_THEN_component_call
     model.append_component_to_list(mock_component)
 
     model.remove_component(1)
-    mock_component.delete_component.assert_called_once()
+    mock_component.delete_component_group.assert_called_once()
 
 
 def test_GIVEN_nothing_WHEN_calling_create_instrument_group_THEN_instrument_group_is_created_and_added_to_model():

--- a/tests/test_nexus_model.py
+++ b/tests/test_nexus_model.py
@@ -89,7 +89,7 @@ def test_GIVEN_unrecognised_name_WHEN_deleting_group_THEN_throws():
     create_group(component_name, nx_class, nexus_file)
 
     with raises(KeyError):
-        delete_group("wrongname", nexus_file)
+        delete_group("nonexistent_component_name", nexus_file)
 
 
 def test_GIVEN_repeated_name_WHEN_creating_group_that_shares_its_name_with_group_component_THEN_creation_successful():

--- a/tests/test_nexus_model.py
+++ b/tests/test_nexus_model.py
@@ -92,7 +92,7 @@ def test_GIVEN_unrecognised_name_WHEN_deleting_group_THEN_throws():
         delete_group("wrongname", nexus_file)
 
 
-def test_GIVEN_repeated_name_WHEN_creating_component_that_shares_its_name_with_deleted_component_THEN_creation_successful():
+def test_GIVEN_repeated_name_WHEN_creating_group_that_shares_its_name_with_group_component_THEN_creation_successful():
     file_name = "test4"
     nx_class = "NXarbitrary"
     component_name = "MyDetector"

--- a/tests/test_nexus_model.py
+++ b/tests/test_nexus_model.py
@@ -2,9 +2,11 @@ from nexus_constructor.nexus_model import (
     NexusModel,
     get_nx_class_for_component,
     create_group,
+    delete_group,
     ComponentType,
     append_nxs_extension,
 )
+from pytest import raises
 import h5py
 
 sample_name = "NXsample"
@@ -65,6 +67,27 @@ def test_GIVEN_nonstandard_nxclass_WHEN_creating_group_THEN_group_is_still_creat
     create_group(name, nx_class, nexus_file)
 
     assert nexus_file[name].attrs["NX_class"] == nx_class
+
+
+def test_GIVEN_recognised_name_WHEN_deleting_group_THEN_group_gets_deleted():
+    name = "test"
+    nx_class = "NXarbitrary"
+    nexus_file = h5py.File(name, driver="core", backing_store=False)
+    create_group(name, nx_class, nexus_file)
+    delete_group(name, nexus_file)
+
+    with raises(KeyError):
+        pass
+
+
+def test_GIVEN_unrecognised_name_WHEN_deleting_group_THEN_throws():
+    name = "test"
+    nx_class = "NXarbitrary"
+    nexus_file = h5py.File(name, driver="core", backing_store=False)
+    create_group(name, nx_class, nexus_file)
+
+    with raises(KeyError):
+        delete_group(name, nexus_file)
 
 
 def test_GIVEN_string_ending_with_nxs_WHEN_appending_nxs_extension_THEN_string_is_not_changed():

--- a/tests/test_nexus_model.py
+++ b/tests/test_nexus_model.py
@@ -89,10 +89,10 @@ def test_GIVEN_unrecognised_name_WHEN_deleting_group_THEN_throws():
     create_group(component_name, nx_class, nexus_file)
 
     with raises(KeyError):
-        delete_group(component_name, nexus_file)
+        delete_group("wrongname", nexus_file)
 
 
-def test_GIVEN_repeated_name_WHEN_creating_component_that_shares_its_name_with_deleted_component_THEN_name_is_accepted():
+def test_GIVEN_repeated_name_WHEN_creating_component_that_shares_its_name_with_deleted_component_THEN_creation_successful():
     file_name = "test4"
     nx_class = "NXarbitrary"
     component_name = "MyDetector"

--- a/tests/test_nexus_model.py
+++ b/tests/test_nexus_model.py
@@ -99,7 +99,8 @@ def test_GIVEN_repeated_name_WHEN_creating_component_that_shares_its_name_with_d
     nexus_file = h5py.File(file_name, driver="core", backing_store=False)
     create_group(component_name, nx_class, nexus_file)
     delete_group(component_name, nexus_file)
-    create_group(component_name, nx_class, nexus_file)
+
+    assert isinstance(create_group(component_name, nx_class, nexus_file), h5py._hl.group.Group)
 
 
 def test_GIVEN_string_ending_with_nxs_WHEN_appending_nxs_extension_THEN_string_is_not_changed():

--- a/tests/test_nexus_model.py
+++ b/tests/test_nexus_model.py
@@ -100,7 +100,9 @@ def test_GIVEN_repeated_name_WHEN_creating_group_that_shares_its_name_with_group
     create_group(component_name, nx_class, nexus_file)
     delete_group(component_name, nexus_file)
 
-    assert isinstance(create_group(component_name, nx_class, nexus_file), h5py._hl.group.Group)
+    assert isinstance(
+        create_group(component_name, nx_class, nexus_file), h5py._hl.group.Group
+    )
 
 
 def test_GIVEN_string_ending_with_nxs_WHEN_appending_nxs_extension_THEN_string_is_not_changed():

--- a/tests/test_nexus_model.py
+++ b/tests/test_nexus_model.py
@@ -92,7 +92,7 @@ def test_GIVEN_unrecognised_name_WHEN_deleting_group_THEN_throws():
         delete_group("nonexistent_component_name", nexus_file)
 
 
-def test_GIVEN_repeated_name_WHEN_creating_group_that_shares_its_name_with_deleted_component_THEN_creation_successful():
+def test_GIVEN_repeated_name_WHEN_creating_group_that_shares_its_name_with_deleted_group_THEN_group_creation_successful():
     file_name = "test4"
     nx_class = "NXarbitrary"
     component_name = "MyDetector"

--- a/tests/test_nexus_model.py
+++ b/tests/test_nexus_model.py
@@ -92,7 +92,7 @@ def test_GIVEN_unrecognised_name_WHEN_deleting_group_THEN_throws():
         delete_group("nonexistent_component_name", nexus_file)
 
 
-def test_GIVEN_repeated_name_WHEN_creating_group_that_shares_its_name_with_group_component_THEN_creation_successful():
+def test_GIVEN_repeated_name_WHEN_creating_group_that_shares_its_name_with_deleted_component_THEN_creation_successful():
     file_name = "test4"
     nx_class = "NXarbitrary"
     component_name = "MyDetector"

--- a/tests/test_nexus_model.py
+++ b/tests/test_nexus_model.py
@@ -70,24 +70,36 @@ def test_GIVEN_nonstandard_nxclass_WHEN_creating_group_THEN_group_is_still_creat
 
 
 def test_GIVEN_recognised_name_WHEN_deleting_group_THEN_group_gets_deleted():
-    name = "test"
+    file_name = "test2"
     nx_class = "NXarbitrary"
-    nexus_file = h5py.File(name, driver="core", backing_store=False)
-    create_group(name, nx_class, nexus_file)
-    delete_group(name, nexus_file)
+    component_name = "MyDetector"
+    nexus_file = h5py.File(file_name, driver="core", backing_store=False)
+    create_group(component_name, nx_class, nexus_file)
+    delete_group(component_name, nexus_file)
 
     with raises(KeyError):
-        pass
+        nexus_file[component_name]
 
 
 def test_GIVEN_unrecognised_name_WHEN_deleting_group_THEN_throws():
-    name = "test"
+    file_name = "test3"
     nx_class = "NXarbitrary"
-    nexus_file = h5py.File(name, driver="core", backing_store=False)
-    create_group(name, nx_class, nexus_file)
+    component_name = "MyDetector"
+    nexus_file = h5py.File(file_name, driver="core", backing_store=False)
+    create_group(component_name, nx_class, nexus_file)
 
     with raises(KeyError):
-        delete_group(name, nexus_file)
+        delete_group(component_name, nexus_file)
+
+
+def test_GIVEN_repeated_name_WHEN_creating_component_that_shares_its_name_with_deleted_component_THEN_name_is_accepted():
+    file_name = "test4"
+    nx_class = "NXarbitrary"
+    component_name = "MyDetector"
+    nexus_file = h5py.File(file_name, driver="core", backing_store=False)
+    create_group(component_name, nx_class, nexus_file)
+    delete_group(component_name, nexus_file)
+    create_group(component_name, nx_class, nexus_file)
 
 
 def test_GIVEN_string_ending_with_nxs_WHEN_appending_nxs_extension_THEN_string_is_not_changed():


### PR DESCRIPTION
### Issue

Closes #283

### Description of work

Removes the component group from the HDF5 file whenever you delete a component. Also added some tests for this as well as a few new functions.

### Acceptance Criteria 

See that the tests pass and that they make sense, cover sensible test cases, etc. Check that the h5py error no longer happens.

### UI tests

n/a

### Nominate for Group Code Review

- [ ] Nominate for code review 
