### PR TITLE
317: 3D view should use the components model to display 3D models

### DIFF
--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -165,7 +165,7 @@ class AddComponentDialog(Ui_AddComponentDialog):
             geometry_model.cylinder.axis_direction.setX(self.cylinderXLineEdit.value())
             geometry_model.cylinder.axis_direction.setY(self.cylinderYLineEdit.value())
             geometry_model.cylinder.axis_direction.setZ(self.cylinderZLineEdit.value())
-        if self.meshRadioButton.isChecked():
+        elif self.meshRadioButton.isChecked():
             geometry_model = OFFModel()
             geometry_model.set_units(self.unitsLineEdit.text())
             geometry_model.set_file(self.geometry_file_name)

--- a/nexus_constructor/instrument_view.py
+++ b/nexus_constructor/instrument_view.py
@@ -78,6 +78,7 @@ class InstrumentView(QWidget):
 
         self.component_meshes = {}
         self.component_entities = {}
+        self.component_translations = {}
 
     def add_component(self, name, geometry):
         """
@@ -92,6 +93,24 @@ class InstrumentView(QWidget):
 
         self.component_meshes[name] = mesh
         self.component_entities[name] = entity
+
+    def delete_component(self, name):
+        """
+        Delete a component from the InstrumentView by removing the components and entities from the dictionaries.
+        :param name: The name of the component.
+        """
+        try:
+            del self.component_entities[name]
+            del self.component_meshes[name]
+            del self.component_translations[name]
+        except KeyError:
+            pass
+
+    def add_translation(self, name):
+        pass
+
+    def delete_translation(self, name):
+        pass
 
     @staticmethod
     def set_material_properties(material, ambient, diffuse, alpha=None):

--- a/nexus_constructor/instrument_view.py
+++ b/nexus_constructor/instrument_view.py
@@ -4,7 +4,11 @@ from PySide2.Qt3DCore import Qt3DCore
 from PySide2.QtCore import QPropertyAnimation
 from PySide2.QtGui import QVector3D, QColor, QMatrix4x4
 from nexus_constructor.neutron_animation_controller import NeutronAnimationController
-from nexus_constructor.geometry_types import CylindricalGeometry
+from nexus_constructor.geometry_types import (
+    CylindricalGeometry,
+    NoShapeGeometry,
+    OFFGeometry,
+)
 
 
 class InstrumentView(QWidget):
@@ -78,15 +82,28 @@ class InstrumentView(QWidget):
         # Insert the beam cylinder last. This ensures that the semi-transparency works correctly.
         self.setup_beam_cylinder()
 
-        self.components = {}
+        self.component_meshes = {}
+        self.component_entities = {}
 
     def add_component(self, name, geometry):
 
-        if type(geometry) is CylindricalGeometry:
-            print("This is a cylinder geometry.")
+        geometry_type = type(geometry)
+
+        if geometry_type is CylindricalGeometry:
+            pass
+        elif geometry_type is OFFGeometry:
+            pass
         else:
-            print("This is not a cylinder geometry.")
-            print(type(geometry))
+            entity = Qt3DCore.QEntity(self.root_entity)
+            mesh = Qt3DExtras.QCuboidMesh()
+            self.set_cube_mesh_dimensions(mesh, 1, 1, 1)
+            material = self.grey_material
+
+        entity.addComponent(mesh)
+        entity.addComponent(material)
+
+        self.component_meshes[name] = mesh
+        self.component_entities[name] = entity
 
     @staticmethod
     def set_material_properties(material, ambient, diffuse, alpha=None):

--- a/nexus_constructor/instrument_view.py
+++ b/nexus_constructor/instrument_view.py
@@ -26,8 +26,6 @@ class InstrumentView(QWidget):
         # Enable the camera to see a large distance by giving it a small nearView and large farView
         self.view.camera().lens().setPerspectiveProjection(45, 16 / 9, 0.01, 1000)
 
-        self.nexus_model = None
-
         # Set the camera view centre as the origin and position the camera so that it looks down at the neutron beam
         self.view.camera().setPosition(QVector3D(6, 8, 30))
         self.view.camera().setViewCenter(QVector3D(0, 0, 0))
@@ -61,7 +59,7 @@ class InstrumentView(QWidget):
             "animations": [],
         }
 
-        for i in range(self.num_neutrons):
+        for _ in range(self.num_neutrons):
             self.neutron_objects["entities"].append(Qt3DCore.QEntity(self.root_entity))
             self.neutron_objects["meshes"].append(Qt3DExtras.QSphereMesh())
             self.neutron_objects["transforms"].append(Qt3DCore.QTransform())
@@ -82,12 +80,15 @@ class InstrumentView(QWidget):
         self.component_entities = {}
 
     def add_component(self, name, geometry):
-
+        """
+        Add a component to the instrument view given a name and its geometry.
+        :param name: The name of the component.
+        :param geometry: The geometry information of the component that is used to create a mesh.
+        """
         entity = Qt3DCore.QEntity(self.root_entity)
         mesh = OffMesh(geometry.off_geometry)
 
-        entity.addComponent(mesh)
-        entity.addComponent(self.grey_material)
+        self.add_components_to_entity(entity, [mesh, self.grey_material])
 
         self.component_meshes[name] = mesh
         self.component_entities[name] = entity

--- a/nexus_constructor/instrument_view.py
+++ b/nexus_constructor/instrument_view.py
@@ -85,10 +85,9 @@ class InstrumentView(QWidget):
 
         entity = Qt3DCore.QEntity(self.root_entity)
         mesh = OffMesh(geometry.off_geometry)
-        material = self.grey_material
 
         entity.addComponent(mesh)
-        entity.addComponent(material)
+        entity.addComponent(self.grey_material)
 
         self.component_meshes[name] = mesh
         self.component_entities[name] = entity

--- a/nexus_constructor/instrument_view.py
+++ b/nexus_constructor/instrument_view.py
@@ -105,7 +105,10 @@ class InstrumentView(QWidget):
         except KeyError:
             print("Unable to delete component " + name + " because it doesn't exist.")
 
-        # Remove translations separately from error message because a component can exist without them.
+        """
+        Remove translations separately from error message because a component without translations can exist. The
+        KeyError should only appear when the entity/mesh don't exist.
+        """
         try:
             del self.component_translations[name]
         except KeyError:

--- a/nexus_constructor/instrument_view.py
+++ b/nexus_constructor/instrument_view.py
@@ -25,6 +25,8 @@ class InstrumentView(QWidget):
         # Enable the camera to see a large distance by giving it a small nearView and large farView
         self.view.camera().lens().setPerspectiveProjection(45, 16 / 9, 0.01, 1000)
 
+        self.nexus_model = None
+
         # Set the camera view centre as the origin and position the camera so that it looks down at the neutron beam
         self.view.camera().setPosition(QVector3D(6, 8, 30))
         self.view.camera().setViewCenter(QVector3D(0, 0, 0))
@@ -74,6 +76,8 @@ class InstrumentView(QWidget):
 
         # Insert the beam cylinder last. This ensures that the semi-transparency works correctly.
         self.setup_beam_cylinder()
+
+        self.components = {}
 
     @staticmethod
     def set_material_properties(material, ambient, diffuse, alpha=None):

--- a/nexus_constructor/instrument_view.py
+++ b/nexus_constructor/instrument_view.py
@@ -97,9 +97,12 @@ class InstrumentView(QWidget):
 
     def delete_component(self, name):
         """
