### PR TITLE
Transforms know their dependents

### DIFF
--- a/nexus_constructor/component.py
+++ b/nexus_constructor/component.py
@@ -122,7 +122,10 @@ class ComponentModel:
         """
         if depends_on is not None and depends_on != ".":
             transform_dataset = self.file.nexus_file[depends_on]
-            if local_only and transform_dataset.parent.parent.name != self.absolute_path:
+            if (
+                local_only
+                and transform_dataset.parent.parent.name != self.absolute_path
+            ):
                 # We're done, the next transformation is not stored in this component
                 return
             transforms.append(TransformationModel(self.file, transform_dataset))
@@ -208,7 +211,9 @@ class ComponentModel:
 
         dependents = transform.get_dependents()
         if dependents:
-            raise DependencyError(f"Cannot delete transformation, it is a dependency of {dependents}")
+            raise DependencyError(
+                f"Cannot delete transformation, it is a dependency of {dependents}"
+            )
 
         # Remove whole transformations group if this is the only transformation in it
         if len(transform.dataset.parent.keys()) == 1:
@@ -228,12 +233,12 @@ class ComponentModel:
     def depends_on(self, transformation: TransformationModel):
         existing_depends_on = self.file.get_attribute_value(self.group, "depends_on")
         if existing_depends_on is not None:
-            TransformationModel(self.file, self.file[existing_depends_on]).deregister_dependent(self)
+            TransformationModel(
+                self.file, self.file[existing_depends_on]
+            ).deregister_dependent(self)
 
         if transformation is None:
-            self.file.set_field_value(
-                self.group, "depends_on", ".", str
-            )
+            self.file.set_field_value(self.group, "depends_on", ".", str)
         else:
             self.file.set_field_value(
                 self.group, "depends_on", transformation.absolute_path, str

--- a/nexus_constructor/nexus/nexus_wrapper.py
+++ b/nexus_constructor/nexus/nexus_wrapper.py
@@ -155,8 +155,12 @@ class NexusWrapper(QObject):
     def set_attribute_value(self, node: h5Node, name: str, value: Any):
         # Deal with arrays of strings
         if isinstance(value, np.ndarray):
-            if value.dtype.type is np.string_ and len(value) > 1:
-                node.attrs.create(name, value, (len(value),), h5py.special_dtype(vlen=str))
+            if value.dtype.type is np.str_ and value.size == 1:
+                value = str(value[0])
+            elif value.dtype.type is np.str_ and value.size > 1:
+                node.attrs.create(
+                    name, value, (len(value),), h5py.special_dtype(vlen=str)
+                )
                 for index, item in enumerate(value):
                     node.attrs[name][index] = item.encode("utf-8")
                 self._emit_file()

--- a/nexus_constructor/nexus/nexus_wrapper.py
+++ b/nexus_constructor/nexus/nexus_wrapper.py
@@ -80,11 +80,11 @@ class NexusWrapper(QObject):
                 filename, mode="r", backing_store=False, driver="core"
             )
             self._load_file(nexus_file)
+            print("NeXus file loaded")
+            self._emit_file()
 
     def _load_file(self, nexus_file: h5py.File):
         self.nexus_file = nexus_file
-        print("NeXus file loaded")
-        self._emit_file()
 
     def rename_node(self, node: h5Node, new_name: str):
         self.nexus_file.move(node.name, f"{node.parent.name}/{new_name}")

--- a/nexus_constructor/nexus/nexus_wrapper.py
+++ b/nexus_constructor/nexus/nexus_wrapper.py
@@ -148,7 +148,7 @@ class NexusWrapper(QObject):
         return group[name]
 
     @staticmethod
-    def get_attribute_value(node: h5Node, name: str) -> str:
+    def get_attribute_value(node: h5Node, name: str):
         if name in node.attrs.keys():
             return node.attrs[name]
 

--- a/nexus_constructor/nexus/nexus_wrapper.py
+++ b/nexus_constructor/nexus/nexus_wrapper.py
@@ -148,10 +148,9 @@ class NexusWrapper(QObject):
         return group[name]
 
     @staticmethod
-    def get_attribute_value(node: h5Node, name: str):
-        if name not in node.attrs.keys():
-            raise NameError(f"Attribute called {name} not found in {node.name}")
-        return node.attrs[name]
+    def get_attribute_value(node: h5Node, name: str) -> str:
+        if name in node.attrs.keys():
+            return node.attrs[name]
 
     def set_attribute_value(self, node: h5Node, name: str, value: Any):
         node.attrs[name] = value

--- a/nexus_constructor/nexus/nexus_wrapper.py
+++ b/nexus_constructor/nexus/nexus_wrapper.py
@@ -76,12 +76,15 @@ class NexusWrapper(QObject):
         :return:
         """
         if filename:
