### PR TITLE
Widgets: fields

### DIFF
--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -85,10 +85,6 @@ class AddComponentDialog(Ui_AddComponentDialog):
         )
         self.fileLineEdit.validator().is_valid.connect(self.ok_validator.set_file_valid)
 
-        self.fieldsLineEdit.setCompleter(
-            QCompleter(QStringListModel(self.possible_fields))
-        )
-
         self.componentTypeComboBox.currentIndexChanged.connect(self.on_nx_class_changed)
 
         # Set default geometry type and show the related fields.
@@ -127,8 +123,6 @@ class AddComponentDialog(Ui_AddComponentDialog):
         self.addFieldButton.clicked.connect(self.add_field)
 
     def add_field(self):
-        self.fieldsLineEdit.clear()
-
         item = QListWidgetItem()
         field = FieldWidget(self.possible_fields)
         item.setSizeHint(field.sizeHint())
@@ -145,7 +139,6 @@ class AddComponentDialog(Ui_AddComponentDialog):
             self.componentTypeComboBox.currentText() in PIXEL_COMPONENT_TYPES
         )
         self.possible_fields = self.nx_classes[self.componentTypeComboBox.currentText()]
-        self.fieldsLineEdit.completer().setModel(QStringListModel(self.possible_fields))
 
     def mesh_file_picker(self):
         """
@@ -198,5 +191,5 @@ class AddComponentDialog(Ui_AddComponentDialog):
         component_name = self.nameLineEdit.text()
         description = self.descriptionPlainTextEdit.text()
         self.nexus_wrapper.add_component(
-            nx_class, component_name, description, self.generate_geometry_model()
+            nx_class, component_name, description, self.generate_geometry_model(), self.listWidget
         )

--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -3,6 +3,7 @@ from enum import Enum
 from PySide2.QtCore import QUrl, QStringListModel
 from PySide2.QtWidgets import QCompleter
 
+from nexus_constructor.component_fields import FieldWidget
 from nexus_constructor.qml_models.geometry_models import (
     CylinderModel,
     OFFModel,
@@ -41,6 +42,7 @@ class AddComponentDialog(Ui_AddComponentDialog):
             os.path.abspath(os.path.join(os.curdir, "definitions"))
         )
         self.possible_fields = self.nx_classes["NXpinhole"]
+        self.fields = dict()
 
     def setupUi(self, parent_dialog):
         """ Sets up push buttons and validators for the add component window. """
@@ -125,12 +127,12 @@ class AddComponentDialog(Ui_AddComponentDialog):
         self.unitsLineEdit.validator().validate(self.unitsLineEdit.text(), 0)
         self.addFieldButton.clicked.connect(self.add_field)
 
+
     def add_field(self):
-        print(self.fieldsLineEdit.text())
-        print(
-            f"possible fields for {self.componentTypeComboBox.currentText()}: {self.possible_fields}"
-        )
         self.fieldsLineEdit.clear()
+        self.fields[self.fieldsLineEdit.text()] = FieldWidget(
+            self.possible_fields, parent=self.fieldsListView
+        )
 
     def on_nx_class_changed(self):
         self.webEngineView.setUrl(

--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -126,7 +126,6 @@ class AddComponentDialog(Ui_AddComponentDialog):
         self.unitsLineEdit.validator().validate(self.unitsLineEdit.text(), 0)
         self.addFieldButton.clicked.connect(self.add_field)
 
-
     def add_field(self):
         self.fieldsLineEdit.clear()
 

--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -116,6 +116,11 @@ class AddComponentDialog(Ui_AddComponentDialog):
 
         # Validate the default value set by the UI
         self.unitsLineEdit.validator().validate(self.unitsLineEdit.text(), 0)
+        self.addFieldButton.clicked.connect(self.add_field)
+
+    def add_field(self):
+        print(self.fieldsLineEdit.text())
+        self.fieldsLineEdit.clear()
 
     def on_nx_class_changed(self):
         self.webEngineView.setUrl(

--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -1,6 +1,8 @@
 from enum import Enum
 
-from PySide2.QtCore import QUrl
+from PySide2.QtCore import QUrl, QStringListModel
+from PySide2.QtWidgets import QCompleter
+
 from nexus_constructor.qml_models.geometry_models import (
     CylinderModel,
     OFFModel,
@@ -38,6 +40,7 @@ class AddComponentDialog(Ui_AddComponentDialog):
         self.nx_classes = make_dictionary_of_class_definitions(
             os.path.abspath(os.path.join(os.curdir, "definitions"))
         )
+        self.possible_fields = self.nx_classes["NXpinhole"]
 
     def setupUi(self, parent_dialog):
         """ Sets up push buttons and validators for the add component window. """
@@ -81,6 +84,10 @@ class AddComponentDialog(Ui_AddComponentDialog):
         )
         self.fileLineEdit.validator().is_valid.connect(self.ok_validator.set_file_valid)
 
+        self.fieldsLineEdit.setCompleter(
+            QCompleter(QStringListModel(self.possible_fields))
+        )
+
         self.componentTypeComboBox.currentIndexChanged.connect(self.on_nx_class_changed)
 
         # Set default geometry type and show the related fields.
@@ -120,6 +127,9 @@ class AddComponentDialog(Ui_AddComponentDialog):
 
     def add_field(self):
         print(self.fieldsLineEdit.text())
+        print(
+            f"possible fields for {self.componentTypeComboBox.currentText()}: {self.possible_fields}"
+        )
         self.fieldsLineEdit.clear()
 
     def on_nx_class_changed(self):
@@ -131,6 +141,8 @@ class AddComponentDialog(Ui_AddComponentDialog):
         self.pixelOptionsBox.setVisible(
             self.componentTypeComboBox.currentText() in PIXEL_COMPONENT_TYPES
         )
+        self.possible_fields = self.nx_classes[self.componentTypeComboBox.currentText()]
+        self.fieldsLineEdit.completer().setModel(QStringListModel(self.possible_fields))
 
     def mesh_file_picker(self):
         """

