### PR TITLE
Stop building executable on windows if we're no longer archiving…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -120,17 +120,17 @@ return {
                 bat """python -m pytest . -s --ignore=definitions --ignore=tests/ui_tests/
                 """
             } // stage
-            if (env.CHANGE_ID) {
-                stage("Build Executable") {
-                    bat """
-                    python setup.py build_exe"""
-                } // stage
+            // if (env.CHANGE_ID) {
+                // stage("Build Executable") {
+                    // bat """
+                    // python setup.py build_exe"""
+                // } // stage
                 // stage('Archive Executable') {
                     // def git_commit_short = scm_vars.GIT_COMMIT.take(7)
                     // powershell label: 'Archiving build folder', script: "Compress-Archive -Path .\\build -DestinationPath nexus-constructor_windows_${git_commit_short}.zip"
                     // archiveArtifacts 'nexus-constructor*.zip'
                 // } // stage
-            } // if
+            // } // if
           } // dir
       } //ws
     } // node


### PR DESCRIPTION
### Issue

None

### Description of work

Disables building the windows executable as we are no longer archiving it anyway. 

### Acceptance Criteria 

Jenkins build still passes and does not attempt to build the executable on windows. 

### UI tests

N/A

### Nominate for Group Code Review

- [ ] Nominate for code review 