-        Delete a component from the InstrumentView by removing the components and entities from the dictionaries.
+        Delete a component from the InstrumentView by removing the components and entity from the dictionaries.
         :param name: The name of the component.
         """
+
+        self.component_entities[name].setParent(None)
+
         try:
             del self.component_entities[name]
             del self.component_meshes[name]
@@ -182,7 +185,7 @@ class InstrumentView(QWidget):
     @staticmethod
     def add_components_to_entity(entity, components):
         """
-        Takes a QEntity and gives it all of the components that are contained in a list.
+        Takes a QEntity and gives it all of the QComponents that are contained in a list.
         """
         for component in components:
             entity.addComponent(component)

--- a/nexus_constructor/instrument_view.py
+++ b/nexus_constructor/instrument_view.py
@@ -4,11 +4,8 @@ from PySide2.Qt3DCore import Qt3DCore
 from PySide2.QtCore import QPropertyAnimation
 from PySide2.QtGui import QVector3D, QColor, QMatrix4x4
 from nexus_constructor.neutron_animation_controller import NeutronAnimationController
-from nexus_constructor.geometry_types import (
-    CylindricalGeometry,
-    NoShapeGeometry,
-    OFFGeometry,
-)
+from nexus_constructor.qml_models.geometry_models import CylinderModel, OFFModel
+from nexus_constructor.qml_models.instrument_model import generate_mesh
 
 
 class InstrumentView(QWidget):
@@ -85,19 +82,11 @@ class InstrumentView(QWidget):
         self.component_meshes = {}
         self.component_entities = {}
 
-    def add_component(self, name, geometry):
+    def add_component(self, name, component):
 
-        geometry_type = type(geometry)
-
-        if geometry_type is CylindricalGeometry:
-            pass
-        elif geometry_type is OFFGeometry:
-            pass
-        else:
-            entity = Qt3DCore.QEntity(self.root_entity)
-            mesh = Qt3DExtras.QCuboidMesh()
-            self.set_cube_mesh_dimensions(mesh, 1, 1, 1)
-            material = self.grey_material
+        entity = Qt3DCore.QEntity(self.root_entity)
+        mesh = generate_mesh(component)
+        material = self.grey_material
 
         entity.addComponent(mesh)
         entity.addComponent(material)

--- a/nexus_constructor/instrument_view.py
+++ b/nexus_constructor/instrument_view.py
@@ -76,7 +76,7 @@ class InstrumentView(QWidget):
         # Dictionaries for component-related objects also to prevent them from going out of scope
         self.component_meshes = {}
         self.component_entities = {}
-        self.component_translations = {}
+        self.component_transformations = {}
 
         # Insert the beam cylinder last. This ensures that the semi-transparency works correctly.
         self.setup_beam_cylinder()
@@ -106,22 +106,22 @@ class InstrumentView(QWidget):
         except KeyError:
             print("Unable to delete component " + name + " because it doesn't exist.")
 
-        self._delete_all_translations(name)
+        self._delete_all_transformations(name)
 
-    def _delete_all_translations(self, component_name):
+    def _delete_all_transformations(self, component_name):
         """