-            print(filename)
-            self.nexus_file = h5py.File(
+            nexus_file = h5py.File(
                 filename, mode="r", backing_store=False, driver="core"
             )
-            print("NeXus file loaded")
-            self._emit_file()
+            self._load_file(nexus_file)
+
+    def _load_file(self, nexus_file: h5py.File):
+        self.nexus_file = nexus_file
+        print("NeXus file loaded")
+        self._emit_file()
 
     def rename_node(self, node: h5Node, new_name: str):
         self.nexus_file.move(node.name, f"{node.parent.name}/{new_name}")

--- a/nexus_constructor/transformations.py
+++ b/nexus_constructor/transformations.py
@@ -5,7 +5,9 @@ import h5py
 from nexus_constructor.nexus import nexus_wrapper as nx
 from typing import TypeVar
 
-TransformationOrComponent = TypeVar("TransformationOrComponent", "TransformationModel", "ComponentModel")
+TransformationOrComponent = TypeVar(
+    "TransformationOrComponent", "TransformationModel", "ComponentModel"
+)
 
 
 class TransformationsList(list):
@@ -85,25 +87,29 @@ class TransformationModel:
         self.dataset[...] = new_value
 
     @property
-    def depends_on(self) -> 'TransformationModel':
+    def depends_on(self) -> "TransformationModel":
         depends_on_path = self.file.get_attribute_value(self.dataset, "depends_on")
         if depends_on_path is not None:
             return TransformationModel(self.file, self.file[depends_on_path])
 
     @depends_on.setter
-    def depends_on(self, depends_on: 'TransformationModel'):
+    def depends_on(self, depends_on: "TransformationModel"):
         """
         Note, until Python 4.0 (or 3.7 with from __future__ import annotations) have
         to use string for depends_on type here, because the current class is not defined yet
         """
         existing_depends_on = self.file.get_attribute_value(self.dataset, "depends_on")
         if existing_depends_on is not None:
-            TransformationModel(self.file, self.file.nexus_file[existing_depends_on]).deregister_dependent(self)
+            TransformationModel(
+                self.file, self.file.nexus_file[existing_depends_on]
+            ).deregister_dependent(self)
 
         if depends_on is None:
             self.file.set_attribute_value(self.dataset, "depends_on", ".")
         else:
-            self.file.set_attribute_value(self.dataset, "depends_on", depends_on.absolute_path)
+            self.file.set_attribute_value(
+                self.dataset, "depends_on", depends_on.absolute_path
+            )
             depends_on.register_dependent(self)
 
     def register_dependent(self, dependent: TransformationOrComponent):
@@ -113,10 +119,18 @@ class TransformationModel:
         :param dependent: transform or component that depends on this one
         """
         if "dependee_of" not in self.dataset.attrs.keys():
-            self.file.set_attribute_value(self.dataset, "dependee_of", dependent.absolute_path)
+            self.file.set_attribute_value(
+                self.dataset, "dependee_of", dependent.absolute_path
+            )
         else:
-            dependee_of_list = self.file.get_attribute_value(self.dataset, "dependee_of")
-            dependee_of_list.append(dependent.dataset.name)
+            dependee_of_list = self.file.get_attribute_value(
+                self.dataset, "dependee_of"
+            )
+            if not isinstance(dependee_of_list, np.ndarray):
+                dependee_of_list = np.array([dependee_of_list])
+            dependee_of_list = np.append(
+                dependee_of_list, np.array([dependent.absolute_path])
+            )
             self.file.set_attribute_value(self.dataset, "dependee_of", dependee_of_list)
 
     def deregister_dependent(self, former_dependent: TransformationOrComponent):
@@ -126,13 +140,22 @@ class TransformationModel:
         :param former_dependent: transform or component that used to depend on this one
         """
         if "dependee_of" in self.dataset.attrs.keys():
-            dependee_of_list = self.file.get_attribute_value(self.dataset, "dependee_of")
-            if not isinstance(dependee_of_list, np.ndarray):
+            dependee_of_list = self.file.get_attribute_value(
+                self.dataset, "dependee_of"
+            )
+            if (
+                not isinstance(dependee_of_list, np.ndarray)
+                and dependee_of_list == former_dependent.absolute_path
+            ):
                 # Must be a single string rather than a list, so simply delete it
                 self.file.delete_attribute(self.dataset, "dependee_of")
             else:
-                dependee_of_list = dependee_of_list[dependee_of_list != former_dependent.absolute_path]
-                self.file.set_attribute_value(self.dataset, "dependee_of", dependee_of_list)
+                dependee_of_list = dependee_of_list[
+                    dependee_of_list != former_dependent.absolute_path
+                ]
+                self.file.set_attribute_value(
+                    self.dataset, "dependee_of", dependee_of_list
+                )
 
     def get_dependents(self):
         if "dependee_of" in self.dataset.attrs.keys():

--- a/nexus_constructor/transformations.py
+++ b/nexus_constructor/transformations.py
@@ -3,6 +3,9 @@ import numpy as np
 from PySide2.QtGui import QVector3D
 import h5py
 from nexus_constructor.nexus import nexus_wrapper as nx
+from typing import TypeVar
+
+TransformationOrComponent = TypeVar("TransformationOrComponent", "TransformationModel", "ComponentModel")
 
 
 class TransformationsList(list):
@@ -27,6 +30,15 @@ class TransformationModel:
     @name.setter
     def name(self, new_name: str):
         self.file.rename_node(self.dataset, new_name)
+
+    @property
+    def absolute_path(self):
+        """
+        Get absolute path of the transform dataset in the NeXus file,
+        this is guarenteed to be unique so it can be used as an ID for this Transformation
+        :return: absolute path of the transform dataset in the NeXus file,
+        """
+        return self.dataset.name
 
     @property
     def type(self):
@@ -84,10 +96,47 @@ class TransformationModel:
         Note, until Python 4.0 (or 3.7 with from __future__ import annotations) have
         to use string for depends_on type here, because the current class is not defined yet
         """
+        existing_depends_on = self.file.get_attribute_value(self.dataset, "depends_on")
+        if existing_depends_on is not None:
+            TransformationModel(self.file, self.file.nexus_file[existing_depends_on]).deregister_dependent(self)
+
         if depends_on is None:
             self.file.set_attribute_value(self.dataset, "depends_on", ".")
         else:
-            self.file.set_attribute_value(self.dataset, "depends_on", depends_on.dataset.name)
+            self.file.set_attribute_value(self.dataset, "depends_on", depends_on.absolute_path)
+            depends_on.register_dependent(self)
+
+    def register_dependent(self, dependent: TransformationOrComponent):
+        """
+        Register dependent transform or component in the dependee_of list of this transform
+        Note, "dependee_of" attribute is not part of the NeXus format
+        :param dependent: transform or component that depends on this one
+        """
+        if "dependee_of" not in self.dataset.attrs.keys():
+            self.file.set_attribute_value(self.dataset, "dependee_of", dependent.absolute_path)
+        else:
+            dependee_of_list = self.file.get_attribute_value(self.dataset, "dependee_of")
+            dependee_of_list.append(dependent.dataset.name)
+            self.file.set_attribute_value(self.dataset, "dependee_of", dependee_of_list)
+
+    def deregister_dependent(self, former_dependent: TransformationOrComponent):
+        """
+        Remove former dependent from the dependee_of list of this transform
+        Note, "dependee_of" attribute is not part of the NeXus format
+        :param former_dependent: transform or component that used to depend on this one
+        """
+        if "dependee_of" in self.dataset.attrs.keys():
+            dependee_of_list = self.file.get_attribute_value(self.dataset, "dependee_of")
+            if not isinstance(dependee_of_list, np.ndarray):
+                # Must be a single string rather than a list, so simply delete it
+                self.file.delete_attribute(self.dataset, "dependee_of")
+            else:
+                dependee_of_list = dependee_of_list[dependee_of_list != former_dependent.absolute_path]
+                self.file.set_attribute_value(self.dataset, "dependee_of", dependee_of_list)
+
+    def get_dependents(self):
+        if "dependee_of" in self.dataset.attrs.keys():
+            return self.file.get_attribute_value(self.dataset, "dependee_of")
 
 
 @attr.s

--- a/nexus_constructor/transformations.py
+++ b/nexus_constructor/transformations.py
@@ -90,7 +90,7 @@ class TransformationModel:
     def depends_on(self) -> "TransformationModel":
         depends_on_path = self.file.get_attribute_value(self.dataset, "depends_on")
         if depends_on_path is not None:
-            return TransformationModel(self.file, self.file[depends_on_path])
+            return TransformationModel(self.file, self.file.nexus_file[depends_on_path])
 
     @depends_on.setter
     def depends_on(self, depends_on: "TransformationModel"):
@@ -159,7 +159,10 @@ class TransformationModel:
 
     def get_dependents(self):
         if "dependee_of" in self.dataset.attrs.keys():
-            return self.file.get_attribute_value(self.dataset, "dependee_of")
+            dependents = self.file.get_attribute_value(self.dataset, "dependee_of")
+            if not isinstance(dependents, np.ndarray):
+                return [dependents]
+            return dependents.tolist()
 
 
 @attr.s

--- a/nexus_constructor/transformations.py
+++ b/nexus_constructor/transformations.py
@@ -72,6 +72,23 @@ class TransformationModel:
         """
         self.dataset[...] = new_value
 
+    @property
+    def depends_on(self) -> 'TransformationModel':
+        depends_on_path = self.file.get_attribute_value(self.dataset, "depends_on")
+        if depends_on_path is not None:
+            return TransformationModel(self.file, self.file[depends_on_path])
+
+    @depends_on.setter
+    def depends_on(self, depends_on: 'TransformationModel'):
+        """
+        Note, until Python 4.0 (or 3.7 with from __future__ import annotations) have
+        to use string for depends_on type here, because the current class is not defined yet
+        """
+        if depends_on is None:
+            self.file.set_attribute_value(self.dataset, "depends_on", ".")
+        else:
+            self.file.set_attribute_value(self.dataset, "depends_on", depends_on.dataset.name)
+
 
 @attr.s
 class Transformation:

--- a/nexus_constructor/validators.py
+++ b/nexus_constructor/validators.py
@@ -1,17 +1,9 @@
 """Validators to be used on QML input fields"""
 from PySide2.QtCore import Signal, QObject
-from PySide2.QtGui import QValidator, QIntValidator
+from PySide2.QtGui import QValidator
 import pint
 import os
 from typing import List
-
-
-class NullableIntValidator(QIntValidator):
-    def validate(self, input: str, pos: int):
-        if input == "":
-            return QValidator.Acceptable
-        else:
-            return super().validate(input, pos)
 
 
 class UnitValidator(QValidator):

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -8,10 +8,10 @@ from uuid import uuid1
 
 
 def _add_component_to_file(
-        nexus_wrapper: NexusWrapper,
-        field_name: str,
-        field_value: Any,
-        component_name: str = "test_component",
+    nexus_wrapper: NexusWrapper,
+    field_name: str,
+    field_value: Any,
+    component_name: str = "test_component",
 ):
     component_group = nexus_wrapper.nexus_file.create_group(component_name)
     component_group.create_dataset(field_name, data=field_value)
@@ -26,7 +26,7 @@ def test_can_create_and_read_from_field_in_component():
     component = ComponentModel(nexus_wrapper, component_group)
     returned_value = component.get_field(field_name)
     assert (
-            returned_value == field_value
+        returned_value == field_value
     ), "Expected to get same value back from field as it was created with"
 
 
@@ -80,13 +80,13 @@ def test_value_of_field_can_be_changed():
     component = ComponentModel(nexus_wrapper, component_group)
     returned_value = component.get_field(field_name)
     assert (
-            returned_value == initial_value
+        returned_value == initial_value
     ), "Expected to get same value back from field as it was created with"
     new_value = 13
     component.set_field("some_field", new_value, dtype=int)
     returned_value = component.get_field(field_name)
     assert (
-            returned_value == new_value
+        returned_value == new_value
     ), "Expected to get same value back from field as it was changed to"
 
 
@@ -106,7 +106,7 @@ def test_type_of_field_can_be_changed():
     component = ComponentModel(nexus_wrapper, component_group)
     returned_value = component.get_field(field_name)
     assert (
-            returned_value == initial_value
+        returned_value == initial_value
     ), "Expected to get same value back from field as it was created with"
 
     new_value = 17.3
@@ -124,7 +124,7 @@ def test_GIVEN_new_component_WHEN_get_transforms_for_component_THEN_transforms_l
     )
     component = ComponentModel(nexus_wrapper, component_group)
     assert (
-            len(component.transforms_full_chain) == 0
+        len(component.transforms_full_chain) == 0
     ), "expected there to be no transformations in the newly created component"
 
 
