### PR TITLE
Add suggestion when component name fails to validate 

### DIFF
--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -124,6 +124,10 @@ class AddComponentDialog(Ui_AddComponentDialog):
         self.nameLineEdit.validator().validate(self.nameLineEdit.text(), 0)
 
     def generate_name_suggestion(self):
+        """
+        Generates a component name suggestion for use in the tooltip when a component is invalid.
+        :return: The component name suggestion, based on the current nx_class. 
+        """
         return generate_unique_name(
             self.componentTypeComboBox.currentText().lstrip("NX"),
             self.instrument.get_component_list(),

--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -22,6 +22,7 @@ from nexus_constructor.instrument import Instrument
 from nexus_constructor.ui_utils import file_dialog, validate_line_edit
 import os
 from functools import partial
+from nexus_constructor.ui_utils import generate_unique_name
 
 
 class GeometryType(Enum):
@@ -90,10 +91,14 @@ class AddComponentDialog(Ui_AddComponentDialog):
         name_validator = NameValidator(self.instrument.get_component_list())
         self.nameLineEdit.setValidator(name_validator)
         self.nameLineEdit.validator().is_valid.connect(
-            partial(validate_line_edit, self.nameLineEdit)
+            partial(
+                validate_line_edit,
+                self.nameLineEdit,
+                tooltip_on_accept="Component name is valid.",
+                tooltip_on_reject=f"Component name is not valid. Suggestion: {self.generate_name_suggestion()}",
+            )
         )
 
-        validate_line_edit(self.nameLineEdit, False)
         validate_line_edit(self.fileLineEdit, False)
 
         self.nameLineEdit.validator().is_valid.connect(self.ok_validator.set_name_valid)
@@ -113,8 +118,15 @@ class AddComponentDialog(Ui_AddComponentDialog):
 
         self.componentTypeComboBox.addItems(list(self.nx_component_classes.keys()))
 
-        # Validate the default value set by the UI
+        # Validate the default values set by the UI
         self.unitsLineEdit.validator().validate(self.unitsLineEdit.text(), 0)
+        self.nameLineEdit.validator().validate(self.nameLineEdit.text(), 0)
+
+    def generate_name_suggestion(self):
+        return generate_unique_name(
+            self.componentTypeComboBox.currentText(),
+            self.instrument.get_component_list(),
+        )
 
     def on_nx_class_changed(self):
         self.webEngineView.setUrl(

--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -95,7 +95,8 @@ class AddComponentDialog(Ui_AddComponentDialog):
                 validate_line_edit,
                 self.nameLineEdit,
                 tooltip_on_accept="Component name is valid.",
-                tooltip_on_reject=f"Component name is not valid. Suggestion: {self.generate_name_suggestion()}",
+                tooltip_on_reject=f"Component name is not valid. Suggestion:",
+                suggestion_callable=self.generate_name_suggestion,
             )
         )
 

--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -126,7 +126,7 @@ class AddComponentDialog(Ui_AddComponentDialog):
     def generate_name_suggestion(self):
         """
         Generates a component name suggestion for use in the tooltip when a component is invalid.
-        :return: The component name suggestion, based on the current nx_class. 
+        :return: The component name suggestion, based on the current nx_class.
         """
         return generate_unique_name(
             self.componentTypeComboBox.currentText().lstrip("NX"),

--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -95,7 +95,7 @@ class AddComponentDialog(Ui_AddComponentDialog):
                 validate_line_edit,
                 self.nameLineEdit,
                 tooltip_on_accept="Component name is valid.",
-                tooltip_on_reject=f"Component name is not valid. Suggestion:",
+                tooltip_on_reject=f"Component name is not valid. Suggestion: ",
                 suggestion_callable=self.generate_name_suggestion,
             )
         )
@@ -125,7 +125,7 @@ class AddComponentDialog(Ui_AddComponentDialog):
 
     def generate_name_suggestion(self):
         return generate_unique_name(
-            self.componentTypeComboBox.currentText(),
+            self.componentTypeComboBox.currentText().lstrip("NX"),
             self.instrument.get_component_list(),
         )
 

--- a/nexus_constructor/ui_utils.py
+++ b/nexus_constructor/ui_utils.py
@@ -34,18 +34,25 @@ def file_dialog(is_save, caption, filter):
 
 
 def validate_line_edit(
-    line_edit, is_valid: bool, tooltip_on_reject="", tooltip_on_accept=""
+    line_edit,
+    is_valid: bool,
+    tooltip_on_reject="",
+    tooltip_on_accept="",
+    suggestion_callable=None,
 ):
     """
     Sets the line edit colour to red if field is invalid or white if valid. Also sets the tooltips if provided.
-    :param tooltip_on_accept: Tooltip to display if line edit is valid.
-    :param tooltip_on_reject: Tooltip to display if line edit is invalid.
     :param line_edit: The line edit object to apply the validation to.
     :param is_valid: Whether the line edit field contains valid text
+    :param suggestion_callable: A callable that returns the suggested alternative if not valid.
+    :param tooltip_on_accept: Tooltip to display if line edit is valid.
+    :param tooltip_on_reject: Tooltip to display if line edit is invalid.
     :return: None.
     """
     colour = "#FFFFFF" if is_valid else "#f6989d"
     line_edit.setStyleSheet(f"QLineEdit {{ background-color: {colour} }}")