--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 from PySide2.QtCore import QUrl, QStringListModel
-from PySide2.QtWidgets import QCompleter
+from PySide2.QtWidgets import QCompleter, QListWidgetItem
 
 from nexus_constructor.component_fields import FieldWidget
 from nexus_constructor.qml_models.geometry_models import (
@@ -42,7 +42,6 @@ class AddComponentDialog(Ui_AddComponentDialog):
             os.path.abspath(os.path.join(os.curdir, "definitions"))
         )
         self.possible_fields = self.nx_classes["NXpinhole"]
-        self.fields = dict()
 
     def setupUi(self, parent_dialog):
         """ Sets up push buttons and validators for the add component window. """
@@ -130,9 +129,12 @@ class AddComponentDialog(Ui_AddComponentDialog):
 
     def add_field(self):
         self.fieldsLineEdit.clear()
-        self.fields[self.fieldsLineEdit.text()] = FieldWidget(
-            self.possible_fields, parent=self.fieldsListView
-        )
+
+        item = QListWidgetItem()
+        field = FieldWidget(self.possible_fields)
+        item.setSizeHint(field.sizeHint())
+        self.listWidget.addItem(item)
+        self.listWidget.setItemWidget(item, field)
 
     def on_nx_class_changed(self):
         self.webEngineView.setUrl(

--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -41,7 +41,6 @@ class AddComponentDialog(Ui_AddComponentDialog):
         self.nx_classes = make_dictionary_of_class_definitions(
             os.path.abspath(os.path.join(os.curdir, "definitions"))
         )
-        self.possible_fields = self.nx_classes["NXpinhole"]
 
     def setupUi(self, parent_dialog):
         """ Sets up push buttons and validators for the add component window. """
@@ -121,6 +120,9 @@ class AddComponentDialog(Ui_AddComponentDialog):
         # Validate the default value set by the UI
         self.unitsLineEdit.validator().validate(self.unitsLineEdit.text(), 0)
         self.addFieldButton.clicked.connect(self.add_field)
+
+        # Set default possible fields based on default nx_class
+        self.on_nx_class_changed()
 
     def add_field(self):
         item = QListWidgetItem()

--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
-from PySide2.QtCore import QUrl, QStringListModel
-from PySide2.QtWidgets import QCompleter, QListWidgetItem
+from PySide2.QtCore import QUrl
+from PySide2.QtWidgets import QListWidgetItem
 
 from nexus_constructor.component_fields import FieldWidget
 from nexus_constructor.qml_models.geometry_models import (

--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -191,5 +191,9 @@ class AddComponentDialog(Ui_AddComponentDialog):
         component_name = self.nameLineEdit.text()
         description = self.descriptionPlainTextEdit.text()
         self.nexus_wrapper.add_component(
-            nx_class, component_name, description, self.generate_geometry_model(), self.listWidget
+            nx_class,
+            component_name,
+            description,
+            self.generate_geometry_model(),
+            self.listWidget,
         )

--- a/nexus_constructor/component_fields.py
+++ b/nexus_constructor/component_fields.py
@@ -5,11 +5,13 @@ from PySide2.QtWidgets import (
     QFrame,
     QComboBox,
     QSizePolicy,
+    QDialog,
 )
 from enum import Enum
 from PySide2.QtWidgets import QCompleter, QLineEdit, QSizePolicy
 from PySide2.QtCore import QStringListModel, Qt
 from typing import List
+import h5py
 
 _field_types = {}
 
@@ -51,7 +53,6 @@ class FieldWidget(QFrame):
         super(FieldWidget, self).__init__(parent)
 
         self.field_name_edit = FieldNameLineEdit(possible_field_names)
-        # self.field_name_edit.editingFinished.connect(self.new_field_name_entered)
 
         self.field_type_combo = QComboBox()
         self.field_type_combo.addItems([item.value for item in FieldType])
@@ -69,10 +70,13 @@ class FieldWidget(QFrame):
         self.edit_button.setMinimumWidth(edit_button_size)
         self.edit_button.setMaximumWidth(edit_button_size)
         self.edit_button.setSizePolicy(fix_horizontal_size)
+        self.edit_button.clicked.connect(self.show_edit_dialog)
 
-        # http://docs.h5py.org/en/stable/faq.html#what-datatypes-are-supported
+        # TODO: add value types http://docs.h5py.org/en/stable/faq.html#what-datatypes-are-supported
+        # TODO: add validator for value types
         self.value_type_combo = QComboBox()
 
+        # TODO: actually remove stuff - use signal to listview?
         self.remove_button = QPushButton("Remove")
 
         self.layout = QHBoxLayout()
@@ -113,3 +117,22 @@ class FieldWidget(QFrame):
         self.nx_class_combo.setVisible(show_nx_class_combo)
         self.edit_button.setVisible(show_edit_button)
         self.value_type_combo.setVisible(show_value_type_combo)
+
+    def show_edit_dialog(self):
+        self.edit_dialog = QDialog()
+        self.edit_dialog.show()
+        if self.field_type_combo.currentText() == FieldType.scalar_dataset.value:
+            # TODO: show scalar edit panel
+            pass
+        elif self.field_type_combo.currentText() == FieldType.array_dataset.value:
+            # TODO: show array edit panel
+            pass
+        elif self.field_type_combo.currentText() == FieldType.kafka_stream.value:
+            # TODO: show kafka stream panel
+            pass
+        elif self.field_type_combo.currentText() == FieldType.link.value:
+            # TODO: show link panel
+            pass
+        elif self.field_type_combo.currentText() == FieldType.nx_class.value:
+            # TODO: show nx class panels
+            pass

--- a/nexus_constructor/component_fields.py
+++ b/nexus_constructor/component_fields.py
@@ -7,11 +7,11 @@ from PySide2.QtWidgets import (
     QSizePolicy,
     QDialog,
 )
-from enum import Enum
 from PySide2.QtWidgets import QCompleter, QLineEdit, QSizePolicy
 from PySide2.QtCore import QStringListModel, Qt
 from typing import List
 import h5py
+from nexus_constructor.field_type import DatasetType, FieldType
 
 _field_types = {}
 
@@ -38,28 +38,6 @@ class FieldNameLineEdit(QLineEdit):
             self.completer().complete()
         else:
             super().keyPressEvent(event)
-
-
-class FieldType(Enum):
-    scalar_dataset = "Scalar dataset"
-    array_dataset = "Array dataset"
-    kafka_stream = "Kafka stream"
-    link = "Link"
-    nx_class = "NX class/group"
-
-
-class DatasetType(Enum):
-    byte = "Byte"
-    ubyte = "Unsigned Byte"
-    short = "Short"
-    ushort = "Unsigned Short"
-    int = "Integer"
-    uint = "Unsigned Integer"
-    long = "Long"
-    ulong = "Unsigned Long"
-    float = "Float"
-    double = "Double"
-    string = "String"
 
 
 class FieldWidget(QFrame):

--- a/nexus_constructor/component_fields.py
+++ b/nexus_constructor/component_fields.py
@@ -86,6 +86,9 @@ class FieldWidget(QFrame):
         self.setFrameShadow(QFrame.Raised)
         self.setFrameShape(QFrame.StyledPanel)
 
+        # Set the layout for the default field type
+        self.field_type_changed()
+
     def field_type_changed(self):
         if self.field_type_combo.currentText() == FieldType.scalar_dataset.value:
             self.set_visibility(True, False, False, True)

--- a/nexus_constructor/component_fields.py
+++ b/nexus_constructor/component_fields.py
@@ -1,16 +1,7 @@
-from PySide2.QtWidgets import (
-    QLineEdit,
-    QPushButton,
-    QHBoxLayout,
-    QFrame,
-    QComboBox,
-    QSizePolicy,
-    QDialog,
-)
+from PySide2.QtWidgets import QPushButton, QHBoxLayout, QFrame, QComboBox, QDialog
 from PySide2.QtWidgets import QCompleter, QLineEdit, QSizePolicy
 from PySide2.QtCore import QStringListModel, Qt
 from typing import List
-import h5py
 from nexus_constructor.field_type import DatasetType, FieldType
 
 _field_types = {}

--- a/nexus_constructor/component_fields.py
+++ b/nexus_constructor/component_fields.py
@@ -1,0 +1,115 @@
+from PySide2.QtWidgets import (
+    QLineEdit,
+    QPushButton,
+    QHBoxLayout,
+    QFrame,
+    QComboBox,
+    QSizePolicy,
+)
+from enum import Enum
+from PySide2.QtWidgets import QCompleter, QLineEdit, QSizePolicy
+from PySide2.QtCore import QStringListModel, Qt
+from typing import List
+
+_field_types = {}
+
+
+class FieldNameLineEdit(QLineEdit):
+    def __init__(self, possible_field_names: List[str]):
+        super().__init__()
+        self.setCompleter(QCompleter())
+        model = QStringListModel()
+        model.setStringList(possible_field_names)
+        self.completer().setModel(model)
+        self.setPlaceholderText("Enter name of new field")
+        self.setMinimumWidth(200)
+        fix_horizontal_size = QSizePolicy()
+        fix_horizontal_size.setHorizontalPolicy(QSizePolicy.Fixed)
+        self.setSizePolicy(fix_horizontal_size)
+
+    def focusInEvent(self, event):
+        self.completer().complete()
+        super(FieldNameLineEdit, self).focusInEvent(event)
+
+    def keyPressEvent(self, event):
+        if event.key() == Qt.Key_Down:
+            self.completer().complete()
+        else:
+            super().keyPressEvent(event)
+
+
+class FieldType(Enum):
+    scalar_dataset = "Scalar dataset"
+    array_dataset = "Array dataset"
+    kafka_stream = "Kafka stream"
+    link = "Link"
+    nx_class = "NX class/group"
+
+
+class FieldWidget(QFrame):
+    def __init__(self, possible_field_names: List[str], parent=None):
+        super(FieldWidget, self).__init__(parent)
+
+        self.field_name_edit = FieldNameLineEdit(possible_field_names)
+        # self.field_name_edit.editingFinished.connect(self.new_field_name_entered)
+
+        self.field_type_combo = QComboBox()
+        self.field_type_combo.addItems([item.value for item in FieldType])
+        self.field_type_combo.currentIndexChanged.connect(self.field_type_changed)
+        self.field_type_combo.setMinimumWidth(100)
+        fix_horizontal_size = QSizePolicy()
+        fix_horizontal_size.setHorizontalPolicy(QSizePolicy.Fixed)
+        self.field_type_combo.setSizePolicy(fix_horizontal_size)
+
+        self.value_line_edit = QLineEdit()
+        self.nx_class_combo = QComboBox()
+
+        self.edit_button = QPushButton("Edit")
+        edit_button_size = 50
+        self.edit_button.setMinimumWidth(edit_button_size)
+        self.edit_button.setMaximumWidth(edit_button_size)
+        self.edit_button.setSizePolicy(fix_horizontal_size)
+
+        # http://docs.h5py.org/en/stable/faq.html#what-datatypes-are-supported
+        self.value_type_combo = QComboBox()
+
+        self.remove_button = QPushButton("Remove")
+
+        self.layout = QHBoxLayout()
+        self.layout.addWidget(self.field_name_edit)
+        self.layout.addWidget(self.field_type_combo)
+        self.layout.addWidget(self.value_line_edit)
+        self.layout.addWidget(self.nx_class_combo)
+        self.layout.addWidget(self.edit_button)
+        self.layout.addWidget(self.value_type_combo)
+        self.layout.addWidget(self.remove_button)
+
+        self.layout.setAlignment(Qt.AlignLeft)
+        self.setLayout(self.layout)
+
+        self.setFrameShadow(QFrame.Raised)
+        self.setFrameShape(QFrame.StyledPanel)
+
+    def field_type_changed(self):
+        if self.field_type_combo.currentText() == FieldType.scalar_dataset.value:
+            self.set_visibility(True, False, False, True)
+        elif self.field_type_combo.currentText() == FieldType.array_dataset.value:
+            self.set_visibility(False, False, True, True)
+        elif self.field_type_combo.currentText() == FieldType.kafka_stream.value:
+            self.set_visibility(False, False, True, False)
+        elif self.field_type_combo.currentText() == FieldType.link.value:
+            self.set_visibility(True, False, False, False)
+        elif self.field_type_combo.currentText() == FieldType.nx_class.value:
+            self.set_visibility(False, True, False, False)
+
+    def set_visibility(
+        self,
+        show_value_line_edit,
+        show_nx_class_combo,
+        show_edit_button,
+        show_value_type_combo,
+    ):
+        self.value_line_edit.setVisible(show_value_line_edit)
+        self.nx_class_combo.setVisible(show_nx_class_combo)
+        self.edit_button.setVisible(show_edit_button)
+        self.value_type_combo.setVisible(show_value_type_combo)

--- a/nexus_constructor/component_fields.py
+++ b/nexus_constructor/component_fields.py
@@ -48,6 +48,20 @@ class FieldType(Enum):
     nx_class = "NX class/group"
 
 
+class DatasetType(Enum):
+    byte = "Byte"
+    ubyte = "Unsigned Byte"
+    short = "Short"
+    ushort = "Unsigned Short"
+    int = "Integer"
+    uint = "Unsigned Integer"
+    long = "Long"
+    ulong = "Unsigned Long"
+    float = "Float"
+    double = "Double"
+    string = "String"
+
+
 class FieldWidget(QFrame):
     def __init__(self, possible_field_names: List[str], parent=None):
         super(FieldWidget, self).__init__(parent)
@@ -72,11 +86,11 @@ class FieldWidget(QFrame):
         self.edit_button.setSizePolicy(fix_horizontal_size)
         self.edit_button.clicked.connect(self.show_edit_dialog)
 
-        # TODO: add value types http://docs.h5py.org/en/stable/faq.html#what-datatypes-are-supported
-        # TODO: add validator for value types
         self.value_type_combo = QComboBox()
+        self.value_type_combo.addItems([item.value for item in DatasetType])
 
         # TODO: actually remove stuff - use signal to listview?
+        # TODO: set up nx classes
         self.remove_button = QPushButton("Remove")
 
         self.layout = QHBoxLayout()

--- a/nexus_constructor/field_type.py
+++ b/nexus_constructor/field_type.py
@@ -37,7 +37,3 @@ PYTHON_TO_HDF5 = {
     DatasetType.double.value: np.double,
     DatasetType.string.value: object,
 }
-
-
-def get_numpy_dtype_from_dataset_type(type: str):
-    return PYTHON_TO_HDF5[type]

--- a/nexus_constructor/field_type.py
+++ b/nexus_constructor/field_type.py
@@ -1,4 +1,5 @@
 from enum import Enum
+import numpy as np
 
 
 class FieldType(Enum):
@@ -21,3 +22,18 @@ class DatasetType(Enum):
     float = "Float"
     double = "Double"
     string = "String"
+
+
+python_to_hdf5_scalar = {
+    DatasetType.byte: np.byte,
+    DatasetType.ubyte: np.ubyte,
+    DatasetType.short: np.short,
+    DatasetType.ushort: np.ushort,
+    DatasetType.int: np.intc,
+    DatasetType.uint: np.uintc,
+    DatasetType.long: np.int_,
+    DatasetType.ulong: np.uint,
+    DatasetType.float: np.single,
+    DatasetType.double: np.double,
+    DatasetType.string: object,
+}

--- a/nexus_constructor/field_type.py
+++ b/nexus_constructor/field_type.py
@@ -1,0 +1,23 @@
+from enum import Enum
+
+
+class FieldType(Enum):
+    scalar_dataset = "Scalar dataset"
+    array_dataset = "Array dataset"
+    kafka_stream = "Kafka stream"
+    link = "Link"
+    nx_class = "NX class/group"
+
+
+class DatasetType(Enum):
+    byte = "Byte"
+    ubyte = "Unsigned Byte"
+    short = "Short"
+    ushort = "Unsigned Short"
+    int = "Integer"
+    uint = "Unsigned Integer"
+    long = "Long"
+    ulong = "Unsigned Long"
+    float = "Float"
+    double = "Double"
+    string = "String"

--- a/nexus_constructor/field_type.py
+++ b/nexus_constructor/field_type.py
@@ -24,16 +24,20 @@ class DatasetType(Enum):
     string = "String"
 
 
-python_to_hdf5_scalar = {
-    DatasetType.byte: np.byte,
-    DatasetType.ubyte: np.ubyte,
-    DatasetType.short: np.short,
-    DatasetType.ushort: np.ushort,
-    DatasetType.int: np.intc,
-    DatasetType.uint: np.uintc,
-    DatasetType.long: np.int_,
-    DatasetType.ulong: np.uint,
-    DatasetType.float: np.single,
-    DatasetType.double: np.double,
-    DatasetType.string: object,
+PYTHON_TO_HDF5 = {
+    DatasetType.byte.value: np.byte,
+    DatasetType.ubyte.value: np.ubyte,
+    DatasetType.short.value: np.short,
+    DatasetType.ushort.value: np.ushort,
+    DatasetType.int.value: np.intc,
+    DatasetType.uint.value: np.uintc,
+    DatasetType.long.value: np.int_,
+    DatasetType.ulong.value: np.uint,
+    DatasetType.float.value: np.single,
+    DatasetType.double.value: np.double,
+    DatasetType.string.value: object,
 }
+
+
+def get_numpy_dtype_from_dataset_type(type: str):
+    return PYTHON_TO_HDF5[type]

--- a/nexus_constructor/nexus_wrapper.py
+++ b/nexus_constructor/nexus_wrapper.py
@@ -121,10 +121,9 @@ class NexusWrapper(QObject):
             if field_type == FieldType.scalar_dataset.value:
                 component_group.create_dataset(
                     field_name,
-                    dtype=PYTHON_TO_HDF5[dataset_type],
-                    data=int(field_widget.value_line_edit.text())
-                    if dataset_type != DatasetType.string
-                    else field_widget.value_line_edit.text(),
+                    data=PYTHON_TO_HDF5[dataset_type](
+                        field_widget.value_line_edit.text()
+                    ),
                 )
             elif field_type == FieldType.array_dataset.value:
                 # TODO: arrays

--- a/nexus_constructor/nexus_wrapper.py
+++ b/nexus_constructor/nexus_wrapper.py
@@ -1,5 +1,5 @@
 import h5py
-
+from nexus_constructor.field_type import FieldType
 from nexus_constructor.qml_models import instrument_model
 from PySide2.QtCore import Signal, QObject
 
@@ -110,8 +110,17 @@ class NexusWrapper(QObject):
         component_group.attrs["NX_class"] = component_type
 
         for i in range(0, fields.count()):
-            # TODO: do something here with the field widget
-            field_widget = fields.item(i)
+            field_widget = fields.itemWidget(fields.item(i))
+            field_type = field_widget.field_type_combo.currentText()
+            if field_type == FieldType.scalar_dataset:
+                # TODO: scalars
+                pass
+            if field_type == FieldType.array_dataset:
+                # TODO: arrays
+                pass
+            if field_type == FieldType.nx_class:
+                # TODO: nx_classes
+                pass
 
         self._emit_file()
 

--- a/nexus_constructor/nexus_wrapper.py
+++ b/nexus_constructor/nexus_wrapper.py
@@ -1,7 +1,13 @@
 import h5py
-from nexus_constructor.field_type import FieldType
+import numpy as np
+from nexus_constructor.field_type import (
+    FieldType,
+    get_numpy_dtype_from_dataset_type,
+    DatasetType,
+)
 from nexus_constructor.qml_models import instrument_model
 from PySide2.QtCore import Signal, QObject
+
 
 COMPS_IN_ENTRY = ["NXmonitor", "NXsample"]
 
@@ -113,21 +119,32 @@ class NexusWrapper(QObject):
             field_widget = fields.itemWidget(fields.item(i))
             field_type = field_widget.field_type_combo.currentText()
             field_name = field_widget.field_name_edit.text()
-            dataset_type = field_widget.field_type_combo.currentText()
+            dataset_type = field_widget.value_type_combo.currentText()
 
             if field_type == FieldType.scalar_dataset.value:
-                # TODO: convert this to a numpy dtype
-                type = dataset_type
                 component_group.create_dataset(
-                    field_name, dtype=type, data=field_widget.value_line_edit.text()
+                    field_name,
+                    dtype=get_numpy_dtype_from_dataset_type(dataset_type),
+                    data=int(field_widget.value_line_edit.text())
+                    if dataset_type != DatasetType.string
+                    else field_widget.value_line_edit.text(),
                 )
-                pass
             elif field_type == FieldType.array_dataset.value:
                 # TODO: arrays
-                type = dataset_type
-                pass
+                component_group.create_dataset(
+                    field_name,
+                    dtype=np.array(
+                        [], dtype=get_numpy_dtype_from_dataset_type(dataset_type)
+                    ),
+                )
             elif field_type == FieldType.nx_class.value:
                 # TODO: nx_classes
+                pass
+            elif field_type == FieldType.kafka_stream.value:
+                # TODO: streams
+                pass
+            elif field_type == FieldType.link:
+                # TODO: links
                 pass
 
         self._emit_file()

--- a/nexus_constructor/nexus_wrapper.py
+++ b/nexus_constructor/nexus_wrapper.py
@@ -1,6 +1,6 @@
 import h5py
 import numpy as np
-from nexus_constructor.field_type import FieldType, DatasetType, PYTHON_TO_HDF5
+from nexus_constructor.field_type import FieldType, PYTHON_TO_HDF5
 from nexus_constructor.qml_models import instrument_model
 from PySide2.QtCore import Signal, QObject
 

--- a/nexus_constructor/nexus_wrapper.py
+++ b/nexus_constructor/nexus_wrapper.py
@@ -112,13 +112,21 @@ class NexusWrapper(QObject):
         for i in range(0, fields.count()):
             field_widget = fields.itemWidget(fields.item(i))
             field_type = field_widget.field_type_combo.currentText()
-            if field_type == FieldType.scalar_dataset:
-                # TODO: scalars
+            field_name = field_widget.field_name_edit.text()
+            dataset_type = field_widget.field_type_combo.currentText()
+
+            if field_type == FieldType.scalar_dataset.value:
+                # TODO: convert this to a numpy dtype
+                type = dataset_type
+                component_group.create_dataset(
+                    field_name, dtype=type, data=field_widget.value_line_edit.text()
+                )
                 pass
-            if field_type == FieldType.array_dataset:
+            elif field_type == FieldType.array_dataset.value:
                 # TODO: arrays
+                type = dataset_type
                 pass
-            if field_type == FieldType.nx_class:
+            elif field_type == FieldType.nx_class.value:
                 # TODO: nx_classes
                 pass
 

--- a/nexus_constructor/nexus_wrapper.py
+++ b/nexus_constructor/nexus_wrapper.py
@@ -109,7 +109,7 @@ class NexusWrapper(QObject):
 
         for i in range(0, fields.count()):
             # TODO: do something here with the field widget
-            print(fields.item(i))
+            field_widget = fields.item(i)
 
         self._emit_file()
 

--- a/nexus_constructor/nexus_wrapper.py
+++ b/nexus_constructor/nexus_wrapper.py
@@ -2,8 +2,8 @@ import h5py
 import numpy as np
 from nexus_constructor.field_type import (
     FieldType,
-    get_numpy_dtype_from_dataset_type,
     DatasetType,
+    PYTHON_TO_HDF5,
 )
 from nexus_constructor.qml_models import instrument_model
 from PySide2.QtCore import Signal, QObject
@@ -124,7 +124,7 @@ class NexusWrapper(QObject):
             if field_type == FieldType.scalar_dataset.value:
                 component_group.create_dataset(
                     field_name,
-                    dtype=get_numpy_dtype_from_dataset_type(dataset_type),
+                    dtype=PYTHON_TO_HDF5[dataset_type],
                     data=int(field_widget.value_line_edit.text())
                     if dataset_type != DatasetType.string
                     else field_widget.value_line_edit.text(),
@@ -132,10 +132,7 @@ class NexusWrapper(QObject):
             elif field_type == FieldType.array_dataset.value:
                 # TODO: arrays
                 component_group.create_dataset(
-                    field_name,
-                    dtype=np.array(
-                        [], dtype=get_numpy_dtype_from_dataset_type(dataset_type)
-                    ),
+                    field_name, dtype=np.array([], dtype=PYTHON_TO_HDF5[dataset_type])
                 )
             elif field_type == FieldType.nx_class.value:
                 # TODO: nx_classes

--- a/nexus_constructor/nexus_wrapper.py
+++ b/nexus_constructor/nexus_wrapper.py
@@ -81,7 +81,9 @@ class NexusWrapper(QObject):
             print("NeXus file loaded")
             self._emit_file()
 
-    def add_component(self, component_type, component_name, description, geometry, fields):
+    def add_component(
+        self, component_type, component_name, description, geometry, fields
+    ):
         """
         Adds a component to the NeXus file and the components list.
         :param component_type: The NX Component type in string form.

--- a/nexus_constructor/nexus_wrapper.py
+++ b/nexus_constructor/nexus_wrapper.py
@@ -81,7 +81,7 @@ class NexusWrapper(QObject):
             print("NeXus file loaded")
             self._emit_file()
 
-    def add_component(self, component_type, component_name, description, geometry):
+    def add_component(self, component_type, component_name, description, geometry, fields):
         """
         Adds a component to the NeXus file and the components list.
         :param component_type: The NX Component type in string form.
@@ -106,6 +106,10 @@ class NexusWrapper(QObject):
 
         component_group = instrument_group.create_group(component_name)
         component_group.attrs["NX_class"] = component_type
+
+        for i in range(0, fields.count()):
+            # TODO: do something here with the field widget
+            print(fields.item(i))
 
         self._emit_file()
 

--- a/tests/test_nexus_wrapper.py
+++ b/tests/test_nexus_wrapper.py
@@ -2,6 +2,11 @@ from nexus_constructor.nexus_wrapper import NexusWrapper, convert_name_with_spac
 from nexus_constructor.qml_models.geometry_models import NoShapeModel
 
 
+class DummyFields:
+    def count(self):
+        return 0
+
+
 def test_GIVEN_nothing_WHEN_creating_nexus_wrapper_THEN_file_contains_entry_group_with_correct_nx_class():
     wrapper = NexusWrapper("contains_entry")
     assert wrapper.entry_group.attrs["NX_class"] == "NXentry"
@@ -28,7 +33,9 @@ def test_GIVEN_component_WHEN_adding_component_THEN_components_list_contains_add
     component_type = "NXcrystal"
     name = "test_crystal"
     description = "shiny"
-    wrapper.add_component(component_type, name, description, NoShapeModel())
+    wrapper.add_component(
+        component_type, name, description, NoShapeModel(), DummyFields()
+    )
 
     component_list = wrapper.get_component_list().components
     assert len(component_list) == 2
@@ -44,7 +51,9 @@ def test_GIVEN_component_WHEN_adding_component_THEN_nexus_file_contains_added_co
     component_type = "NXcrystal"
     name = "test_crystal"
     description = "shiny"
-    wrapper.add_component(component_type, name, description, NoShapeModel())
+    wrapper.add_component(
+        component_type, name, description, NoShapeModel(), DummyFields()
+    )
 
     assert name in wrapper.instrument_group
     component_in_nexus_file = wrapper.instrument_group[name]

--- a/ui/add_component.py
+++ b/ui/add_component.py
@@ -3,7 +3,7 @@
 # Form implementation generated from reading ui file 'add_component.ui',
 # licensing of 'add_component.ui' applies.
 #
-# Created: Thu Jun 13 16:16:47 2019
+# Created: Wed Jun 19 10:34:21 2019
 #      by: pyside2-uic  running on PySide2 5.12.3
 #
 # WARNING! All changes made in this file will be lost!
@@ -177,14 +177,17 @@ class Ui_AddComponentDialog(object):
         sizePolicy.setHeightForWidth(self.fieldsBox.sizePolicy().hasHeightForWidth())
         self.fieldsBox.setSizePolicy(sizePolicy)
         self.fieldsBox.setObjectName("fieldsBox")
-        self.verticalLayout = QtWidgets.QVBoxLayout(self.fieldsBox)
-        self.verticalLayout.setObjectName("verticalLayout")
+        self.gridLayout_5 = QtWidgets.QGridLayout(self.fieldsBox)
+        self.gridLayout_5.setObjectName("gridLayout_5")
         self.fieldsLineEdit = QtWidgets.QLineEdit(self.fieldsBox)
         self.fieldsLineEdit.setObjectName("fieldsLineEdit")
-        self.verticalLayout.addWidget(self.fieldsLineEdit)
+        self.gridLayout_5.addWidget(self.fieldsLineEdit, 0, 0, 1, 1)
+        self.addFieldButton = QtWidgets.QPushButton(self.fieldsBox)
+        self.addFieldButton.setObjectName("addFieldButton")
+        self.gridLayout_5.addWidget(self.addFieldButton, 0, 1, 1, 1)
         self.fieldsListView = QtWidgets.QListView(self.fieldsBox)
         self.fieldsListView.setObjectName("fieldsListView")
-        self.verticalLayout.addWidget(self.fieldsListView)
+        self.gridLayout_5.addWidget(self.fieldsListView, 1, 0, 1, 2)
         self.verticalLayout_2.addWidget(self.fieldsBox)
         self.verticalLayout_2.setStretch(5, 1)
         self.gridLayout_4.addLayout(self.verticalLayout_2, 0, 0, 1, 1)
@@ -228,4 +231,5 @@ class Ui_AddComponentDialog(object):
         self.unitsbox.setTitle(QtWidgets.QApplication.translate("AddComponentDialog", "Units", None, -1))
         self.unitsLineEdit.setText(QtWidgets.QApplication.translate("AddComponentDialog", "m", None, -1))
         self.fieldsBox.setTitle(QtWidgets.QApplication.translate("AddComponentDialog", "Fields", None, -1))
+        self.addFieldButton.setText(QtWidgets.QApplication.translate("AddComponentDialog", "Add Field", None, -1))
 

--- a/ui/add_component.py
+++ b/ui/add_component.py
@@ -3,7 +3,7 @@
 # Form implementation generated from reading ui file 'add_component.ui',
 # licensing of 'add_component.ui' applies.
 #
-# Created: Wed Jun 19 11:14:03 2019
+# Created: Wed Jun 19 11:26:21 2019
 #      by: pyside2-uic  running on PySide2 5.12.3
 #
 # WARNING! All changes made in this file will be lost!
@@ -179,9 +179,6 @@ class Ui_AddComponentDialog(object):
         self.fieldsBox.setObjectName("fieldsBox")
         self.gridLayout_5 = QtWidgets.QGridLayout(self.fieldsBox)
         self.gridLayout_5.setObjectName("gridLayout_5")
-        self.fieldsLineEdit = QtWidgets.QLineEdit(self.fieldsBox)
-        self.fieldsLineEdit.setObjectName("fieldsLineEdit")
-        self.gridLayout_5.addWidget(self.fieldsLineEdit, 0, 0, 1, 1)
         self.addFieldButton = QtWidgets.QPushButton(self.fieldsBox)
         self.addFieldButton.setObjectName("addFieldButton")
         self.gridLayout_5.addWidget(self.addFieldButton, 0, 1, 1, 1)

--- a/ui/add_component.py
+++ b/ui/add_component.py
@@ -3,7 +3,7 @@
 # Form implementation generated from reading ui file 'add_component.ui',
 # licensing of 'add_component.ui' applies.
 #
-# Created: Wed Jun 19 10:34:21 2019
+# Created: Wed Jun 19 11:14:03 2019
 #      by: pyside2-uic  running on PySide2 5.12.3
 #
 # WARNING! All changes made in this file will be lost!
@@ -185,9 +185,9 @@ class Ui_AddComponentDialog(object):
         self.addFieldButton = QtWidgets.QPushButton(self.fieldsBox)
         self.addFieldButton.setObjectName("addFieldButton")
         self.gridLayout_5.addWidget(self.addFieldButton, 0, 1, 1, 1)
-        self.fieldsListView = QtWidgets.QListView(self.fieldsBox)
-        self.fieldsListView.setObjectName("fieldsListView")
-        self.gridLayout_5.addWidget(self.fieldsListView, 1, 0, 1, 2)
+        self.listWidget = QtWidgets.QListWidget(self.fieldsBox)
+        self.listWidget.setObjectName("listWidget")
+        self.gridLayout_5.addWidget(self.listWidget, 1, 0, 1, 2)
         self.verticalLayout_2.addWidget(self.fieldsBox)
         self.verticalLayout_2.setStretch(5, 1)
         self.gridLayout_4.addLayout(self.verticalLayout_2, 0, 0, 1, 1)

--- a/ui/add_component.ui
+++ b/ui/add_component.ui
@@ -310,7 +310,7 @@
             </widget>
            </item>
            <item row="1" column="0" colspan="2">
-            <widget class="QListView" name="fieldsListView"/>
+            <widget class="QListWidget" name="listWidget"/>
            </item>
           </layout>
          </widget>

--- a/ui/add_component.ui
+++ b/ui/add_component.ui
@@ -299,9 +299,6 @@
            <string>Fields</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_5">
-           <item row="0" column="0">
-            <widget class="QLineEdit" name="fieldsLineEdit"/>
-           </item>
            <item row="0" column="1">
             <widget class="QPushButton" name="addFieldButton">
              <property name="text">

--- a/ui/add_component.ui
+++ b/ui/add_component.ui
@@ -298,11 +298,18 @@
           <property name="title">
            <string>Fields</string>
           </property>
-          <layout class="QVBoxLayout" name="verticalLayout">
-           <item>
+          <layout class="QGridLayout" name="gridLayout_5">
+           <item row="0" column="0">
             <widget class="QLineEdit" name="fieldsLineEdit"/>
            </item>
-           <item>
+           <item row="0" column="1">
+            <widget class="QPushButton" name="addFieldButton">
+             <property name="text">
+              <string>Add Field</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0" colspan="2">
             <widget class="QListView" name="fieldsListView"/>
            </item>
           </layout>


### PR DESCRIPTION
### Issue

Closes #304 

### Description of work

Adds a fields list widget into the add component window. This currently supports Scalar fields but nothing else, and requires dialogs for other types. I have created tickets for these. 

The field widget should have auto complete functionality when you start typing and should display any fields in the nexus base class description

### Acceptance Criteria 

Added component_fields and field_type which contain the widget and the list of types respectively.

### UI tests

N/A

### Nominate for Group Code Review

- [ ] Nominate for code review 