@@ -139,7 +139,7 @@ def test_GIVEN_component_with_a_transform_added_WHEN_get_transforms_for_componen
     component.depends_on = transform
 
     assert (
-            len(component.transforms_full_chain) == 1
+        len(component.transforms_full_chain) == 1
     ), "expected there to be a transformation in the component"
 
 
@@ -155,7 +155,7 @@ def test_GIVEN_component_with_a_transform_added_WHEN_transform_is_deleted_THEN_t
     component.remove_transformation(transform)
 
     assert (
-            len(component.transforms_full_chain) == 0
+        len(component.transforms_full_chain) == 0
     ), "expected there to be no transforms in the component"
 
 
@@ -297,4 +297,30 @@ def test_removing_transformation_which_no_longer_has_a_dependent_transform_in_an
     try:
         first_component.remove_transformation(first_transform)
     except Exception:
-        pytest.fail("Expected to be able to remove transformation which is no longer a dependee")
+        pytest.fail(
+            "Expected to be able to remove transformation which is no longer a dependee"
+        )
+
+
+def test_removing_transformation_which_still_has_one_dependent_transform_is_not_allowed():
+    nexus_wrapper = NexusWrapper(str(uuid1()))
+    component_group = _add_component_to_file(
+        nexus_wrapper, "some_field", 42, "component_name"
+    )
+    component = ComponentModel(nexus_wrapper, component_group)
+
+    first_transform = component.add_rotation(QVector3D(1.0, 0.0, 0.0), 90.0)
+    second_transform = component.add_rotation(
+        QVector3D(1.0, 0.0, 0.0), 90.0, depends_on=first_transform
+    )
+    third_transform = component.add_rotation(
+        QVector3D(1.0, 0.0, 0.0), 90.0, depends_on=first_transform
+    )
+
+    # Make third transform no longer depend on the first one
+    third_transform.depends_on = None
+
+    with pytest.raises(DependencyError):
+        assert component.remove_transformation(
+            first_transform
+        ), "Expected not to be allowed to delete the transform as the second transform still depends on it"

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -310,9 +310,8 @@ def test_removing_transformation_which_still_has_one_dependent_transform_is_not_
     component = ComponentModel(nexus_wrapper, component_group)
 
     first_transform = component.add_rotation(QVector3D(1.0, 0.0, 0.0), 90.0)