+    if "Suggestion" in tooltip_on_reject and callable(suggestion_callable):
+        tooltip_on_reject += suggestion_callable()
     line_edit.setToolTip(tooltip_on_accept) if is_valid else line_edit.setToolTip(
         tooltip_on_reject
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -103,7 +103,7 @@ def test_GIVEN_name_with_1_in_already_WHEN_generating_unique_name_THEN_number_is
     )
 
 
-def test_GIVEN_name_with_1_as_prefix_and_name_with_11_already_in_list_WHEN_generating_unique_name_THEN_following_number_is_incremented_and_name_is_unique():
+def test_GIVEN_name_with_1_as_suffix_and_name_with_11_already_in_list_WHEN_generating_unique_name_THEN_following_number_is_incremented_and_name_is_unique():
     comp = DummyComponent("something1")
 
     assert (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+from mock import Mock
+
 from nexus_constructor.ui_utils import validate_line_edit
 
 
@@ -45,3 +47,31 @@ def test_GIVEN_invalid_WHEN_validating_line_edit_with_no_tooltip_THEN_tooltip_is
     line_edit = DummyLineEdit()
     validate_line_edit(line_edit, False)
     assert line_edit.toolTip == ""
+
+
+def test_GIVEN_suggestion_callable_WHEN_validating_line_edit_THEN_callable_is_called():
+    line_edit = DummyLineEdit()
+    suggestion = Mock(side_effect="test")
+
+    validate_line_edit(
+        line_edit,
+        False,
+        tooltip_on_reject="Suggestion: ",
+        suggestion_callable=suggestion,
+    )
+
+    assert suggestion.called_once()
+
+
+def test_GIVEN_suggestion_callable_WHEN_validating_line_edit_with_valid_line_edit_THEN_callable_is_not_called_even_if_suggestion_in_name():
+    line_edit = DummyLineEdit()
+    suggestion = Mock(side_effect="test")
+
+    validate_line_edit(
+        line_edit,
+        True,
+        tooltip_on_reject="Suggestion: ",
+        suggestion_callable=suggestion,
+    )
+
+    assert suggestion.not_called()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 from mock import Mock
 
-from nexus_constructor.ui_utils import validate_line_edit
+from nexus_constructor.ui_utils import validate_line_edit, generate_unique_name
 
 
 class DummyLineEdit:
@@ -75,3 +75,37 @@ def test_GIVEN_suggestion_callable_WHEN_validating_line_edit_with_valid_line_edi
     )
 
     assert suggestion.not_called()
+
+
+class DummyComponent:
+    def __init__(self, name: str):
+        self.name = name
+
+
+def test_GIVEN_unique_name_WHEN_generating_unique_name_THEN_returns_unchanged_name():
+    name = "something"
+    assert generate_unique_name(name, []) == name
+
+
+def test_GIVEN_name_already_in_list_WHEN_generating_unique_name_THEN_returns_changed_name():
+    comp = DummyComponent("something")
+    assert generate_unique_name(comp.name, [comp]) == comp.name + "1"
+
+
+def test_GIVEN_name_with_1_in_already_WHEN_generating_unique_name_THEN_number_is_appended_to_the_suffix_of_the_name():
+    comp = DummyComponent("something1")
+
+    assert (
+        generate_unique_name(
+            comp.name, [DummyComponent("something1"), DummyComponent("something2")]
+        )
+        == comp.name + "1"
+    )
+
+
+def test_GIVEN_name_with_1_as_prefix_and_name_with_11_already_in_list_WHEN_generating_unique_name_THEN_following_number_is_incremented_and_name_is_unique():
+    comp = DummyComponent("something1")
+
+    assert (
+        generate_unique_name(comp.name, [comp, DummyComponent(comp.name + "1")])
+    ) == "something12"


### PR DESCRIPTION
### Issue

Closes #320 

### Description of work

Adds a suggestion_callable parameter to `validate_line_edit` which gives a suggestion based on the `nx_class` selected and the existing names in the component list. 

Suggestions are in the tooltip that's shown when hovering over the name line edit.

### Acceptance Criteria 

- Test with no components - anything other than a blank name should be valid, but it should still give you a suggestion. 

- Test with components that already exist - should give a suggestion. 


### UI tests

N/A

### Nominate for Group Code Review

- [ ] Nominate for code review 
