### PR TITLE
Widgets: main window 

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,4 +3,4 @@ ignore = E203, E266, E501, W503, E123, C901
 max-line-length = 80
 max-complexity = 18
 select = B,C,E,F,W,T4,B9
-exclude = ui/
+exclude = ui

--- a/.flake8
+++ b/.flake8
@@ -3,3 +3,4 @@ ignore = E203, E266, E501, W503, E123, C901
 max-line-length = 80
 max-complexity = 18
 select = B,C,E,F,W,T4,B9
+exclude = ui/

--- a/.flake8
+++ b/.flake8
@@ -3,4 +3,4 @@ ignore = E203, E266, E501, W503, E123, C901
 max-line-length = 80
 max-complexity = 18
 select = B,C,E,F,W,T4,B9
-exclude = ui
+exclude = ui/,build*

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,7 +95,7 @@ def get_linux_pipeline() {
         stage("Check formatting") {
             sh """docker exec ${container_name} ${sh_cmd} -c \"
                 cd ${project}
-                build_env/bin/python -m black . --check --exclude=build_env/,ui/
+                build_env/bin/python -m black . --check --exclude=(build_env\/|ui\/)
             \""""
         } // stage
         stage("Run Linter") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,7 +95,7 @@ def get_linux_pipeline() {
         stage("Check formatting") {
             sh """docker exec ${container_name} ${sh_cmd} -c \"
                 cd ${project}
-                build_env/bin/python -m black . --check --exclude=(build_env\/|ui\/)
+                build_env/bin/python -m black . --check --exclude=(build_env\\/|ui\\/)
             \""""
         } // stage
         stage("Run Linter") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,7 +95,7 @@ def get_linux_pipeline() {
         stage("Check formatting") {
             sh """docker exec ${container_name} ${sh_cmd} -c \"
                 cd ${project}
-                build_env/bin/python -m black . --check --exclude=ui/\\|build*
+                build_env/bin/python -m black . --check
             \""""
         } // stage
         stage("Run Linter") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,7 +95,7 @@ def get_linux_pipeline() {
         stage("Check formatting") {
             sh """docker exec ${container_name} ${sh_cmd} -c \"
                 cd ${project}
-                build_env/bin/python -m black . --check --exclude=(build_env\\/|ui\\/)
+                build_env/bin/python -m black . --check --exclude=ui/\\|build*
             \""""
         } // stage
         stage("Run Linter") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,7 +95,7 @@ def get_linux_pipeline() {
         stage("Check formatting") {
             sh """docker exec ${container_name} ${sh_cmd} -c \"
                 cd ${project}
-                build_env/bin/python -m black . --check --exclude=build_env/
+                build_env/bin/python -m black . --check --exclude=build_env/,ui/
             \""""
         } // stage
         stage("Run Linter") {

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 """
 Entry script for the nexus constructor application.
-Requires Python 3.5+
+Requires Python 3.6+
 """
 
 import sys

--- a/main.py
+++ b/main.py
@@ -8,7 +8,6 @@ import h5py
 from PySide2.QtWidgets import QApplication, QMainWindow, QDialog, QFileDialog
 from PySide2 import QtCore
 from ui.mainwindow import Ui_MainWindow
-from uuid import uuid4
 import silx.gui.hdf5
 
 from nexus_constructor.qml_models import instrument_model
@@ -17,7 +16,7 @@ NEXUS_FILE_TYPES = "NeXus Files (*.nxs,*.nex,*.nx5)"
 
 
 def set_up_in_memory_nexus_file():
-    return h5py.File(str(uuid4()), mode="x", driver="core", backing_store=False)
+    return h5py.File("nexus-constructor", mode="x", driver="core", backing_store=False)
 
 
 class MainWindow(Ui_MainWindow):

--- a/main.py
+++ b/main.py
@@ -11,6 +11,8 @@ from ui.mainwindow import Ui_MainWindow
 from uuid import uuid4
 import silx.gui.hdf5
 
+from nexus_constructor.qml_models import instrument_model
+
 NEXUS_FILE_TYPES = "NeXus Files (*.nxs,*.nex,*.nx5)"
 
 
@@ -26,6 +28,9 @@ class MainWindow(Ui_MainWindow):
         self.entry_group.attrs["NX_class"] = "NXentry"
         self.instrument_group = self.entry_group.create_group("instrument")
         self.instrument_group.attrs["NX_class"] = "NXinstrument"
+
+        self.components_list_model = instrument_model.InstrumentModel()
+        self.components_list_model.initialise(self.entry_group)
 
     file_dialog_native = QFileDialog.DontUseNativeDialog
 
@@ -49,6 +54,7 @@ class MainWindow(Ui_MainWindow):
         self.treemodel.setDatasetDragEnabled(True)
         self.treemodel.setFileDropEnabled(True)
         self.verticalLayout.addWidget(self.widget)
+        self.listView.setModel(self.components_list_model)
 
         self.widget.setVisible(True)
 

--- a/main.py
+++ b/main.py
@@ -53,6 +53,7 @@ class MainWindow(Ui_MainWindow):
         self.treemodel.insertH5pyObject(self.nexus_file)
         self.treemodel.setDatasetDragEnabled(True)
         self.treemodel.setFileDropEnabled(True)
+        self.treemodel.setFileMoveEnabled(True)
         self.verticalLayout.addWidget(self.widget)
         self.listView.setModel(self.components_list_model)
 

--- a/main.py
+++ b/main.py
@@ -4,24 +4,115 @@ Requires Python 3.5+
 """
 
 import sys
-from os import path, environ
-from nexus_constructor.application import Application
-from PySide2.QtGui import QGuiApplication, QIcon
+import h5py
+from PySide2.QtWidgets import QApplication, QMainWindow, QDialog, QFileDialog
+from PySide2 import QtCore
+from ui.mainwindow import Ui_MainWindow
+from uuid import uuid4
+import silx.gui.hdf5
+
+NEXUS_FILE_TYPES = "NeXus Files (*.nxs,*.nex,*.nx5)"
+
+
+def set_up_in_memory_nexus_file():
+    return h5py.File(str(uuid4()), mode="x", driver="core", backing_store=False)
+
+
+class MainWindow(Ui_MainWindow):
+    def __init__(self):
+        super().__init__()
+        self.nexus_file = set_up_in_memory_nexus_file()
+        self.entry_group = self.nexus_file.create_group("entry")
+        self.entry_group.attrs["NX_class"] = "NXentry"
+        self.instrument_group = self.entry_group.create_group("instrument")
+        self.instrument_group.attrs["NX_class"] = "NXinstrument"
+
+    file_dialog_native = QFileDialog.DontUseNativeDialog
+
+    def setupUi(self, main_window):
+        super().setupUi(main_window)
+
+        self.addWindow = QDialog()
+
+        self.pushButton.clicked.connect(self.show_add_component_window)
+        self.actionExport_to_NeXus_file.triggered.connect(self.save_to_nexus_file)
+        self.actionOpen_NeXus_file.triggered.connect(self.open_nexus_file)
+        self.actionExport_to_Filewriter_JSON.triggered.connect(
+            self.save_to_filewriter_json
+        )
+
+        self.widget = silx.gui.hdf5.Hdf5TreeView()
+        self.widget.setAcceptDrops(True)
+        self.widget.setDragEnabled(True)
+        self.treemodel = self.widget.findHdf5TreeModel()
+        self.treemodel.insertH5pyObject(self.nexus_file)
+        self.treemodel.setDatasetDragEnabled(True)
+        self.treemodel.setFileDropEnabled(True)
+        self.verticalLayout.addWidget(self.widget)
+
+        self.widget.setVisible(True)
+
+    def save_to_nexus_file(self):
+        options = QFileDialog.Options()
+        options |= self.file_dialog_native
+        fileName, _ = QFileDialog.getSaveFileName(
+            parent=None,
+            caption="QFileDialog.getSaveFileName()",
+            directory="",
+            filter=f"{NEXUS_FILE_TYPES};;All Files (*)",
+            options=options,
+        )
+        if fileName:
+            print(fileName)
+            file = h5py.File(fileName, mode="x")
+            try:
+                file.copy(source=self.nexus_file["/entry/"], dest="/entry/")
+                print("Saved to NeXus file")
+            except ValueError as e:
+                print(f"File writing failed: {e}")
+
+    def save_to_filewriter_json(self):
+        options = QFileDialog.Options()
+        options |= self.file_dialog_native
+        fileName, _ = QFileDialog.getSaveFileName(
+            parent=None,
+            caption="QFileDialog.getSaveFileName()",
+            directory="",
+            filter="JSON Files (*.json);;All Files (*)",
+            options=options,
+        )
+        if fileName:
+            print(fileName)
+
+    def open_nexus_file(self):
+        options = QFileDialog.Options()
+
+        options |= self.file_dialog_native
+        fileName, _ = QFileDialog.getOpenFileName(
+            parent=None,
+            caption="QFileDialog.getOpenFileName()",
+            directory="",
+            filter=f"{NEXUS_FILE_TYPES};;All Files (*)",
+            options=options,
+        )
+        if fileName:
+            print(fileName)
+            self.nexus_file = h5py.File(
+                fileName, mode="r", backing_store=False, driver="core"
+            )
+            self.widget.findHdf5TreeModel().clear()
+            self.widget.findHdf5TreeModel().insertH5pyObject(self.nexus_file)
+            print("NeXus file loaded")
+
+    def show_add_component_window(self):
+        self.addWindow.exec()
+
 
 if __name__ == "__main__":
-    location = sys.executable if getattr(sys, "frozen", False) else __file__
-    resource_folder = path.join(path.dirname(location), "resources")
-
-    environ["QT_QUICK_CONTROLS_CONF"] = path.join(
-        resource_folder, "qtquickcontrols2.conf"
-    )
-
-    app = QGuiApplication(sys.argv)
-
-    # Non-blank name and organisation name are required by DefaultFileDialog
-    app.setOrganizationName("name")
-    app.setOrganizationDomain("domain")
-    app.setWindowIcon(QIcon(path.join(resource_folder, "images", "icon.png")))
-
-    window = Application(resource_folder)
+    app = QApplication(sys.argv)
+    app.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
+    window = QMainWindow()
+    ui = MainWindow()
+    ui.setupUi(window)
+    window.show()
     sys.exit(app.exec_())

--- a/nexus_constructor/qml_models/instrument_model.py
+++ b/nexus_constructor/qml_models/instrument_model.py
@@ -110,7 +110,7 @@ class InstrumentModel(QAbstractListModel):
             parent_group=group,
         )
         try:
-            self.instrument_group = group["/instrument/"]
+            self.instrument_group = group["instrument"]
         except KeyError:
             self.create_instrument_group(group)
 

--- a/nexus_constructor/qml_models/instrument_model.py
+++ b/nexus_constructor/qml_models/instrument_model.py
@@ -110,8 +110,6 @@ class InstrumentModel(QAbstractListModel):
             parent_group=group,
         )
 
-        self.create_instrument_group(group)
-
         self.append_component_to_list(sample)
         self.send_model_updated()
 

--- a/nexus_constructor/qml_models/instrument_model.py
+++ b/nexus_constructor/qml_models/instrument_model.py
@@ -105,7 +105,7 @@ class InstrumentModel(QAbstractListModel):
         """
         sample = create_component(
             component_type=ComponentType.SAMPLE,
-            name="Sample",
+            name="sample",
             geometry=OFFCube,
             parent_group=group,
         )

--- a/nexus_constructor/qml_models/instrument_model.py
+++ b/nexus_constructor/qml_models/instrument_model.py
@@ -109,6 +109,10 @@ class InstrumentModel(QAbstractListModel):
             geometry=OFFCube,
             parent_group=group,
         )
+        try:
+            self.instrument_group = group["/instrument/"]
+        except KeyError:
+            self.create_instrument_group(group)
 
         self.append_component_to_list(sample)
         self.send_model_updated()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+exclude = '/(build*|ui/)'

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ numpy-stl
 pre-commit
 pint
 mock
+silx
 
 # newer versions of jsonschema don't work with the executables built by cx_Freeze
 jsonschema==2.6.0

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -3,13 +3,12 @@
 # Form implementation generated from reading ui file 'mainwindow.ui',
 # licensing of 'mainwindow.ui' applies.
 #
-# Created: Thu May 30 10:02:37 2019
+# Created: Thu May 30 10:46:06 2019
 #      by: pyside2-uic  running on PySide2 5.12.1
 #
 # WARNING! All changes made in this file will be lost!
 
 from PySide2 import QtCore, QtGui, QtWidgets
-from PySide2.QtQuickWidgets import QQuickWidget
 
 class Ui_MainWindow(object):
     def setupUi(self, MainWindow):
@@ -48,17 +47,15 @@ class Ui_MainWindow(object):
         self.verticalLayout.addWidget(self.widget)
         self.tabWidget.addTab(self.tab, "")
         self.horizontalLayout.addWidget(self.tabWidget)
-        self.quickWidget = QQuickWidget(self.centralwidget)
+        self.centralWidget = QtWidgets.QWidget(self.centralwidget)
         sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
-        sizePolicy.setHeightForWidth(self.quickWidget.sizePolicy().hasHeightForWidth())
-        self.quickWidget.setSizePolicy(sizePolicy)
-        self.quickWidget.setMinimumSize(QtCore.QSize(500, 0))
-        self.quickWidget.setResizeMode(QQuickWidget.SizeRootObjectToView)
-        self.quickWidget.setSource(QtCore.QUrl("file:./view.qml"))
-        self.quickWidget.setObjectName("quickWidget")
-        self.horizontalLayout.addWidget(self.quickWidget)
+        sizePolicy.setHeightForWidth(self.centralWidget.sizePolicy().hasHeightForWidth())
+        self.centralWidget.setSizePolicy(sizePolicy)
+        self.centralWidget.setMinimumSize(QtCore.QSize(500, 0))
+        self.centralWidget.setObjectName("centralWidget")
+        self.horizontalLayout.addWidget(self.centralWidget)
         self.gridLayout.addLayout(self.horizontalLayout, 1, 0, 1, 1)
         MainWindow.setCentralWidget(self.centralwidget)
         self.menubar = QtWidgets.QMenuBar(MainWindow)

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -3,7 +3,7 @@
 # Form implementation generated from reading ui file 'mainwindow.ui',
 # licensing of 'mainwindow.ui' applies.
 #
-# Created: Thu May 30 11:03:47 2019
+# Created: Thu May 30 11:26:13 2019
 #      by: pyside2-uic  running on PySide2 5.12.1
 #
 # WARNING! All changes made in this file will be lost!
@@ -36,15 +36,14 @@ class Ui_MainWindow(object):
         self.tabWidget.addTab(self.tab_2, "")
         self.tab = QtWidgets.QWidget()
         self.tab.setObjectName("tab")
-        self.verticalLayoutWidget = QtWidgets.QWidget(self.tab)
-        self.verticalLayoutWidget.setGeometry(QtCore.QRect(0, 0, 502, 481))
-        self.verticalLayoutWidget.setObjectName("verticalLayoutWidget")
-        self.verticalLayout = QtWidgets.QVBoxLayout(self.verticalLayoutWidget)
-        self.verticalLayout.setContentsMargins(0, 0, 0, 0)
+        self.gridLayout_2 = QtWidgets.QGridLayout(self.tab)
+        self.gridLayout_2.setObjectName("gridLayout_2")
+        self.verticalLayout = QtWidgets.QVBoxLayout()
         self.verticalLayout.setObjectName("verticalLayout")
-        self.widget = QtWidgets.QWidget(self.verticalLayoutWidget)
+        self.widget = QtWidgets.QWidget(self.tab)
         self.widget.setObjectName("widget")
         self.verticalLayout.addWidget(self.widget)
+        self.gridLayout_2.addLayout(self.verticalLayout, 0, 0, 1, 1)
         self.tabWidget.addTab(self.tab, "")
         self.horizontalLayout.addWidget(self.tabWidget)
         self.centralWidget = QtWidgets.QWidget(self.centralwidget)
@@ -83,7 +82,7 @@ class Ui_MainWindow(object):
         self.menubar.addAction(self.menuFile.menuAction())
 
         self.retranslateUi(MainWindow)
-        self.tabWidget.setCurrentIndex(0)
+        self.tabWidget.setCurrentIndex(1)
         QtCore.QMetaObject.connectSlotsByName(MainWindow)
 
     def retranslateUi(self, MainWindow):

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -3,7 +3,7 @@
 # Form implementation generated from reading ui file 'mainwindow.ui',
 # licensing of 'mainwindow.ui' applies.
 #
-# Created: Thu May 30 09:51:17 2019
+# Created: Thu May 30 10:02:37 2019
 #      by: pyside2-uic  running on PySide2 5.12.1
 #
 # WARNING! All changes made in this file will be lost!
@@ -24,6 +24,17 @@ class Ui_MainWindow(object):
         self.horizontalLayout.setObjectName("horizontalLayout")
         self.tabWidget = QtWidgets.QTabWidget(self.centralwidget)
         self.tabWidget.setObjectName("tabWidget")
+        self.tab_2 = QtWidgets.QWidget()
+        self.tab_2.setObjectName("tab_2")
+        self.verticalLayout_2 = QtWidgets.QVBoxLayout(self.tab_2)
+        self.verticalLayout_2.setObjectName("verticalLayout_2")
+        self.pushButton = QtWidgets.QPushButton(self.tab_2)
+        self.pushButton.setObjectName("pushButton")
+        self.verticalLayout_2.addWidget(self.pushButton)
+        self.listWidget = QtWidgets.QListWidget(self.tab_2)
+        self.listWidget.setObjectName("listWidget")
+        self.verticalLayout_2.addWidget(self.listWidget)
+        self.tabWidget.addTab(self.tab_2, "")
         self.tab = QtWidgets.QWidget()
         self.tab.setObjectName("tab")
         self.verticalLayoutWidget = QtWidgets.QWidget(self.tab)
@@ -32,21 +43,10 @@ class Ui_MainWindow(object):
         self.verticalLayout = QtWidgets.QVBoxLayout(self.verticalLayoutWidget)
         self.verticalLayout.setContentsMargins(0, 0, 0, 0)
         self.verticalLayout.setObjectName("verticalLayout")
-        self.pushButton = QtWidgets.QPushButton(self.verticalLayoutWidget)
-        self.pushButton.setObjectName("pushButton")
-        self.verticalLayout.addWidget(self.pushButton)
         self.widget = QtWidgets.QWidget(self.verticalLayoutWidget)
         self.widget.setObjectName("widget")
         self.verticalLayout.addWidget(self.widget)
         self.tabWidget.addTab(self.tab, "")
-        self.tab_2 = QtWidgets.QWidget()
-        self.tab_2.setObjectName("tab_2")
-        self.verticalLayout_2 = QtWidgets.QVBoxLayout(self.tab_2)
-        self.verticalLayout_2.setObjectName("verticalLayout_2")
-        self.listWidget = QtWidgets.QListWidget(self.tab_2)
-        self.listWidget.setObjectName("listWidget")
-        self.verticalLayout_2.addWidget(self.listWidget)
-        self.tabWidget.addTab(self.tab_2, "")
         self.horizontalLayout.addWidget(self.tabWidget)
         self.quickWidget = QQuickWidget(self.centralwidget)
         sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
@@ -59,7 +59,7 @@ class Ui_MainWindow(object):
         self.quickWidget.setSource(QtCore.QUrl("file:./view.qml"))
         self.quickWidget.setObjectName("quickWidget")
         self.horizontalLayout.addWidget(self.quickWidget)
-        self.gridLayout.addLayout(self.horizontalLayout, 0, 0, 1, 1)
+        self.gridLayout.addLayout(self.horizontalLayout, 1, 0, 1, 1)
         MainWindow.setCentralWidget(self.centralwidget)
         self.menubar = QtWidgets.QMenuBar(MainWindow)
         self.menubar.setGeometry(QtCore.QRect(0, 0, 1141, 19))
@@ -86,14 +86,14 @@ class Ui_MainWindow(object):
         self.menubar.addAction(self.menuFile.menuAction())
 
         self.retranslateUi(MainWindow)
-        self.tabWidget.setCurrentIndex(1)
+        self.tabWidget.setCurrentIndex(0)
         QtCore.QMetaObject.connectSlotsByName(MainWindow)
 
     def retranslateUi(self, MainWindow):
         MainWindow.setWindowTitle(QtWidgets.QApplication.translate("MainWindow", "NeXus Constructor", None, -1))
         self.pushButton.setText(QtWidgets.QApplication.translate("MainWindow", "Add component", None, -1))
-        self.tabWidget.setTabText(self.tabWidget.indexOf(self.tab), QtWidgets.QApplication.translate("MainWindow", "NeXus File Layout", None, -1))
         self.tabWidget.setTabText(self.tabWidget.indexOf(self.tab_2), QtWidgets.QApplication.translate("MainWindow", "Components", None, -1))
+        self.tabWidget.setTabText(self.tabWidget.indexOf(self.tab), QtWidgets.QApplication.translate("MainWindow", "NeXus File Layout", None, -1))
         self.menuFile.setTitle(QtWidgets.QApplication.translate("MainWindow", "File", None, -1))
         self.actionShow_Filewriter_JSON.setText(QtWidgets.QApplication.translate("MainWindow", "Show Filewriter JSON", None, -1))
         self.actionHide_JSON_Pane.setText(QtWidgets.QApplication.translate("MainWindow", "Hide JSON Pane", None, -1))

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -3,7 +3,7 @@
 # Form implementation generated from reading ui file 'mainwindow.ui',
 # licensing of 'mainwindow.ui' applies.
 #
-# Created: Thu May 30 11:26:13 2019
+# Created: Thu May 30 12:13:15 2019
 #      by: pyside2-uic  running on PySide2 5.12.1
 #
 # WARNING! All changes made in this file will be lost!
@@ -13,15 +13,16 @@ from PySide2 import QtCore, QtGui, QtWidgets
 class Ui_MainWindow(object):
     def setupUi(self, MainWindow):
         MainWindow.setObjectName("MainWindow")
-        MainWindow.resize(1141, 599)
+        MainWindow.resize(1163, 712)
         self.centralwidget = QtWidgets.QWidget(MainWindow)
         self.centralwidget.setObjectName("centralwidget")
         self.gridLayout = QtWidgets.QGridLayout(self.centralwidget)
         self.gridLayout.setObjectName("gridLayout")
-        self.horizontalLayout = QtWidgets.QHBoxLayout()
-        self.horizontalLayout.setSizeConstraint(QtWidgets.QLayout.SetDefaultConstraint)
-        self.horizontalLayout.setObjectName("horizontalLayout")
+        self.gridLayout_3 = QtWidgets.QGridLayout()
+        self.gridLayout_3.setSizeConstraint(QtWidgets.QLayout.SetDefaultConstraint)
+        self.gridLayout_3.setObjectName("gridLayout_3")
         self.tabWidget = QtWidgets.QTabWidget(self.centralwidget)
+        self.tabWidget.setMinimumSize(QtCore.QSize(400, 0))
         self.tabWidget.setObjectName("tabWidget")
         self.tab_2 = QtWidgets.QWidget()
         self.tab_2.setObjectName("tab_2")
@@ -45,7 +46,7 @@ class Ui_MainWindow(object):
         self.verticalLayout.addWidget(self.widget)
         self.gridLayout_2.addLayout(self.verticalLayout, 0, 0, 1, 1)
         self.tabWidget.addTab(self.tab, "")
-        self.horizontalLayout.addWidget(self.tabWidget)
+        self.gridLayout_3.addWidget(self.tabWidget, 0, 0, 1, 1)
         self.centralWidget = QtWidgets.QWidget(self.centralwidget)
         sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
         sizePolicy.setHorizontalStretch(0)
@@ -54,11 +55,11 @@ class Ui_MainWindow(object):
         self.centralWidget.setSizePolicy(sizePolicy)
         self.centralWidget.setMinimumSize(QtCore.QSize(500, 0))
         self.centralWidget.setObjectName("centralWidget")
-        self.horizontalLayout.addWidget(self.centralWidget)
-        self.gridLayout.addLayout(self.horizontalLayout, 1, 0, 1, 1)
+        self.gridLayout_3.addWidget(self.centralWidget, 0, 1, 1, 1)
+        self.gridLayout.addLayout(self.gridLayout_3, 1, 0, 1, 1)
         MainWindow.setCentralWidget(self.centralwidget)
         self.menubar = QtWidgets.QMenuBar(MainWindow)
-        self.menubar.setGeometry(QtCore.QRect(0, 0, 1141, 19))
+        self.menubar.setGeometry(QtCore.QRect(0, 0, 1163, 19))
         self.menubar.setObjectName("menubar")
         self.menuFile = QtWidgets.QMenu(self.menubar)
         self.menuFile.setObjectName("menuFile")
@@ -66,10 +67,6 @@ class Ui_MainWindow(object):
         self.statusbar = QtWidgets.QStatusBar(MainWindow)
         self.statusbar.setObjectName("statusbar")
         MainWindow.setStatusBar(self.statusbar)
-        self.actionShow_Filewriter_JSON = QtWidgets.QAction(MainWindow)
-        self.actionShow_Filewriter_JSON.setObjectName("actionShow_Filewriter_JSON")
-        self.actionHide_JSON_Pane = QtWidgets.QAction(MainWindow)
-        self.actionHide_JSON_Pane.setObjectName("actionHide_JSON_Pane")
         self.actionOpen_NeXus_file = QtWidgets.QAction(MainWindow)
         self.actionOpen_NeXus_file.setObjectName("actionOpen_NeXus_file")
         self.actionExport_to_NeXus_file = QtWidgets.QAction(MainWindow)
@@ -82,7 +79,7 @@ class Ui_MainWindow(object):
         self.menubar.addAction(self.menuFile.menuAction())
 
         self.retranslateUi(MainWindow)
-        self.tabWidget.setCurrentIndex(1)
+        self.tabWidget.setCurrentIndex(0)
         QtCore.QMetaObject.connectSlotsByName(MainWindow)
 
     def retranslateUi(self, MainWindow):
@@ -91,8 +88,6 @@ class Ui_MainWindow(object):
         self.tabWidget.setTabText(self.tabWidget.indexOf(self.tab_2), QtWidgets.QApplication.translate("MainWindow", "Components", None, -1))
         self.tabWidget.setTabText(self.tabWidget.indexOf(self.tab), QtWidgets.QApplication.translate("MainWindow", "NeXus File Layout", None, -1))
         self.menuFile.setTitle(QtWidgets.QApplication.translate("MainWindow", "File", None, -1))
-        self.actionShow_Filewriter_JSON.setText(QtWidgets.QApplication.translate("MainWindow", "Show Filewriter JSON", None, -1))
-        self.actionHide_JSON_Pane.setText(QtWidgets.QApplication.translate("MainWindow", "Hide JSON Pane", None, -1))
         self.actionOpen_NeXus_file.setText(QtWidgets.QApplication.translate("MainWindow", "Open NeXus file", None, -1))
         self.actionExport_to_NeXus_file.setText(QtWidgets.QApplication.translate("MainWindow", "Export to NeXus file", None, -1))
         self.actionExport_to_Filewriter_JSON.setText(QtWidgets.QApplication.translate("MainWindow", "Export to Filewriter JSON", None, -1))

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -3,7 +3,7 @@
 # Form implementation generated from reading ui file 'mainwindow.ui',
 # licensing of 'mainwindow.ui' applies.
 #
-# Created: Thu May 30 12:13:15 2019
+# Created: Thu May 30 12:14:26 2019
 #      by: pyside2-uic  running on PySide2 5.12.1
 #
 # WARNING! All changes made in this file will be lost!
@@ -47,15 +47,15 @@ class Ui_MainWindow(object):
         self.gridLayout_2.addLayout(self.verticalLayout, 0, 0, 1, 1)
         self.tabWidget.addTab(self.tab, "")
         self.gridLayout_3.addWidget(self.tabWidget, 0, 0, 1, 1)
-        self.centralWidget = QtWidgets.QWidget(self.centralwidget)
+        self.sceneWidget = QtWidgets.QWidget(self.centralwidget)
         sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
-        sizePolicy.setHeightForWidth(self.centralWidget.sizePolicy().hasHeightForWidth())
-        self.centralWidget.setSizePolicy(sizePolicy)
-        self.centralWidget.setMinimumSize(QtCore.QSize(500, 0))
-        self.centralWidget.setObjectName("centralWidget")
-        self.gridLayout_3.addWidget(self.centralWidget, 0, 1, 1, 1)
+        sizePolicy.setHeightForWidth(self.sceneWidget.sizePolicy().hasHeightForWidth())
+        self.sceneWidget.setSizePolicy(sizePolicy)
+        self.sceneWidget.setMinimumSize(QtCore.QSize(500, 0))
+        self.sceneWidget.setObjectName("sceneWidget")
+        self.gridLayout_3.addWidget(self.sceneWidget, 0, 1, 1, 1)
         self.gridLayout.addLayout(self.gridLayout_3, 1, 0, 1, 1)
         MainWindow.setCentralWidget(self.centralwidget)
         self.menubar = QtWidgets.QMenuBar(MainWindow)

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -3,7 +3,7 @@
 # Form implementation generated from reading ui file 'mainwindow.ui',
 # licensing of 'mainwindow.ui' applies.
 #
-# Created: Thu May 30 10:46:06 2019
+# Created: Thu May 30 11:03:47 2019
 #      by: pyside2-uic  running on PySide2 5.12.1
 #
 # WARNING! All changes made in this file will be lost!
@@ -30,9 +30,9 @@ class Ui_MainWindow(object):
         self.pushButton = QtWidgets.QPushButton(self.tab_2)
         self.pushButton.setObjectName("pushButton")
         self.verticalLayout_2.addWidget(self.pushButton)
-        self.listWidget = QtWidgets.QListWidget(self.tab_2)
-        self.listWidget.setObjectName("listWidget")
-        self.verticalLayout_2.addWidget(self.listWidget)
+        self.listView = QtWidgets.QListView(self.tab_2)
+        self.listView.setObjectName("listView")
+        self.verticalLayout_2.addWidget(self.listView)
         self.tabWidget.addTab(self.tab_2, "")
         self.tab = QtWidgets.QWidget()
         self.tab.setObjectName("tab")

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+
+# Form implementation generated from reading ui file 'mainwindow.ui',
+# licensing of 'mainwindow.ui' applies.
+#
+# Created: Thu May 30 09:51:17 2019
+#      by: pyside2-uic  running on PySide2 5.12.1
+#
+# WARNING! All changes made in this file will be lost!
+
+from PySide2 import QtCore, QtGui, QtWidgets
+
+class Ui_MainWindow(object):
+    def setupUi(self, MainWindow):
+        MainWindow.setObjectName("MainWindow")
+        MainWindow.resize(1141, 599)
+        self.centralwidget = QtWidgets.QWidget(MainWindow)
+        self.centralwidget.setObjectName("centralwidget")
+        self.gridLayout = QtWidgets.QGridLayout(self.centralwidget)
+        self.gridLayout.setObjectName("gridLayout")
+        self.horizontalLayout = QtWidgets.QHBoxLayout()
+        self.horizontalLayout.setSizeConstraint(QtWidgets.QLayout.SetDefaultConstraint)
+        self.horizontalLayout.setObjectName("horizontalLayout")
+        self.tabWidget = QtWidgets.QTabWidget(self.centralwidget)
+        self.tabWidget.setObjectName("tabWidget")
+        self.tab = QtWidgets.QWidget()
+        self.tab.setObjectName("tab")
+        self.verticalLayoutWidget = QtWidgets.QWidget(self.tab)
+        self.verticalLayoutWidget.setGeometry(QtCore.QRect(0, 0, 502, 481))
+        self.verticalLayoutWidget.setObjectName("verticalLayoutWidget")
+        self.verticalLayout = QtWidgets.QVBoxLayout(self.verticalLayoutWidget)
+        self.verticalLayout.setContentsMargins(0, 0, 0, 0)
+        self.verticalLayout.setObjectName("verticalLayout")
+        self.pushButton = QtWidgets.QPushButton(self.verticalLayoutWidget)
+        self.pushButton.setObjectName("pushButton")
+        self.verticalLayout.addWidget(self.pushButton)
+        self.widget = QtWidgets.QWidget(self.verticalLayoutWidget)
+        self.widget.setObjectName("widget")
+        self.verticalLayout.addWidget(self.widget)
+        self.tabWidget.addTab(self.tab, "")
+        self.tab_2 = QtWidgets.QWidget()
+        self.tab_2.setObjectName("tab_2")
+        self.verticalLayout_2 = QtWidgets.QVBoxLayout(self.tab_2)
+        self.verticalLayout_2.setObjectName("verticalLayout_2")
+        self.listWidget = QtWidgets.QListWidget(self.tab_2)
+        self.listWidget.setObjectName("listWidget")
+        self.verticalLayout_2.addWidget(self.listWidget)
+        self.tabWidget.addTab(self.tab_2, "")
+        self.horizontalLayout.addWidget(self.tabWidget)
+        self.quickWidget = QQuickWidget(self.centralwidget)
+        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
+        sizePolicy.setHorizontalStretch(0)
+        sizePolicy.setVerticalStretch(0)
+        sizePolicy.setHeightForWidth(self.quickWidget.sizePolicy().hasHeightForWidth())
+        self.quickWidget.setSizePolicy(sizePolicy)
+        self.quickWidget.setMinimumSize(QtCore.QSize(500, 0))
+        self.quickWidget.setResizeMode(QQuickWidget.SizeRootObjectToView)
+        self.quickWidget.setSource(QtCore.QUrl("file:./view.qml"))
+        self.quickWidget.setObjectName("quickWidget")
+        self.horizontalLayout.addWidget(self.quickWidget)
+        self.gridLayout.addLayout(self.horizontalLayout, 0, 0, 1, 1)
+        MainWindow.setCentralWidget(self.centralwidget)
+        self.menubar = QtWidgets.QMenuBar(MainWindow)
+        self.menubar.setGeometry(QtCore.QRect(0, 0, 1141, 19))
+        self.menubar.setObjectName("menubar")
+        self.menuFile = QtWidgets.QMenu(self.menubar)
+        self.menuFile.setObjectName("menuFile")
+        MainWindow.setMenuBar(self.menubar)
+        self.statusbar = QtWidgets.QStatusBar(MainWindow)
+        self.statusbar.setObjectName("statusbar")
+        MainWindow.setStatusBar(self.statusbar)
+        self.actionShow_Filewriter_JSON = QtWidgets.QAction(MainWindow)
+        self.actionShow_Filewriter_JSON.setObjectName("actionShow_Filewriter_JSON")
+        self.actionHide_JSON_Pane = QtWidgets.QAction(MainWindow)
+        self.actionHide_JSON_Pane.setObjectName("actionHide_JSON_Pane")
+        self.actionOpen_NeXus_file = QtWidgets.QAction(MainWindow)
+        self.actionOpen_NeXus_file.setObjectName("actionOpen_NeXus_file")
+        self.actionExport_to_NeXus_file = QtWidgets.QAction(MainWindow)
+        self.actionExport_to_NeXus_file.setObjectName("actionExport_to_NeXus_file")
+        self.actionExport_to_Filewriter_JSON = QtWidgets.QAction(MainWindow)
+        self.actionExport_to_Filewriter_JSON.setObjectName("actionExport_to_Filewriter_JSON")
+        self.menuFile.addAction(self.actionOpen_NeXus_file)
+        self.menuFile.addAction(self.actionExport_to_NeXus_file)
+        self.menuFile.addAction(self.actionExport_to_Filewriter_JSON)
+        self.menubar.addAction(self.menuFile.menuAction())
+
+        self.retranslateUi(MainWindow)
+        self.tabWidget.setCurrentIndex(1)
+        QtCore.QMetaObject.connectSlotsByName(MainWindow)
+
+    def retranslateUi(self, MainWindow):
+        MainWindow.setWindowTitle(QtWidgets.QApplication.translate("MainWindow", "NeXus Constructor", None, -1))
+        self.pushButton.setText(QtWidgets.QApplication.translate("MainWindow", "Add component", None, -1))
+        self.tabWidget.setTabText(self.tabWidget.indexOf(self.tab), QtWidgets.QApplication.translate("MainWindow", "NeXus File Layout", None, -1))
+        self.tabWidget.setTabText(self.tabWidget.indexOf(self.tab_2), QtWidgets.QApplication.translate("MainWindow", "Components", None, -1))
+        self.menuFile.setTitle(QtWidgets.QApplication.translate("MainWindow", "File", None, -1))
+        self.actionShow_Filewriter_JSON.setText(QtWidgets.QApplication.translate("MainWindow", "Show Filewriter JSON", None, -1))
+        self.actionHide_JSON_Pane.setText(QtWidgets.QApplication.translate("MainWindow", "Hide JSON Pane", None, -1))
+        self.actionOpen_NeXus_file.setText(QtWidgets.QApplication.translate("MainWindow", "Open NeXus file", None, -1))
+        self.actionExport_to_NeXus_file.setText(QtWidgets.QApplication.translate("MainWindow", "Export to NeXus file", None, -1))
+        self.actionExport_to_Filewriter_JSON.setText(QtWidgets.QApplication.translate("MainWindow", "Export to Filewriter JSON", None, -1))
+
+from QtQuickWidgets.QQuickWidget import QQuickWidget

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -9,6 +9,7 @@
 # WARNING! All changes made in this file will be lost!
 
 from PySide2 import QtCore, QtGui, QtWidgets
+from PySide2.QtQuickWidgets import QQuickWidget
 
 class Ui_MainWindow(object):
     def setupUi(self, MainWindow):
@@ -100,4 +101,3 @@ class Ui_MainWindow(object):
         self.actionExport_to_NeXus_file.setText(QtWidgets.QApplication.translate("MainWindow", "Export to NeXus file", None, -1))
         self.actionExport_to_Filewriter_JSON.setText(QtWidgets.QApplication.translate("MainWindow", "Export to Filewriter JSON", None, -1))
 
-from QtQuickWidgets.QQuickWidget import QQuickWidget

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -3,7 +3,7 @@
 # Form implementation generated from reading ui file 'mainwindow.ui',
 # licensing of 'mainwindow.ui' applies.
 #
-# Created: Thu May 30 12:14:26 2019
+# Created: Thu May 30 12:27:57 2019
 #      by: pyside2-uic  running on PySide2 5.12.1
 #
 # WARNING! All changes made in this file will be lost!
@@ -13,7 +13,7 @@ from PySide2 import QtCore, QtGui, QtWidgets
 class Ui_MainWindow(object):
     def setupUi(self, MainWindow):
         MainWindow.setObjectName("MainWindow")
-        MainWindow.resize(1163, 712)
+        MainWindow.resize(1263, 712)
         self.centralwidget = QtWidgets.QWidget(MainWindow)
         self.centralwidget.setObjectName("centralwidget")
         self.gridLayout = QtWidgets.QGridLayout(self.centralwidget)
@@ -22,7 +22,7 @@ class Ui_MainWindow(object):
         self.gridLayout_3.setSizeConstraint(QtWidgets.QLayout.SetDefaultConstraint)
         self.gridLayout_3.setObjectName("gridLayout_3")
         self.tabWidget = QtWidgets.QTabWidget(self.centralwidget)
-        self.tabWidget.setMinimumSize(QtCore.QSize(400, 0))
+        self.tabWidget.setMinimumSize(QtCore.QSize(500, 0))
         self.tabWidget.setObjectName("tabWidget")
         self.tab_2 = QtWidgets.QWidget()
         self.tab_2.setObjectName("tab_2")
@@ -49,17 +49,17 @@ class Ui_MainWindow(object):
         self.gridLayout_3.addWidget(self.tabWidget, 0, 0, 1, 1)
         self.sceneWidget = QtWidgets.QWidget(self.centralwidget)
         sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
-        sizePolicy.setHorizontalStretch(0)
+        sizePolicy.setHorizontalStretch(1)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.sceneWidget.sizePolicy().hasHeightForWidth())
         self.sceneWidget.setSizePolicy(sizePolicy)
-        self.sceneWidget.setMinimumSize(QtCore.QSize(500, 0))
+        self.sceneWidget.setMinimumSize(QtCore.QSize(745, 0))
         self.sceneWidget.setObjectName("sceneWidget")
-        self.gridLayout_3.addWidget(self.sceneWidget, 0, 1, 1, 1)
+        self.gridLayout_3.addWidget(self.sceneWidget, 0, 1, 1, 2)
         self.gridLayout.addLayout(self.gridLayout_3, 1, 0, 1, 1)
         MainWindow.setCentralWidget(self.centralwidget)
         self.menubar = QtWidgets.QMenuBar(MainWindow)
-        self.menubar.setGeometry(QtCore.QRect(0, 0, 1163, 19))
+        self.menubar.setGeometry(QtCore.QRect(0, 0, 1263, 19))
         self.menubar.setObjectName("menubar")
         self.menuFile = QtWidgets.QMenu(self.menubar)
         self.menuFile.setObjectName("menuFile")

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1141</width>
-    <height>599</height>
+    <width>1163</width>
+    <height>712</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,14 +16,20 @@
   <widget class="QWidget" name="centralwidget">
    <layout class="QGridLayout" name="gridLayout">
     <item row="1" column="0">
-     <layout class="QHBoxLayout" name="horizontalLayout">
+     <layout class="QGridLayout" name="gridLayout_3">
       <property name="sizeConstraint">
        <enum>QLayout::SetDefaultConstraint</enum>
       </property>
-      <item>
+      <item row="0" column="0" alignment="Qt::AlignLeft">
        <widget class="QTabWidget" name="tabWidget">
+        <property name="minimumSize">
+         <size>
+          <width>400</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="currentIndex">
-         <number>1</number>
+         <number>0</number>
         </property>
         <widget class="QWidget" name="tab_2">
          <attribute name="title">
@@ -58,7 +64,7 @@
         </widget>
        </widget>
       </item>
-      <item>
+      <item row="0" column="1">
        <widget class="QWidget" name="centralWidget" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -83,7 +89,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>1141</width>
+     <width>1163</width>
      <height>19</height>
     </rect>
    </property>
@@ -98,16 +104,6 @@
    <addaction name="menuFile"/>
   </widget>
   <widget class="QStatusBar" name="statusbar"/>
-  <action name="actionShow_Filewriter_JSON">
-   <property name="text">
-    <string>Show Filewriter JSON</string>
-   </property>
-  </action>
-  <action name="actionHide_JSON_Pane">
-   <property name="text">
-    <string>Hide JSON Pane</string>
-   </property>
-  </action>
   <action name="actionOpen_NeXus_file">
    <property name="text">
     <string>Open NeXus file</string>

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -15,7 +15,7 @@
   </property>
   <widget class="QWidget" name="centralwidget">
    <layout class="QGridLayout" name="gridLayout">
-    <item row="0" column="0">
+    <item row="1" column="0">
      <layout class="QHBoxLayout" name="horizontalLayout">
       <property name="sizeConstraint">
        <enum>QLayout::SetDefaultConstraint</enum>
@@ -23,8 +23,25 @@
       <item>
        <widget class="QTabWidget" name="tabWidget">
         <property name="currentIndex">
-         <number>1</number>
+         <number>0</number>
         </property>
+        <widget class="QWidget" name="tab_2">
+         <attribute name="title">
+          <string>Components</string>
+         </attribute>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <item>
+           <widget class="QPushButton" name="pushButton">
+            <property name="text">
+             <string>Add component</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QListWidget" name="listWidget"/>
+          </item>
+         </layout>
+        </widget>
         <widget class="QWidget" name="tab">
          <attribute name="title">
           <string>NeXus File Layout</string>
@@ -40,27 +57,10 @@
           </property>
           <layout class="QVBoxLayout" name="verticalLayout">
            <item>
-            <widget class="QPushButton" name="pushButton">
-             <property name="text">
-              <string>Add component</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QWidget" name="widget" native="true"/>
            </item>
           </layout>
          </widget>
-        </widget>
-        <widget class="QWidget" name="tab_2">
-         <attribute name="title">
-          <string>Components</string>
-         </attribute>
-         <layout class="QVBoxLayout" name="verticalLayout_2">
-          <item>
-           <widget class="QListWidget" name="listWidget"/>
-          </item>
-         </layout>
         </widget>
        </widget>
       </item>

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -65,7 +65,7 @@
        </widget>
       </item>
       <item>
-       <widget class="QQuickWidget" name="quickWidget">
+       <widget class="QWidget" name="centralWidget">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
           <horstretch>0</horstretch>
@@ -77,14 +77,6 @@
           <width>500</width>
           <height>0</height>
          </size>
-        </property>
-        <property name="resizeMode">
-         <enum>QQuickWidget::SizeRootObjectToView</enum>
-        </property>
-        <property name="source">
-         <url>
-          <string>file:./view.qml</string>
-         </url>
         </property>
        </widget>
       </item>

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -38,7 +38,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QListWidget" name="listWidget"/>
+           <widget class="QListView" name="listView"/>
           </item>
          </layout>
         </widget>
@@ -65,7 +65,7 @@
        </widget>
       </item>
       <item>
-       <widget class="QWidget" name="centralWidget">
+       <widget class="QWidget" name="centralWidget" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
           <horstretch>0</horstretch>
@@ -130,13 +130,6 @@
    </property>
   </action>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>QQuickWidget</class>
-   <extends>QWidget</extends>
-   <header>QtQuickWidgets/QQuickWidget</header>
-  </customwidget>
- </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -23,7 +23,7 @@
       <item>
        <widget class="QTabWidget" name="tabWidget">
         <property name="currentIndex">
-         <number>0</number>
+         <number>1</number>
         </property>
         <widget class="QWidget" name="tab_2">
          <attribute name="title">
@@ -46,21 +46,15 @@
          <attribute name="title">
           <string>NeXus File Layout</string>
          </attribute>
-         <widget class="QWidget" name="verticalLayoutWidget">
-          <property name="geometry">
-           <rect>
-            <x>0</x>
-            <y>0</y>
-            <width>502</width>
-            <height>481</height>
-           </rect>
-          </property>
-          <layout class="QVBoxLayout" name="verticalLayout">
-           <item>
-            <widget class="QWidget" name="widget" native="true"/>
-           </item>
-          </layout>
-         </widget>
+         <layout class="QGridLayout" name="gridLayout_2">
+          <item row="0" column="0">
+           <layout class="QVBoxLayout" name="verticalLayout">
+            <item>
+             <widget class="QWidget" name="widget" native="true"/>
+            </item>
+           </layout>
+          </item>
+         </layout>
         </widget>
        </widget>
       </item>

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1163</width>
+    <width>1263</width>
     <height>712</height>
    </rect>
   </property>
@@ -20,11 +20,11 @@
       <property name="sizeConstraint">
        <enum>QLayout::SetDefaultConstraint</enum>
       </property>
-      <item row="0" column="0" alignment="Qt::AlignLeft">
+      <item row="0" column="0">
        <widget class="QTabWidget" name="tabWidget">
         <property name="minimumSize">
          <size>
-          <width>400</width>
+          <width>500</width>
           <height>0</height>
          </size>
         </property>
@@ -64,17 +64,17 @@
         </widget>
        </widget>
       </item>
-      <item row="0" column="1">
+      <item row="0" column="1" colspan="2">
        <widget class="QWidget" name="sceneWidget" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-          <horstretch>0</horstretch>
+          <horstretch>1</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
         <property name="minimumSize">
          <size>
-          <width>500</width>
+          <width>745</width>
           <height>0</height>
          </size>
         </property>
@@ -89,7 +89,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>1163</width>
+     <width>1263</width>
      <height>19</height>
     </rect>
    </property>

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MainWindow</class>
+ <widget class="QMainWindow" name="MainWindow">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1141</width>
+    <height>599</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>NeXus Constructor</string>
+  </property>
+  <widget class="QWidget" name="centralwidget">
+   <layout class="QGridLayout" name="gridLayout">
+    <item row="0" column="0">
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="sizeConstraint">
+       <enum>QLayout::SetDefaultConstraint</enum>
+      </property>
+      <item>
+       <widget class="QTabWidget" name="tabWidget">
+        <property name="currentIndex">
+         <number>1</number>
+        </property>
+        <widget class="QWidget" name="tab">
+         <attribute name="title">
+          <string>NeXus File Layout</string>
+         </attribute>
+         <widget class="QWidget" name="verticalLayoutWidget">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>502</width>
+            <height>481</height>
+           </rect>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout">
+           <item>
+            <widget class="QPushButton" name="pushButton">
+             <property name="text">
+              <string>Add component</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QWidget" name="widget" native="true"/>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+        <widget class="QWidget" name="tab_2">
+         <attribute name="title">
+          <string>Components</string>
+         </attribute>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <item>
+           <widget class="QListWidget" name="listWidget"/>
+          </item>
+         </layout>
+        </widget>
+       </widget>
+      </item>
+      <item>
+       <widget class="QQuickWidget" name="quickWidget">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>500</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="resizeMode">
+         <enum>QQuickWidget::SizeRootObjectToView</enum>
+        </property>
+        <property name="source">
+         <url>
+          <string>file:./view.qml</string>
+         </url>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QMenuBar" name="menubar">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>1141</width>
+     <height>19</height>
+    </rect>
+   </property>
+   <widget class="QMenu" name="menuFile">
+    <property name="title">
+     <string>File</string>
+    </property>
+    <addaction name="actionOpen_NeXus_file"/>
+    <addaction name="actionExport_to_NeXus_file"/>
+    <addaction name="actionExport_to_Filewriter_JSON"/>
+   </widget>
+   <addaction name="menuFile"/>
+  </widget>
+  <widget class="QStatusBar" name="statusbar"/>
+  <action name="actionShow_Filewriter_JSON">
+   <property name="text">
+    <string>Show Filewriter JSON</string>
+   </property>
+  </action>
+  <action name="actionHide_JSON_Pane">
+   <property name="text">
+    <string>Hide JSON Pane</string>
+   </property>
+  </action>
+  <action name="actionOpen_NeXus_file">
+   <property name="text">
+    <string>Open NeXus file</string>
+   </property>
+  </action>
+  <action name="actionExport_to_NeXus_file">
+   <property name="text">
+    <string>Export to NeXus file</string>
+   </property>
+  </action>
+  <action name="actionExport_to_Filewriter_JSON">
+   <property name="text">
+    <string>Export to Filewriter JSON</string>
+   </property>
+  </action>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QQuickWidget</class>
+   <extends>QWidget</extends>
+   <header>QtQuickWidgets/QQuickWidget</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -65,7 +65,7 @@
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="QWidget" name="centralWidget" native="true">
+       <widget class="QWidget" name="sceneWidget" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
           <horstretch>0</horstretch>


### PR DESCRIPTION
### Issue


### Description of work

Converts the main window to use widgets. 

note: this breaks everything, hence why merging into switch_to_widgets, the umbrella branch for the widgets conversion

### Acceptance Criteria 

- window looks normal
- scales and resizes as normal 
- (optional) file bar is in native position on mac (#227) - @SkyToGround could you check this please? 

### UI tests

None apply to this so ignore them

### Nominate for Group Code Review

- [ ] Nominate for code review 