-    second_transform = component.add_rotation(
-        QVector3D(1.0, 0.0, 0.0), 90.0, depends_on=first_transform
-    )
+    # second_transform
+    component.add_rotation(QVector3D(1.0, 0.0, 0.0), 90.0, depends_on=first_transform)
     third_transform = component.add_rotation(
         QVector3D(1.0, 0.0, 0.0), 90.0, depends_on=first_transform
     )

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -246,7 +246,7 @@ def test_transforms_contains_only_local_transforms_not_full_depends_on_chain():
 
     assert len(
         second_component.transforms
-    ), "Expect transforms to contain only the 1 transform local to this component"
+    ), "Expect transforms list to contain only the 1 transform local to this component"
 
 
 def test_removing_transformation_which_has_a_dependent_transform_in_another_component_is_not_allowed():
@@ -271,3 +271,30 @@ def test_removing_transformation_which_has_a_dependent_transform_in_another_comp
         assert first_component.remove_transformation(
             first_transform
         ), "Expected not to be allowed to delete the transform as a transform in another component depends on it"
+
+
+def test_removing_transformation_which_no_longer_has_a_dependent_transform_in_another_component_is_allowed():
+    nexus_wrapper = NexusWrapper(str(uuid1()))
+    component_group = _add_component_to_file(
+        nexus_wrapper, "some_field", 42, "component_name"
+    )
+    first_component = ComponentModel(nexus_wrapper, component_group)
+    component_group = _add_component_to_file(
+        nexus_wrapper, "some_field", 42, "other_component_name"
+    )
+    second_component = ComponentModel(nexus_wrapper, component_group)
+
+    first_transform = first_component.add_rotation(QVector3D(1.0, 0.0, 0.0), 90.0)
+    second_transform = second_component.add_rotation(
+        QVector3D(1.0, 0.0, 0.0), 90.0, depends_on=first_transform
+    )
+
+    second_component.depends_on = second_transform
+
+    # Make second transform no longer depend on the first
+    second_transform.depends_on = None
+
+    try:
+        first_component.remove_transformation(first_transform)
+    except Exception:
+        pytest.fail("Expected to be able to remove transformation which is no longer a dependee")

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -1,3 +1,5 @@
+import h5py
+from nexus_constructor.transformations import TransformationModel
 from nexus_constructor.instrument import _convert_name_with_spaces, Instrument
 from nexus_constructor.nexus.nexus_wrapper import NexusWrapper
 