-        Deletes all the translations associated with a component. Doesn't print a message in the case of a KeyError
-        because components without translations can exist.
+        Deletes all the transformations associated with a component. Doesn't print a message in the case of a KeyError
+        because components without transformations can exist.
         """
         try:
-            del self.component_translations[component_name]
+            del self.component_transformations[component_name]
         except KeyError:
             pass
 
-    def add_translation(self, component_name, translation_name):
+    def add_transformation(self, component_name, transformation_name):
         pass
 
-    def delete_single_translation(self, component_name, translation_name):
+    def delete_single_transformation(self, component_name, transformation_name):
         pass
 
     @staticmethod

--- a/nexus_constructor/instrument_view.py
+++ b/nexus_constructor/instrument_view.py
@@ -111,10 +111,10 @@ class InstrumentView(QWidget):
         except KeyError:
             pass
 
-    def add_translation(self, name):
+    def add_translation(self, component_name, translation_name):
         pass
 
-    def delete_translation(self, name):
+    def delete_translation(self, component_name, translation_name):
         pass
 
     @staticmethod

--- a/nexus_constructor/instrument_view.py
+++ b/nexus_constructor/instrument_view.py
@@ -107,7 +107,7 @@ class InstrumentView(QWidget):
 
         """
         Remove translations separately from error message because a component without translations can exist. The
-        KeyError should only appear when the entity/mesh don't exist.
+        KeyError should only be considered a problem when the entity/mesh don't exist.
         """
         try:
             del self.component_translations[name]

--- a/nexus_constructor/instrument_view.py
+++ b/nexus_constructor/instrument_view.py
@@ -90,7 +90,7 @@ class InstrumentView(QWidget):
         entity = Qt3DCore.QEntity(self.root_entity)
         mesh = OffMesh(geometry.off_geometry)
 
-        self.add_components_to_entity(entity, [mesh, self.grey_material])
+        self.add_qcomponents_to_entity(entity, [mesh, self.grey_material])
 
         self.component_meshes[name] = mesh
         self.component_entities[name] = entity
@@ -178,12 +178,12 @@ class InstrumentView(QWidget):
         Sets up the cube that represents a sample in the 3D view by giving the cube entity a mesh and a material.
         """
         self.set_cube_mesh_dimensions(self.cube_mesh, *self.sample_cube_dimensions)
