### PR TITLE
346: Use neutron animation in the gnomon

### DIFF
--- a/nexus_constructor/gnomon.py
+++ b/nexus_constructor/gnomon.py
@@ -89,6 +89,8 @@ class Gnomon:
 
         self.num_neutrons = 9
 
+        self.neutron_animation_length = self.gnomon_cylinder_length * 1.5
+
         # Create a dictionary for neutron-related objects so that they are always in scope and not destroyed by C++
         self.neutron_objects = {
             "entities": [],
@@ -390,7 +392,7 @@ class Gnomon:
         cylinder_mesh.setRings(rings)
 
     @staticmethod
-    def set_beam_transform(cylinder_transform, gnomon_cylinder_length):
+    def set_beam_transform(cylinder_transform, neutron_animation_length):
         """
         Configures the transform for the beam cylinder by giving it a matrix. The matrix will turn the cylinder sideways
         and then move it "backwards" in the z-direction by 20 units so that it ends at the location of the sample.
@@ -398,7 +400,7 @@ class Gnomon:
         """
         cylinder_matrix = QMatrix4x4()
         cylinder_matrix.rotate(90, QVector3D(1, 0, 0))
-        cylinder_matrix.translate(QVector3D(0, gnomon_cylinder_length, 0))
+        cylinder_matrix.translate(QVector3D(0, neutron_animation_length * 0.5, 0))
 
         cylinder_transform.setMatrix(cylinder_matrix)
 
@@ -407,9 +409,9 @@ class Gnomon:
         Sets up the beam cylinder by giving the cylinder entity a mesh, a material, and a transformation.
         """
         self.set_cylinder_mesh_dimensions(
-            self.cylinder_mesh, 1.5, self.gnomon_cylinder_length * 2, 2
+            self.cylinder_mesh, 1.5, self.neutron_animation_length, 2
         )
-        self.set_beam_transform(self.cylinder_transform, self.gnomon_cylinder_length)
+        self.set_beam_transform(self.cylinder_transform, self.neutron_animation_length)
         self.add_qcomponents_to_entity(
             self.cylinder_entity,
             [self.cylinder_mesh, self.beam_material, self.cylinder_transform],
@@ -474,16 +476,14 @@ class Gnomon:
                 self.neutron_objects["transforms"][i]
             )
 
-            x_cylinder_length = 8
-
             neutron_animation = QPropertyAnimation(
                 self.neutron_objects["transforms"][i]
             )
             self.set_neutron_animation_properties(
                 neutron_animation,
                 neutron_animation_controller,
-                x_cylinder_length,
-                time_span_offsets[i],
+                self.neutron_animation_length,
+                time_span_offsets[i] * 0.5,
             )
 
             self.neutron_objects["animation_controllers"].append(

--- a/nexus_constructor/gnomon.py
+++ b/nexus_constructor/gnomon.py
@@ -343,7 +343,7 @@ class Gnomon:
             self.main_camera.position() - self.main_camera.viewCenter()
         )
         updated_gnomon_camera_position = updated_gnomon_camera_position.normalized()
-        updated_gnomon_camera_position *= self.gnomon_cylinder_length * 4
+        updated_gnomon_camera_position *= self.gnomon_cylinder_length * 4.2
 
         self.gnomon_camera.setPosition(updated_gnomon_camera_position)
         self.gnomon_camera.setUpVector(self.main_camera.upVector())
@@ -483,7 +483,7 @@ class Gnomon:
                 neutron_animation,
                 neutron_animation_controller,
                 self.neutron_animation_length,
-                time_span_offsets[i] * 0.5,
+                time_span_offsets[i],
             )
 
             self.neutron_objects["animation_controllers"].append(

--- a/nexus_constructor/gnomon.py
+++ b/nexus_constructor/gnomon.py
@@ -1,11 +1,16 @@
 from PySide2.Qt3DCore import Qt3DCore
 from PySide2.Qt3DExtras import Qt3DExtras
 from PySide2.Qt3DRender import Qt3DRender
+from PySide2.QtCore import QPropertyAnimation
 from PySide2.QtGui import QVector3D, QMatrix4x4, QColor, QFont, QVector4D
+
+from nexus_constructor.neutron_animation_controller import NeutronAnimationController
 
 
 class Gnomon:
-    def __init__(self, root_entity, main_camera, component_adder):
+    def __init__(
+        self, root_entity, main_camera, beam_material, grey_material, component_adder
+    ):
         """
         A class that houses the Qt3D items (entities, transformations, etc) related to the gnomon (or axis indicator).
         The gnomon/axis indicator is an object that appears in the bottom right-hand corner of the instrument view that
@@ -19,6 +24,8 @@ class Gnomon:
         self.gnomon_cylinder_length = 4
         self.main_camera = main_camera
         self.gnomon_camera = self.create_gnomon_camera(main_camera)
+        self.beam_material = beam_material
+        self.grey_material = grey_material
 
         self.x_axis_entity = Qt3DCore.QEntity(self.gnomon_root_entity)
         self.y_axis_entity = Qt3DCore.QEntity(self.gnomon_root_entity)
@@ -74,6 +81,29 @@ class Gnomon:
         self.prepare_gnomon_material(self.x_material, "red")
         self.prepare_gnomon_material(self.y_material, "green")
         self.prepare_gnomon_material(self.z_material, "blue")
+
+        # Initialise beam objects
+        self.cylinder_entity = Qt3DCore.QEntity(self.gnomon_root_entity)
+        self.cylinder_mesh = Qt3DExtras.QCylinderMesh()
+        self.cylinder_transform = Qt3DCore.QTransform()
+
+        self.num_neutrons = 9
+
+        # Create a dictionary for neutron-related objects so that they are always in scope and not destroyed by C++
+        self.neutron_objects = {
+            "entities": [],
+            "meshes": [],
+            "transforms": [],
+            "animation_controllers": [],
+            "animations": [],
+        }
+
+        for _ in range(self.num_neutrons):
+            self.neutron_objects["entities"].append(
+                Qt3DCore.QEntity(self.gnomon_root_entity)
+            )
+            self.neutron_objects["meshes"].append(Qt3DExtras.QSphereMesh())
+            self.neutron_objects["transforms"].append(Qt3DCore.QTransform())
 
     def get_gnomon_camera(self):
         """
@@ -345,3 +375,127 @@ class Gnomon:
         billboard_transformation.setRow(3, QVector4D())
         billboard_transformation.setColumn(3, QVector4D(text_vector, 1))
         return billboard_transformation
+
+    @staticmethod
+    def set_cylinder_mesh_dimensions(cylinder_mesh, radius, length, rings):
+        """
+        Sets the dimensions of a cylinder mesh.
+        :param cylinder_mesh: The cylinder mesh to modify.
+        :param radius: The desired radius.
+        :param length: The desired length.
+        :param rings: The desired number of rings.
+        """
+        cylinder_mesh.setRadius(radius)
+        cylinder_mesh.setLength(length)
+        cylinder_mesh.setRings(rings)
+
+    @staticmethod
+    def set_beam_transform(cylinder_transform, gnomon_cylinder_length):
+        """
+        Configures the transform for the beam cylinder by giving it a matrix. The matrix will turn the cylinder sideways
+        and then move it "backwards" in the z-direction by 20 units so that it ends at the location of the sample.
+        :param cylinder_transform: A QTransform object.
+        """
+        cylinder_matrix = QMatrix4x4()
+        cylinder_matrix.rotate(90, QVector3D(1, 0, 0))
+        cylinder_matrix.translate(QVector3D(0, gnomon_cylinder_length, 0))
+
+        cylinder_transform.setMatrix(cylinder_matrix)
+
+    def setup_beam_cylinder(self):
+        """
+        Sets up the beam cylinder by giving the cylinder entity a mesh, a material, and a transformation.
+        """
+        self.set_cylinder_mesh_dimensions(
+            self.cylinder_mesh, 1.5, self.gnomon_cylinder_length * 2, 2
+        )
+        self.set_beam_transform(self.cylinder_transform, self.gnomon_cylinder_length)
+        self.add_qcomponents_to_entity(
+            self.cylinder_entity,
+            [self.cylinder_mesh, self.beam_material, self.cylinder_transform],
+        )
+
+    @staticmethod
+    def set_neutron_animation_properties(
+        neutron_animation,
+        neutron_animation_controller,
+        animation_distance,
+        time_span_offset,
+    ):
+        """
+        Prepares a QPropertyAnimation for a neutron by giving it a target, a distance, and loop settings.
+        :param neutron_animation: The QPropertyAnimation to be configured.
+        :param neutron_animation_controller: The related animation controller object.
+        :param animation_distance: The starting distance of the neutron.
+        :param time_span_offset: The offset that allows the neutron to move at a different time from other neutrons.
+        """
+        neutron_animation.setTargetObject(neutron_animation_controller)
+        neutron_animation.setPropertyName(b"distance")
+        neutron_animation.setStartValue(0)
+        neutron_animation.setEndValue(animation_distance)
+        neutron_animation.setDuration(500 + time_span_offset)
+        neutron_animation.setLoopCount(-1)
+        neutron_animation.start()
+
+    @staticmethod
+    def set_sphere_mesh_radius(sphere_mesh, radius):
+        """
+        Sets the radius of a sphere mesh.
+        :param sphere_mesh: The sphere mesh to modify.
+        :param radius: The desired radius.
+        """
+        sphere_mesh.setRadius(radius)
+
+    def setup_neutrons(self):
+        """
+        Sets up the neutrons and their animations by preparing their meshes and then giving offset and
+        distance parameters to an animation controller.
+        """
+
+        # Create lists of x, y, and time offsets for the neutron animations
+        x_offsets = [0, 0, 0, 2, -2, 1.4, 1.4, -1.4, -1.4]
+        y_offsets = [0, 2, -2, 0, 0, 1.4, -1.4, 1.4, -1.4]
+        time_span_offsets = [0, -5, -7, 5, 7, 19, -19, 23, -23]
+
+        neutron_radius = 1.5
+
+        for i in range(self.num_neutrons):
+
+            self.set_sphere_mesh_radius(
+                self.neutron_objects["meshes"][i], neutron_radius
+            )
+
+            neutron_animation_controller = NeutronAnimationController(
+                x_offsets[i] * 0.5,
+                y_offsets[i] * 0.5,
+                self.neutron_objects["transforms"][i],
+            )
+            neutron_animation_controller.set_target(
+                self.neutron_objects["transforms"][i]
+            )
+
+            x_cylinder_length = 8
+
+            neutron_animation = QPropertyAnimation(
+                self.neutron_objects["transforms"][i]
+            )
+            self.set_neutron_animation_properties(
+                neutron_animation,
+                neutron_animation_controller,
+                x_cylinder_length,
+                time_span_offsets[i],
+            )
+
+            self.neutron_objects["animation_controllers"].append(
+                neutron_animation_controller
+            )
+            self.neutron_objects["animations"].append(neutron_animation)
+
+            self.add_qcomponents_to_entity(
+                self.neutron_objects["entities"][i],
+                [
+                    self.neutron_objects["meshes"][i],
+                    self.grey_material,
+                    self.neutron_objects["transforms"][i],
+                ],
+            )

--- a/nexus_constructor/instrument_view.py
+++ b/nexus_constructor/instrument_view.py
@@ -71,7 +71,7 @@ class InstrumentView(QWidget):
 
         for _ in range(self.num_neutrons):
             self.neutron_objects["entities"].append(
-                Qt3DCore.QEntity(self.component_root_entity)
+                Qt3DCore.QEntity(self.gnomon_root_entity)
             )
             self.neutron_objects["meshes"].append(Qt3DExtras.QSphereMesh())
             self.neutron_objects["transforms"].append(Qt3DCore.QTransform())
@@ -326,8 +326,8 @@ class InstrumentView(QWidget):
         """
         neutron_animation.setTargetObject(neutron_animation_controller)
         neutron_animation.setPropertyName(b"distance")
-        neutron_animation.setStartValue(animation_distance)
-        neutron_animation.setEndValue(0)
+        neutron_animation.setStartValue(0)
+        neutron_animation.setEndValue(animation_distance)
         neutron_animation.setDuration(500 + time_span_offset)
         neutron_animation.setLoopCount(-1)
         neutron_animation.start()
@@ -343,7 +343,7 @@ class InstrumentView(QWidget):
         y_offsets = [0, 2, -2, 0, 0, 1.4, -1.4, 1.4, -1.4]
         time_span_offsets = [0, -5, -7, 5, 7, 19, -19, 23, -23]
 
-        neutron_radius = 3
+        neutron_radius = 1.5
 
         for i in range(self.num_neutrons):
 
@@ -352,11 +352,15 @@ class InstrumentView(QWidget):
             )
 
             neutron_animation_controller = NeutronAnimationController(
-                x_offsets[i], y_offsets[i], self.neutron_objects["transforms"][i]
+                x_offsets[i] * 0.5,
+                y_offsets[i] * 0.5,
+                self.neutron_objects["transforms"][i],
             )
             neutron_animation_controller.set_target(
                 self.neutron_objects["transforms"][i]
             )