@@ -65,3 +67,44 @@ def test_GIVEN_instrument_with_component_WHEN_component_is_removed_THEN_componen
     check_if_component_is_in_component_list(
         component_type, description, instrument, name, expect_component_present=False
     )
+
+
+def test_dependents_list_is_created_by_instrument():
+    """
+    The dependents list for transforms is stored in the "dependent_of" attribute,
+    which is not part of the NeXus standard,
+    we therefore cannot rely on it being present and correct in a file we load.
+    This test makes sure that instrument generates this information in the wrapped NeXus file it is given.
+    """
+
+    # Create minimal test file with some transformations but no "dependent_of" attributes
+    in_memory_test_file = h5py.File(
+        "test_file", mode="x", driver="core", backing_store=False
+    )
+    entry_group = in_memory_test_file.create_group("entry")
+    entry_group.attrs["NX_class"] = "NXentry"
+    instrument_group = entry_group.create_group("instrument")
+    instrument_group.attrs["NX_class"] = "NXinstrument"
+    transforms_group = instrument_group.create_group("transformations")
+    transforms_group.attrs["NX_class"] = "NXtransformations"
+    transform_1 = transforms_group.create_dataset("transform_1", data=42)
+    transform_2 = transforms_group.create_dataset("transform_2", data=42)
+    transform_3 = transforms_group.create_dataset("transform_3", data=42)
+    transform_4 = transforms_group.create_dataset("transform_4", data=42)
+    transform_2.attrs["depends_on"] = transform_1.name
+    transform_3.attrs["depends_on"] = transform_2.name
+    transform_4.attrs["depends_on"] = transform_2.name
+
+    nexus_wrapper = NexusWrapper("test_file_with_transforms")
+    nexus_wrapper._load_file(in_memory_test_file)
+    Instrument(nexus_wrapper)
+
+    transform_1_loaded = TransformationModel(nexus_wrapper, transform_1)
+    assert (
+        len(transform_1_loaded.get_dependents()) == 1
+    ), "Expected transform 1 to have a registered dependent (transform 2)"
+
+    transform_2_loaded = TransformationModel(nexus_wrapper, transform_2)
+    assert (
+        len(transform_2_loaded.get_dependents()) == 2
+    ), "Expected transform 2 to have 2 registered dependents (transforms 3 and 4)"

