### PR TITLE
Adding requirements-dev.txt, adding macos node to run unit tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,8 +43,8 @@ builders = pipeline_builder.createBuilders { container ->
         container.sh """
             cd ${project}
             build_env/bin/pip --proxy ${https_proxy} install --upgrade pip
-            build_env/bin/pip --proxy ${https_proxy} install -r requirements.txt
-            build_env/bin/pip --proxy ${https_proxy} install codecov==2.0.15 black
+            build_env/bin/pip --proxy ${https_proxy} install -r requirements-dev.txt
+            build_env/bin/pip --proxy ${https_proxy} install codecov==2.0.15
             git submodule update --init
             """
     } // stage
@@ -113,7 +113,7 @@ return {
             stage("Setup") {
                   bat """
                   git submodule update --init
-                  python -m pip install --user -r requirements.txt
+                  python -m pip install --user -r requirements-dev.txt
                 """
             } // stage
             stage("Run tests") {
@@ -150,12 +150,11 @@ def get_macos_pipeline() {
                     } // catch
                 } // stage
                 stage('Setup') {
-                    sh "python3 -m pip install --user -r requirements.txt"
+                    sh "python3 -m pip install --user -r requirements-dev.txt"
                 } // stage
-                stage('Build Executable') {
-                    sh "python3 setup.py build_exe"
+                stage('Run tests') {
+                    sh "python3 -m pytest . -s --ignore=definitions/"
                 } // stage
-                 // archive as well
             } // dir
         } // node
     } // return
@@ -174,10 +173,7 @@ node("docker") {
         }
     }
     
-    // disabled for now as the build isn't setup for Mac OS just yet.
-    // builders['macOS'] = get_macos_pipeline()
-
-    // Only build executables on windows if it is a PR build
+    builders['macOS'] = get_macos_pipeline()
     builders['windows10'] = get_win10_pipeline()
     parallel builders
 }

--- a/README.md
+++ b/README.md
@@ -8,10 +8,18 @@ Construct NeXus files with instrument geometry information using a GUI
 This project is developed for Python 3.6, so an install of 3.6 or higher
 is required. https://www.python.org/downloads/
 
-Python dependencies are listed in requirements.txt at the root of the
+Runtime Python dependencies are listed in requirements.txt at the root of the
 repository. They can be installed from a terminal by running
 ```
 pip install -r requirements.txt
+```
+
+### Development dependencies
+
+Development dependencies (including all runtime dependencies) can be installed by using the following command: 
+
+```
+pip install -r requirements-dev.txt
 ```
 
 The black pre-commit hook (installed by [pre-commit](https://pre-commit.com/)) requires Python 3.6 or above.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,20 @@
+# Development requirements
+
+# Mirror the basic requirements
+-r requirements.txt
+
+# cx_Freeze is used for packaging, the pypi version does not have a fix for Python 3.7 on Windows 10 (https://github.com/anthony-tuininga/cx_Freeze/issues/407)
+git+https://github.com/anthony-tuininga/cx_Freeze.git@master
+# newer versions of jsonschema don't work with the executables built by cx_Freeze
+jsonschema==2.6.0
+
+# Formatting/linting
+black
+pre-commit
+flake8
+
+# Testing
+pytest
+pytest-cov
+pytest-qt
+mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,24 +1,11 @@
 # In general libraries should not be pinned to specific versions
 attrs
-pytest
-pytest-cov
-pytest-qt
 h5py
-flake8
 git+https://github.com/ess-dmsc/python-nexus-utilities@6f5d2c7f1ca66063227aad2a111a2cc567d573f6#egg=nexusutils
 numpy-stl
-pre-commit
 pint
-mock
 silx
 xmltodict
 
-# newer versions of jsonschema don't work with the executables built by cx_Freeze
-jsonschema==2.6.0
-
-# cx_Freeze is used for packaging, the pypi version does not have a fix for Python 3.7 on Windows 10 (https://github.com/anthony-tuininga/cx_Freeze/issues/407)
-git+https://github.com/anthony-tuininga/cx_Freeze.git@master
-
 # PySide2 has had some issues with new versions and packaging so we will pin it
 PySide2==5.12.3
-


### PR DESCRIPTION
### Issue

Closes #342 

### Description of work
- Splitted up requirements into basic and dev (`requirements.txt`, `requirements-dev.txt`) 
- Mirrored dependencies from `requirements.txt` into `requirements-dev.txt`
- Enabled MacOS node and running tests on it
- Removed manual `black` install in jenkinsfile 

### Acceptance Criteria 

- Jenkins build passes on all 3 platforms 
- `requirements-dev.txt` installs all the dependencies, including the ones in `requirements.txt`
- Reviewer is happy with basic and dev requirements. 

### UI tests

N/A

### Nominate for Group Code Review

- [ ] Nominate for code review 