-        self.add_components_to_entity(
+        self.add_qcomponents_to_entity(
             self.cube_entity, [self.cube_mesh, self.red_material]
         )
 
     @staticmethod
-    def add_components_to_entity(entity, components):
+    def add_qcomponents_to_entity(entity, components):
         """
         Takes a QEntity and gives it all of the QComponents that are contained in a list.
         """
@@ -224,7 +224,7 @@ class InstrumentView(QWidget):
             self.cylinder_mesh, 2.5, self.cylinder_length, 2
         )
         self.set_beam_transform(self.cylinder_transform)
-        self.add_components_to_entity(
+        self.add_qcomponents_to_entity(
             self.cylinder_entity,
             [self.cylinder_mesh, self.beam_material, self.cylinder_transform],
         )
@@ -301,7 +301,7 @@ class InstrumentView(QWidget):
             )
             self.neutron_objects["animations"].append(neutron_animation)
 
-            self.add_components_to_entity(
+            self.add_qcomponents_to_entity(
                 self.neutron_objects["entities"][i],
                 [
                     self.neutron_objects["meshes"][i],

--- a/nexus_constructor/instrument_view.py
+++ b/nexus_constructor/instrument_view.py
@@ -106,19 +106,22 @@ class InstrumentView(QWidget):
         except KeyError:
             print("Unable to delete component " + name + " because it doesn't exist.")
 
+        self._delete_all_translations(name)
+
+    def _delete_all_translations(self, component_name):
         """
-        Remove translations separately from error message because a component without translations can exist. The
-        KeyError should only be considered a problem when the entity/mesh don't exist.
+        Deletes all the translations associated with a component. Doesn't print a message in the case of a KeyError
+        because components without translations can exist.
         """
         try:
-            del self.component_translations[name]
+            del self.component_translations[component_name]
         except KeyError:
             pass
 
     def add_translation(self, component_name, translation_name):
         pass
 
-    def delete_translation(self, component_name, translation_name):
+    def delete_single_translation(self, component_name, translation_name):
         pass
 
     @staticmethod

--- a/nexus_constructor/instrument_view.py
+++ b/nexus_constructor/instrument_view.py
@@ -4,8 +4,7 @@ from PySide2.Qt3DCore import Qt3DCore
 from PySide2.QtCore import QPropertyAnimation
 from PySide2.QtGui import QVector3D, QColor, QMatrix4x4
 from nexus_constructor.neutron_animation_controller import NeutronAnimationController
-from nexus_constructor.qml_models.geometry_models import CylinderModel, OFFModel
-from nexus_constructor.qml_models.instrument_model import generate_mesh
+from nexus_constructor.off_renderer import OffMesh
 
 
 class InstrumentView(QWidget):
@@ -82,10 +81,10 @@ class InstrumentView(QWidget):
         self.component_meshes = {}
         self.component_entities = {}
 
-    def add_component(self, name, component):
+    def add_component(self, name, geometry):
 
         entity = Qt3DCore.QEntity(self.root_entity)
-        mesh = generate_mesh(component)
+        mesh = OffMesh(geometry.off_geometry)
         material = self.grey_material
 
         entity.addComponent(mesh)

--- a/nexus_constructor/instrument_view.py
+++ b/nexus_constructor/instrument_view.py
@@ -73,12 +73,13 @@ class InstrumentView(QWidget):
         self.cylinder_mesh = Qt3DExtras.QCylinderMesh()
         self.cylinder_transform = Qt3DCore.QTransform()
 
-        # Insert the beam cylinder last. This ensures that the semi-transparency works correctly.
-        self.setup_beam_cylinder()
-
+        # Dictionaries for component-related objects also to prevent them from going out of scope
         self.component_meshes = {}
         self.component_entities = {}
         self.component_translations = {}
+
+        # Insert the beam cylinder last. This ensures that the semi-transparency works correctly.
+        self.setup_beam_cylinder()
 
     def add_component(self, name, geometry):
         """

--- a/nexus_constructor/instrument_view.py
+++ b/nexus_constructor/instrument_view.py
@@ -102,6 +102,11 @@ class InstrumentView(QWidget):
         try:
             del self.component_entities[name]
             del self.component_meshes[name]
+        except KeyError:
+            print("Unable to delete component " + name + " because it doesn't exist.")
+
+        # Remove translations separately from error message because a component can exist without them.
+        try:
             del self.component_translations[name]
         except KeyError:
             pass

--- a/nexus_constructor/instrument_view.py
+++ b/nexus_constructor/instrument_view.py
@@ -4,6 +4,7 @@ from PySide2.Qt3DCore import Qt3DCore
 from PySide2.QtCore import QPropertyAnimation
 from PySide2.QtGui import QVector3D, QColor, QMatrix4x4
 from nexus_constructor.neutron_animation_controller import NeutronAnimationController
+from nexus_constructor.geometry_types import CylindricalGeometry
 
 
 class InstrumentView(QWidget):
@@ -78,6 +79,14 @@ class InstrumentView(QWidget):
         self.setup_beam_cylinder()
 
         self.components = {}
+
+    def add_component(self, name, geometry):
+
+        if type(geometry) is CylindricalGeometry:
+            print("This is a cylinder geometry.")
+        else:
+            print("This is not a cylinder geometry.")
+            print(type(geometry))
 
     @staticmethod
     def set_material_properties(material, ambient, diffuse, alpha=None):

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -40,6 +40,8 @@ class MainWindow(Ui_MainWindow):
         self.listView.setModel(self.nexus_wrapper.get_component_list())
         self.nexus_wrapper.set_instrument_view(self.sceneWidget)
 
+        self.nexus_wrapper.component_added.connect(self.sceneWidget.add_component)
+
         self.set_up_warning_window()
 
         self.widget.setVisible(True)

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -38,7 +38,6 @@ class MainWindow(Ui_MainWindow):
         self.nexus_wrapper.file_changed.connect(self.update_nexus_file_structure_view)
         self.verticalLayout.addWidget(self.widget)
         self.listView.setModel(self.nexus_wrapper.get_component_list())
-        self.nexus_wrapper.set_instrument_view(self.sceneWidget)
 
         self.nexus_wrapper.component_added.connect(self.sceneWidget.add_component)
 

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -39,6 +39,9 @@ class MainWindow(Ui_MainWindow):
         self.verticalLayout.addWidget(self.widget)
         self.listView.setModel(self.nexus_wrapper.get_component_list())
 
+        # self.sceneWidget.setModel(self.nexus_wrapper)
+        self.nexus_wrapper.set_instrument_view(self.sceneWidget)
+
         self.set_up_warning_window()
 
         self.widget.setVisible(True)

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -38,8 +38,6 @@ class MainWindow(Ui_MainWindow):
         self.nexus_wrapper.file_changed.connect(self.update_nexus_file_structure_view)
         self.verticalLayout.addWidget(self.widget)
         self.listView.setModel(self.nexus_wrapper.get_component_list())
-
-        # self.sceneWidget.setModel(self.nexus_wrapper)
         self.nexus_wrapper.set_instrument_view(self.sceneWidget)
 
         self.set_up_warning_window()

--- a/nexus_constructor/nexus_wrapper.py
+++ b/nexus_constructor/nexus_wrapper.py
@@ -112,7 +112,8 @@ class NexusWrapper(QObject):
         component_group = instrument_group.create_group(component_name)
         component_group.attrs["NX_class"] = component_type
 
-        self.instrument_view.add_component(component_name, geometry)
+        self.instrument_view.add_component(component_name, geometry.get_geometry())
+
 
         self._emit_file()
 

--- a/nexus_constructor/nexus_wrapper.py
+++ b/nexus_constructor/nexus_wrapper.py
@@ -114,7 +114,6 @@ class NexusWrapper(QObject):
 
         self.instrument_view.add_component(component_name, geometry.get_geometry())
 
-
         self._emit_file()
 
     def get_component_geometry(self, component_name):

--- a/nexus_constructor/nexus_wrapper.py
+++ b/nexus_constructor/nexus_wrapper.py
@@ -116,9 +116,6 @@ class NexusWrapper(QObject):
 
         self._emit_file()
 
-    def get_component_geometry(self, component_name):
-        pass
-
 
 def convert_name_with_spaces(component_name):
     return component_name.replace(" ", "_")

--- a/nexus_constructor/nexus_wrapper.py
+++ b/nexus_constructor/nexus_wrapper.py
@@ -112,8 +112,6 @@ class NexusWrapper(QObject):
         component_group = instrument_group.create_group(component_name)
         component_group.attrs["NX_class"] = component_type
 
-        self.instrument_view.add_component(component_name, geometry.get_geometry())
-
         self._emit_file()
 
     def get_component_geometry(self, component_name):

--- a/nexus_constructor/nexus_wrapper.py
+++ b/nexus_constructor/nexus_wrapper.py
@@ -41,6 +41,11 @@ class NexusWrapper(QObject):
         self._emit_file()
 
     def set_instrument_view(self, instrument_view):
+        """
+        Set the instrument view of the NeXus wrapper so that the instrument view can be informed when a component is
+        added/deleted/changed.
+        :param instrument_view: The instrument view for visualising the components.
+        """
         self.instrument_view = instrument_view
 
     def _emit_file(self):

--- a/nexus_constructor/nexus_wrapper.py
+++ b/nexus_constructor/nexus_wrapper.py
@@ -22,6 +22,7 @@ class NexusWrapper(QObject):
 
     # Signal that indicates the nexus file has been changed in some way
     file_changed = Signal("QVariant")
+    component_added = Signal(str, "QVariant")
 
     def __init__(self, filename="nexus-constructor"):
         super().__init__()
@@ -117,7 +118,7 @@ class NexusWrapper(QObject):
         component_group = instrument_group.create_group(component_name)
         component_group.attrs["NX_class"] = component_type
 
-        self.instrument_view.add_component(component_name, geometry.get_geometry())
+        self.component_added.emit(component_name, geometry.get_geometry())
 
         self._emit_file()
 

--- a/nexus_constructor/nexus_wrapper.py
+++ b/nexus_constructor/nexus_wrapper.py
@@ -35,8 +35,13 @@ class NexusWrapper(QObject):
         self.instrument_group = self.entry_group.create_group("instrument")
         self.instrument_group.attrs["NX_class"] = "NXinstrument"
 
+        self.instrument_view = None
+
         self.components_list_model = instrument_model.InstrumentModel()
         self._emit_file()
+
+    def set_instrument_view(self, instrument_view):
+        self.instrument_view = instrument_view
 
     def _emit_file(self):
         """
@@ -107,7 +112,12 @@ class NexusWrapper(QObject):
         component_group = instrument_group.create_group(component_name)
         component_group.attrs["NX_class"] = component_type
 
+        self.instrument_view.add_component(component_name, geometry)
+
         self._emit_file()
+
+    def get_component_geometry(self, component_name):
+        pass
 
 
 def convert_name_with_spaces(component_name):

--- a/nexus_constructor/nexus_wrapper.py
+++ b/nexus_constructor/nexus_wrapper.py
@@ -112,6 +112,8 @@ class NexusWrapper(QObject):
         component_group = instrument_group.create_group(component_name)
         component_group.attrs["NX_class"] = component_type
 
+        self.instrument_view.add_component(component_name, geometry.get_geometry())
+
         self._emit_file()
 
     def get_component_geometry(self, component_name):

--- a/nexus_constructor/nexus_wrapper.py
+++ b/nexus_constructor/nexus_wrapper.py
@@ -36,18 +36,8 @@ class NexusWrapper(QObject):
         self.instrument_group = self.entry_group.create_group("instrument")
         self.instrument_group.attrs["NX_class"] = "NXinstrument"
 
-        self.instrument_view = None
-
         self.components_list_model = instrument_model.InstrumentModel()
         self._emit_file()
-
-    def set_instrument_view(self, instrument_view):
-        """
-        Set the instrument view of the NeXus wrapper so that the instrument view can be informed when a component is
-        added/deleted/changed.
-        :param instrument_view: The instrument view for visualising the components.
-        """
-        self.instrument_view = instrument_view
 
     def _emit_file(self):
         """

--- a/tests/test_instrument_view.py
+++ b/tests/test_instrument_view.py
@@ -69,7 +69,7 @@ def test_GIVEN_components_WHEN_calling_add_components_to_entity_THEN_components_
     mock_components = [Mock() for _ in range(4)]
     calls = [call(mock_component) for mock_component in mock_components]
 
-    InstrumentView.add_components_to_entity(mock_entity, mock_components)
+    InstrumentView.add_qcomponents_to_entity(mock_entity, mock_components)
 
     mock_entity.addComponent.assert_has_calls(calls)
 

--- a/tests/test_instrument_view.py
+++ b/tests/test_instrument_view.py
@@ -1,5 +1,4 @@
 from PySide2.QtGui import QMatrix4x4, QVector3D
-from PySide2.QtWidgets import QWidget
 
 from nexus_constructor.instrument_view import InstrumentView
 from mock import Mock, call

--- a/tests/test_instrument_view.py
+++ b/tests/test_instrument_view.py
@@ -1,4 +1,5 @@
 from PySide2.QtGui import QMatrix4x4, QVector3D
+from PySide2.QtWidgets import QWidget
 
 from nexus_constructor.instrument_view import InstrumentView
 from mock import Mock, call

--- a/tests/test_nexus_wrapper.py
+++ b/tests/test_nexus_wrapper.py
@@ -1,5 +1,6 @@
 from nexus_constructor.nexus_wrapper import NexusWrapper, convert_name_with_spaces
 from nexus_constructor.qml_models.geometry_models import NoShapeModel
+from mock import Mock
 
 
 def test_GIVEN_nothing_WHEN_creating_nexus_wrapper_THEN_file_contains_entry_group_with_correct_nx_class():
@@ -28,6 +29,7 @@ def test_GIVEN_component_WHEN_adding_component_THEN_components_list_contains_add
     component_type = "NXcrystal"
     name = "test_crystal"
     description = "shiny"
+    wrapper.instrument_view = Mock()
     wrapper.add_component(component_type, name, description, NoShapeModel())
 
     component_list = wrapper.get_component_list().components
@@ -44,6 +46,7 @@ def test_GIVEN_component_WHEN_adding_component_THEN_nexus_file_contains_added_co
     component_type = "NXcrystal"
     name = "test_crystal"
     description = "shiny"
+    wrapper.instrument_view = Mock()
     wrapper.add_component(component_type, name, description, NoShapeModel())
 
     assert name in wrapper.instrument_group

--- a/tests/test_nexus_wrapper.py
+++ b/tests/test_nexus_wrapper.py
@@ -29,7 +29,6 @@ def test_GIVEN_component_WHEN_adding_component_THEN_components_list_contains_add
     component_type = "NXcrystal"
     name = "test_crystal"
     description = "shiny"
-    wrapper.instrument_view = Mock()
     wrapper.add_component(component_type, name, description, NoShapeModel())
 
     component_list = wrapper.get_component_list().components
@@ -46,7 +45,6 @@ def test_GIVEN_component_WHEN_adding_component_THEN_nexus_file_contains_added_co
     component_type = "NXcrystal"
     name = "test_crystal"
     description = "shiny"
-    wrapper.instrument_view = Mock()
     wrapper.add_component(component_type, name, description, NoShapeModel())
 
     assert name in wrapper.instrument_group

--- a/tests/test_nexus_wrapper.py
+++ b/tests/test_nexus_wrapper.py
@@ -1,6 +1,5 @@
 from nexus_constructor.nexus_wrapper import NexusWrapper, convert_name_with_spaces
 from nexus_constructor.qml_models.geometry_models import NoShapeModel
-from mock import Mock
 
 
 def test_GIVEN_nothing_WHEN_creating_nexus_wrapper_THEN_file_contains_entry_group_with_correct_nx_class():


### PR DESCRIPTION
### Issue

Closes #317

### Description of work

Allows "Add Component" to add different components types to the 3D view. At the moment there is no way of deleting components/transformations or adding transformations. I have implemented a method for deleting components that worked when I tried it out. Once the button for deleting components gets added that should be simple to connect to the `delete_component` method.

### Acceptance Criteria 

Add components with different geometry types (none, cylinder, mesh) and check that they appear in the instrument view. Also check that changing the units gives the correct result.

### UI tests

n/a

### Nominate for Group Code Review

- [ ] Nominate for code review 