--- a/tests/test_nexus_wrapper.py
+++ b/tests/test_nexus_wrapper.py
@@ -1,4 +1,6 @@
+import h5py
 from nexus_constructor.nexus.nexus_wrapper import NexusWrapper, append_nxs_extension
+from nexus_constructor.transformations import TransformationModel
 
 
 def test_GIVEN_nothing_WHEN_creating_nexus_wrapper_THEN_file_contains_entry_group_with_correct_nx_class():
@@ -24,3 +26,47 @@ def test_nxs_is_appended_to_filename():
 def test_nxs_not_appended_to_filename_if_already_present():
     test_filename = "banana.nxs"
     assert append_nxs_extension(test_filename) == f"{test_filename}"
+
+
+class NexusWrapperNoInit(NexusWrapper):
+    def __init__(self):
+        pass
+
+
+def test_dependents_list_is_created_on_file_load():
+    """
+    The dependents list for transforms is not part of NeXus standard,
+    we therefore cannot rely on it being present and correct in any loaded file.
+    This test makes sure that we generate this information on file load.
+    """
+
+    # Create minimal test file with some transformations
+    in_memory_test_file = h5py.File(
+        "test_file", mode="x", driver="core", backing_store=False
+    )
+    entry_group = in_memory_test_file.create_group("entry")
+    entry_group.attrs["NX_class"] = "NXentry"
+    instrument_group = entry_group.create_group("instrument")
+    instrument_group.attrs["NX_class"] = "NXinstrument"
+    transforms_group = instrument_group.create_group("transformations")
+    transforms_group.attrs["NX_class"] = "NXtransformations"
+    transform_1 = transforms_group.create_dataset("transform_1", data=42)
+    transform_2 = transforms_group.create_dataset("transform_2", data=42)
+    transform_3 = transforms_group.create_dataset("transform_3", data=42)
+    transform_4 = transforms_group.create_dataset("transform_4", data=42)
+    transform_2.attrs["depends_on"] = transform_1.name
+    transform_3.attrs["depends_on"] = transform_2.name
+    transform_4.attrs["depends_on"] = transform_2.name
+
+    nexus_wrapper = NexusWrapperNoInit()
+    nexus_wrapper._load_file(in_memory_test_file)
+
+    transform_1_loaded = TransformationModel(nexus_wrapper, transform_1)
+    assert (
+        len(transform_1_loaded.get_dependents()) == 1
+    ), "Expected transform 1 to have a registered dependent (transform 2)"
+
+    transform_2_loaded = TransformationModel(nexus_wrapper, transform_2)
+    assert (
+        len(transform_2_loaded.get_dependents()) == 2
+    ), "Expected transform 2 to have 2 registered dependents (transforms 3 and 4)"