+
+            x_cylinder_length = 8
 
             neutron_animation = QPropertyAnimation(
                 self.neutron_objects["transforms"][i]
@@ -364,7 +368,7 @@ class InstrumentView(QWidget):
             self.set_neutron_animation_properties(
                 neutron_animation,
                 neutron_animation_controller,
-                -self.beam_cylinder_length,
+                x_cylinder_length,
                 time_span_offsets[i],
             )
 

--- a/nexus_constructor/instrument_view.py
+++ b/nexus_constructor/instrument_view.py
@@ -1,12 +1,11 @@
-from PySide2.Qt3DRender import Qt3DRender
-from PySide2.QtWidgets import QWidget, QVBoxLayout
-from PySide2.Qt3DExtras import Qt3DExtras
 from PySide2.Qt3DCore import Qt3DCore
-from PySide2.QtCore import QPropertyAnimation, QRectF
-from PySide2.QtGui import QVector3D, QColor, QMatrix4x4
+from PySide2.Qt3DExtras import Qt3DExtras
+from PySide2.Qt3DRender import Qt3DRender
+from PySide2.QtCore import QRectF
+from PySide2.QtGui import QVector3D, QColor
+from PySide2.QtWidgets import QWidget, QVBoxLayout
 
 from nexus_constructor.gnomon import Gnomon
-from nexus_constructor.neutron_animation_controller import NeutronAnimationController
 from nexus_constructor.off_renderer import OffMesh
 
 

--- a/nexus_constructor/instrument_view.py
+++ b/nexus_constructor/instrument_view.py
@@ -99,7 +99,7 @@ class InstrumentView(QWidget):
         component_clear_buffers.setBuffers(Qt3DRender.QClearBuffers.AllBuffers)
         component_clear_buffers.setClearColor(QColor("lightgrey"))
 
-        gnomon_size = 0.15
+        gnomon_size = 0.2
         gnomon_start = 1 - gnomon_size
 
         # Create a viewport for gnomon in small section of the screen

--- a/tests/test_gnomon.py
+++ b/tests/test_gnomon.py
@@ -194,3 +194,81 @@ def test_GIVEN_view_matrix_and_vector_WHEN_calling_create_billboard_transformati
     actual_matrix = Gnomon.create_billboard_transformation(view_matrix, text_vector)
 
     assert expected_matrix == actual_matrix
+
+
+def test_GIVEN_animation_parameters_WHEN_calling_set_neutron_animation_properties_THEN_properties_set():
+
+    mock_neutron_animation_controller = Mock()
+    animation_distance = 15
+    time_span_offset = 5
+
+    mock_neutron_animation = Mock()
+    mock_neutron_animation.setTargetObject = Mock()
+    mock_neutron_animation.setPropertyName = Mock()
+    mock_neutron_animation.setStartValue = Mock()
+    mock_neutron_animation.setEndValue = Mock()
+    mock_neutron_animation.setDuration = Mock()
+    mock_neutron_animation.setLoopCount = Mock()
+    mock_neutron_animation.start = Mock()
+
+    Gnomon.set_neutron_animation_properties(
+        mock_neutron_animation,
+        mock_neutron_animation_controller,
+        animation_distance,
+        time_span_offset,
+    )
+
+    mock_neutron_animation.setTargetObject.assert_called_once_with(
+        mock_neutron_animation_controller
+    )
+    mock_neutron_animation.setPropertyName.assert_called_once_with(b"distance")
+    mock_neutron_animation.setStartValue.assert_called_once_with(0)
+    mock_neutron_animation.setEndValue.assert_called_once_with(animation_distance)
+    mock_neutron_animation.setDuration.assert_called_once_with(500 + time_span_offset)
+    mock_neutron_animation.setLoopCount.assert_called_once_with(-1)
+    mock_neutron_animation.start.assert_called_once()
+
+
+def test_GIVEN_cylinder_dimensions_WHEN_calling_set_cylinder_mesh_dimensions_THEN_dimensions_set():
+
+    radius = 2
+    length = 10
+    rings = 2
+
+    mock_cylinder = Mock()
+    mock_cylinder.setRadius = Mock()
+    mock_cylinder.setLength = Mock()
+    mock_cylinder.setRings = Mock()
+
+    Gnomon.set_cylinder_mesh_dimensions(mock_cylinder, radius, length, rings)
+
+    mock_cylinder.setRadius.assert_called_once_with(radius)
+    mock_cylinder.setLength.assert_called_once_with(length)
+    mock_cylinder.setRings.assert_called_once_with(rings)
+
+
+def test_GIVEN_cylinder_transform_WHEN_calling_set_beam_transform_THEN_matrix_set():
+
+    neutron_animation_length = 15
+
+    expected_matrix = QMatrix4x4()
+    expected_matrix.rotate(90, QVector3D(1, 0, 0))
+    expected_matrix.translate(QVector3D(0, neutron_animation_length * 0.5, 0))
+
+    mock_cylinder_transform = Mock()
+    mock_cylinder_transform.setMatrix = Mock()
+
+    Gnomon.set_beam_transform(mock_cylinder_transform, neutron_animation_length)
+
+    assert mock_cylinder_transform.setMatrix.call_args[0][0] == expected_matrix
+
+
+def test_GIVEN_radius_WHEN_calling_set_sphere_mesh_radius_THEN_radius_set():
+
+    radius = 2
+    mock_sphere_mesh = Mock()
+    mock_sphere_mesh.setRadius = Mock()
+
+    Gnomon.set_sphere_mesh_radius(mock_sphere_mesh, radius)
+
+    mock_sphere_mesh.setRadius.assert_called_once_with(radius)

--- a/tests/test_instrument_view.py
+++ b/tests/test_instrument_view.py
@@ -13,10 +13,8 @@ def test_GIVEN_material_properties_WHEN_calling_set_material_properties_THEN_pro
     mock_material.setAmbient = Mock()
     mock_material.setDiffuse = Mock()
 
-    """
-    This method doesn't exist for QPhongMaterial but is mocked all the same to make sure that it isn't called when an
-    alpha argument isn't given
-    """
+    # This method doesn't exist for QPhongMaterial but is mocked all the same to make sure that it isn't called when an
+    # alpha argument isn't given
     mock_material.setAlpha = Mock()
 
     InstrumentView.set_material_properties(mock_material, ambient, diffuse)
@@ -72,79 +70,3 @@ def test_GIVEN_components_WHEN_calling_add_components_to_entity_THEN_components_
     InstrumentView.add_qcomponents_to_entity(mock_entity, mock_components)
 
     mock_entity.addComponent.assert_has_calls(calls)
-
-
-def test_GIVEN_cylinder_dimensions_WHEN_calling_set_cylinder_mesh_dimensions_THEN_dimensions_set():
-
-    radius = 2
-    length = 10
-    rings = 2
-
-    mock_cylinder = Mock()
-    mock_cylinder.setRadius = Mock()
-    mock_cylinder.setLength = Mock()
-    mock_cylinder.setRings = Mock()
-
-    InstrumentView.set_cylinder_mesh_dimensions(mock_cylinder, radius, length, rings)
-
-    mock_cylinder.setRadius.assert_called_once_with(radius)
-    mock_cylinder.setLength.assert_called_once_with(length)
-    mock_cylinder.setRings.assert_called_once_with(rings)
-
-
-def test_GIVEN_cylinder_transform_WHEN_calling_set_beam_transform_THEN_matrix_set():
-
-    expected_matrix = QMatrix4x4()
-    expected_matrix.rotate(270, QVector3D(1, 0, 0))
-    expected_matrix.translate(QVector3D(0, 20, 0))
-
-    mock_cylinder_transform = Mock()
-    mock_cylinder_transform.setMatrix = Mock()
-
-    InstrumentView.set_beam_transform(mock_cylinder_transform)
-
-    assert mock_cylinder_transform.setMatrix.call_args[0][0] == expected_matrix
-
-
-def test_GIVEN_radius_WHEN_calling_set_sphere_mesh_radius_THEN_radius_set():
-
-    radius = 2
-    mock_sphere_mesh = Mock()
-    mock_sphere_mesh.setRadius = Mock()
-
-    InstrumentView.set_sphere_mesh_radius(mock_sphere_mesh, radius)
-
-    mock_sphere_mesh.setRadius.assert_called_once_with(radius)
-
-
-def test_GIVEN_animation_parameters_WHEN_calling_set_neutron_animation_properties_THEN_properties_set():
-
-    mock_neutron_animation_controller = Mock()
-    animation_distance = 15
-    time_span_offset = 5
-
-    mock_neutron_animation = Mock()
-    mock_neutron_animation.setTargetObject = Mock()
-    mock_neutron_animation.setPropertyName = Mock()
-    mock_neutron_animation.setStartValue = Mock()
-    mock_neutron_animation.setEndValue = Mock()
-    mock_neutron_animation.setDuration = Mock()
-    mock_neutron_animation.setLoopCount = Mock()
-    mock_neutron_animation.start = Mock()
-
-    InstrumentView.set_neutron_animation_properties(
-        mock_neutron_animation,
-        mock_neutron_animation_controller,
-        animation_distance,
-        time_span_offset,
-    )
-
-    mock_neutron_animation.setTargetObject.assert_called_once_with(
-        mock_neutron_animation_controller
-    )
-    mock_neutron_animation.setPropertyName.assert_called_once_with(b"distance")
-    mock_neutron_animation.setStartValue.assert_called_once_with(animation_distance)
-    mock_neutron_animation.setEndValue.assert_called_once_with(0)
-    mock_neutron_animation.setDuration.assert_called_once_with(500 + time_span_offset)
-    mock_neutron_animation.setLoopCount.assert_called_once_with(-1)
-    mock_neutron_animation.start.assert_called_once()

--- a/tests/test_instrument_view.py
+++ b/tests/test_instrument_view.py
@@ -1,7 +1,6 @@
-from PySide2.QtGui import QMatrix4x4, QVector3D
+from mock import Mock, call
 
 from nexus_constructor.instrument_view import InstrumentView
-from mock import Mock, call
 
 
 def test_GIVEN_material_properties_WHEN_calling_set_material_properties_THEN_properties_set():


### PR DESCRIPTION
### Issue

Closes #346

### Description of work

Moves the beam cylinder and neutron animation to the gnomon. Methods related to the neutrons and beam were moved to gnomon.py. Tests for these methods were also moved to test_gnomon.py. I shrunk the size of the neutrons and beam in order to make this look better. Also had the x/y offsets halved for the `NeutronAnimationController`.

There is also a bit of a strange effect when the axis labels are in front of the neutrons/cylinder. Not sure how important that is.

### Acceptance Criteria 

Check that all the tests pass. Also check that the gnomon still fits entirely inside its viewport box even if you move it around.

### UI tests

n/a

### Nominate for Group Code Review

- [ ] Nominate for code review 