--- a/tests/test_nexus_wrapper.py
+++ b/tests/test_nexus_wrapper.py
@@ -35,12 +35,13 @@ class NexusWrapperNoInit(NexusWrapper):
 
 def test_dependents_list_is_created_on_file_load():
     """
-    The dependents list for transforms is not part of NeXus standard,
-    we therefore cannot rely on it being present and correct in any loaded file.
+    The dependents list for transforms is stored in the "dependent_of" attribute,
+    which is not part of the NeXus standard,
+    we therefore cannot rely on it being present and correct in a file we load.
     This test makes sure that we generate this information on file load.
     """
 
-    # Create minimal test file with some transformations
+    # Create minimal test file with some transformations but no "dependent_of" attributes
     in_memory_test_file = h5py.File(
         "test_file", mode="x", driver="core", backing_store=False
     )

--- a/tests/test_nexus_wrapper.py
+++ b/tests/test_nexus_wrapper.py
@@ -1,6 +1,4 @@
-import h5py
 from nexus_constructor.nexus.nexus_wrapper import NexusWrapper, append_nxs_extension
-from nexus_constructor.transformations import TransformationModel
 
 
 def test_GIVEN_nothing_WHEN_creating_nexus_wrapper_THEN_file_contains_entry_group_with_correct_nx_class():
@@ -26,48 +24,3 @@ def test_nxs_is_appended_to_filename():
 def test_nxs_not_appended_to_filename_if_already_present():
     test_filename = "banana.nxs"
     assert append_nxs_extension(test_filename) == f"{test_filename}"
-
-
-class NexusWrapperNoInit(NexusWrapper):
-    def __init__(self):
-        pass
-
-
-def test_dependents_list_is_created_on_file_load():
-    """
-    The dependents list for transforms is stored in the "dependent_of" attribute,
-    which is not part of the NeXus standard,
-    we therefore cannot rely on it being present and correct in a file we load.
-    This test makes sure that we generate this information on file load.
-    """
-
-    # Create minimal test file with some transformations but no "dependent_of" attributes
-    in_memory_test_file = h5py.File(
-        "test_file", mode="x", driver="core", backing_store=False
-    )
-    entry_group = in_memory_test_file.create_group("entry")
-    entry_group.attrs["NX_class"] = "NXentry"
-    instrument_group = entry_group.create_group("instrument")
-    instrument_group.attrs["NX_class"] = "NXinstrument"
-    transforms_group = instrument_group.create_group("transformations")
-    transforms_group.attrs["NX_class"] = "NXtransformations"
-    transform_1 = transforms_group.create_dataset("transform_1", data=42)
-    transform_2 = transforms_group.create_dataset("transform_2", data=42)
-    transform_3 = transforms_group.create_dataset("transform_3", data=42)
-    transform_4 = transforms_group.create_dataset("transform_4", data=42)
-    transform_2.attrs["depends_on"] = transform_1.name
-    transform_3.attrs["depends_on"] = transform_2.name
-    transform_4.attrs["depends_on"] = transform_2.name
-
-    nexus_wrapper = NexusWrapperNoInit()
-    nexus_wrapper._load_file(in_memory_test_file)
-
-    transform_1_loaded = TransformationModel(nexus_wrapper, transform_1)
-    assert (
-        len(transform_1_loaded.get_dependents()) == 1
-    ), "Expected transform 1 to have a registered dependent (transform 2)"
-
-    transform_2_loaded = TransformationModel(nexus_wrapper, transform_2)
-    assert (
-        len(transform_2_loaded.get_dependents()) == 2
-    ), "Expected transform 2 to have 2 registered dependents (transforms 3 and 4)"


### PR DESCRIPTION
### Issue

Closes #157

### Description of work

Keep track of what transforms and components depend on a given transform by storing this information in an `dependee_of` attribute in the transformation. This is then used to stop a transformation being deleted if anything else is still dependent on it. This is covered by unit tests in `test_component.py`.
As `dependee_of` is not part of the NeXus standard we cannot rely on it being present in any existing NeXus files which we load, so I make sure it is generated on file load. This is covered by a unit test in `test_instrument.py`.
