### PR TITLE
Adding dialog for when a nexus file has multiple entries 

### DIFF
--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -50,18 +50,26 @@ class MainWindow(Ui_MainWindow):
         self.widget.setVisible(True)
 
     def show_entries_dialog(self, map_of_entries: dict, nexus_file):
+        """
+        Shows the entries dialog when loading a nexus file if there are multiple entries.
+        :param map_of_entries: A map of the entry groups, with the key being the name of the group and value being the actual h5py group object.
+        :param nexus_file: A reference to the nexus file.
+        """
         self.entries_dialog = QDialog()
         self.entries_dialog.setMinimumWidth(400)
         self.entries_dialog.setWindowTitle(
             "Multiple Entries found. Please choose the entry name from the list."
         )
         combo = QComboBox()
+
+        # Populate the combo box with the names of the entry groups.
         [combo.addItem(x) for x in map_of_entries.keys()]
 
         ok_button = QPushButton()
         ok_button.setText("OK")
         ok_button.clicked.connect(self.entries_dialog.close)
 
+        # Connect the clicked signal of the ok_button to instrument.load_file and pass the file and entry group object.
         ok_button.clicked.connect(
             partial(
                 self.instrument.nexus.load_file,

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -1,5 +1,6 @@
 from functools import partial
 
+import h5py
 from PySide2.QtWidgets import QDialog, QLabel, QGridLayout, QComboBox, QPushButton
 from nexus_constructor.instrument import Instrument
 from nexus_constructor.add_component_window import AddComponentDialog
@@ -49,7 +50,7 @@ class MainWindow(Ui_MainWindow):
 
         self.widget.setVisible(True)
 
-    def show_entries_dialog(self, map_of_entries: dict, nexus_file):
+    def show_entries_dialog(self, map_of_entries: dict, nexus_file: h5py.File):
         """
         Shows the entries dialog when loading a nexus file if there are multiple entries.
         :param map_of_entries: A map of the entry groups, with the key being the name of the group and value being the actual h5py group object.

--- a/nexus_constructor/nexus/nexus_wrapper.py
+++ b/nexus_constructor/nexus/nexus_wrapper.py
@@ -1,12 +1,8 @@
-from functools import partial
-from time import sleep
-
 import h5py
 
 from PySide2.QtCore import Signal, QObject
 from typing import Any, TypeVar
 import numpy as np
-from PySide2.QtWidgets import QDialog, QComboBox, QGridLayout, QPushButton, QLabel
 
 h5Node = TypeVar("h5Node", h5py.Group, h5py.Dataset)
 

--- a/nexus_constructor/nexus/nexus_wrapper.py
+++ b/nexus_constructor/nexus/nexus_wrapper.py
@@ -81,20 +81,26 @@ class NexusWrapper(QObject):
                 filename, mode="r", backing_store=False, driver="core"
             )
 
-            entries_in_root = dict()
+            self.find_entries_in_file(nexus_file)
 
-            def append_nx_entries_to_list(name, node):
-                if isinstance(node, h5py.Group):
-                    if "NX_class" in node.attrs.keys():
-                        if node.attrs["NX_class"] == "NXentry":
-                            entries_in_root[name] = node
+    def find_entries_in_file(self, nexus_file):
+        """
+        Find the entry group in the specified nexus file. If there are multiple, emit the signal required to show the multiple entry selection dialog in the UI.
+        :param nexus_file: A reference to the nexus file to check for the entry group.
+        """
+        entries_in_root = dict()
 
-            nexus_file["/"].visititems(append_nx_entries_to_list)
+        def append_nx_entries_to_list(name, node):
+            if isinstance(node, h5py.Group):
+                if "NX_class" in node.attrs.keys():
+                    if node.attrs["NX_class"] == "NXentry":
+                        entries_in_root[name] = node
 
-            if len(entries_in_root.keys()) > 1:
-                self.show_entries_dialog.emit(entries_in_root, nexus_file)
-            else:
-                self.load_file(list(entries_in_root.values())[0], nexus_file)
+        nexus_file["/"].visititems(append_nx_entries_to_list)
+        if len(entries_in_root.keys()) > 1:
+            self.show_entries_dialog.emit(entries_in_root, nexus_file)
+        else:
+            self.load_file(list(entries_in_root.values())[0], nexus_file)
 
     def load_file(self, entry: h5py.Group, nexus_file: h5py.File):
         """

--- a/nexus_constructor/nexus/nexus_wrapper.py
+++ b/nexus_constructor/nexus/nexus_wrapper.py
@@ -216,7 +216,7 @@ class NexusWrapper(QObject):
         :param entry: The entry group object to search for the instrument group in.
         :return: the instrument group object.
         """
-        for node in entry:
+        for node in entry.values():
             if isinstance(node, h5py.Group):
                 if "NX_class" in node.attrs.keys():
                     if node.attrs["NX_class"] == "NXinstrument":

--- a/nexus_constructor/nexus/nexus_wrapper.py
+++ b/nexus_constructor/nexus/nexus_wrapper.py
@@ -96,7 +96,12 @@ class NexusWrapper(QObject):
             else:
                 self.load_file(list(entries_in_root.values())[0], nexus_file)
 
-    def load_file(self, entry, nexus_file):
+    def load_file(self, entry: h5py.Group, nexus_file: h5py.File):
+        """
+        Sets the entry group, instrument group and reference to the nexus file.
+        :param entry: The entry group.
+        :param nexus_file: The nexus file reference.
+        """
         self.entry = entry
         self.instrument = self.get_instrument_group_from_entry(self.entry)
         self.nexus_file = nexus_file
@@ -205,7 +210,12 @@ class NexusWrapper(QObject):
         )
 
     @staticmethod
-    def get_instrument_group_from_entry(entry):
+    def get_instrument_group_from_entry(entry: h5py.Group) -> h5py.Group:
+        """
+        Get the first NXinstrument object from an entry group.
+        :param entry: The entry group object to search for the instrument group in.
+        :return: the instrument group object.
+        """
         for node in entry:
             if isinstance(node, h5py.Group):
                 if "NX_class" in node.attrs.keys():

--- a/nexus_constructor/nexus/nexus_wrapper.py
+++ b/nexus_constructor/nexus/nexus_wrapper.py
@@ -83,7 +83,7 @@ class NexusWrapper(QObject):
 
             self.find_entries_in_file(nexus_file)
 
-    def find_entries_in_file(self, nexus_file):
+    def find_entries_in_file(self, nexus_file: h5py.File):
         """
         Find the entry group in the specified nexus file. If there are multiple, emit the signal required to show the multiple entry selection dialog in the UI.
         :param nexus_file: A reference to the nexus file to check for the entry group.

--- a/nexus_constructor/nexus/nexus_wrapper.py
+++ b/nexus_constructor/nexus/nexus_wrapper.py
@@ -93,7 +93,10 @@ class NexusWrapper(QObject):
         def append_nx_entries_to_list(name, node):
             if isinstance(node, h5py.Group):
                 if "NX_class" in node.attrs.keys():
-                    if node.attrs["NX_class"] == "NXentry":
+                    if (
+                        node.attrs["NX_class"] == b"NXentry"
+                        or node.attrs["NX_class"] == "NXentry"
+                    ):
                         entries_in_root[name] = node
 
         nexus_file["/"].visititems(append_nx_entries_to_list)

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -96,7 +96,7 @@ def test_dependents_list_is_created_by_instrument():
     transform_4.attrs["depends_on"] = transform_2.name
 
     nexus_wrapper = NexusWrapper("test_file_with_transforms")
-    nexus_wrapper._load_file(in_memory_test_file)
+    nexus_wrapper.load_file(entry_group, in_memory_test_file)
     Instrument(nexus_wrapper)
 
     transform_1_loaded = TransformationModel(nexus_wrapper, transform_1)

--- a/tests/test_nexus_wrapper.py
+++ b/tests/test_nexus_wrapper.py
@@ -1,3 +1,5 @@
+from mock import Mock
+
 from nexus_constructor.nexus.nexus_wrapper import NexusWrapper, append_nxs_extension
 from tests.test_nexus_to_json import create_in_memory_file
 
@@ -62,3 +64,46 @@ def test_GIVEN_multiple_entry_groups_WHEN_getting_instrument_group_from_entry_TH
     assert wrapper.nexus_file == file
     assert wrapper.entry == entry
     assert wrapper.instrument == inst_group
+
+
+def test_GIVEN_single_entry_group_with_instrument_group_WHEN_finding_entry_THEN_file_is_loaded_correctly():
+    file = create_in_memory_file("test_nw4")
+
+    entry = file.create_group("entry")
+    entry.attrs["NX_class"] = "NXentry"
+
+    inst_group = entry.create_group("instrument")
+    inst_group.attrs["NX_class"] = "NXinstrument"
+
+    wrapper = NexusWrapper(filename="test_nw5")
+
+    wrapper.find_entries_in_file(file)
+
+    assert wrapper.nexus_file == file
+    assert wrapper.entry == entry
+    assert wrapper.instrument == inst_group
+
+
+def test_GIVEN_multiple_entry_groups_in_file_WHEN_finding_entry_THEN_signal_is_emitted_with_correct_arguments():
+    file = create_in_memory_file("test_nw6")
+
+    entry = file.create_group("entry")
+    entry.attrs["NX_class"] = "NXentry"
+
+    inst_group = entry.create_group("instrument")
+    inst_group.attrs["NX_class"] = "NXinstrument"
+
+    entry2 = file.create_group("entry2")
+    entry.attrs["NX_class"] = "NXentry"
+
+    inst_group2 = entry2.create_group("instrument2")
+    inst_group2.attrs["NX_class"] = "NXinstrument"
+
+    wrapper = NexusWrapper(filename="test_nw7")
+    wrapper.show_entries_dialog = Mock()
+
+    wrapper.find_entries_in_file(file)
+
+    expected_entry_dict = {entry.name: entry, entry2.name: entry2}
+
+    assert wrapper.show_entries_dialog.emit.called_once_with(expected_entry_dict, file)

--- a/tests/test_nexus_wrapper.py
+++ b/tests/test_nexus_wrapper.py
@@ -88,7 +88,8 @@ def test_GIVEN_multiple_entry_groups_in_file_WHEN_finding_entry_THEN_signal_is_e
     file = create_in_memory_file("test_nw6")
 
     entry = file.create_group("entry")
-    entry.attrs["NX_class"] = "NXentry"
+    # Test with byte string as well as python string.
+    entry.attrs["NX_class"] = b"NXentry"
 
     inst_group = entry.create_group("instrument")
     inst_group.attrs["NX_class"] = "NXinstrument"

--- a/tests/test_nexus_wrapper.py
+++ b/tests/test_nexus_wrapper.py
@@ -94,13 +94,14 @@ def test_GIVEN_multiple_entry_groups_in_file_WHEN_finding_entry_THEN_signal_is_e
     inst_group.attrs["NX_class"] = "NXinstrument"
 
     entry2 = file.create_group("entry2")
-    entry.attrs["NX_class"] = "NXentry"
+    entry2.attrs["NX_class"] = "NXentry"
 
     inst_group2 = entry2.create_group("instrument2")
     inst_group2.attrs["NX_class"] = "NXinstrument"
 
     wrapper = NexusWrapper(filename="test_nw7")
     wrapper.show_entries_dialog = Mock()
+    wrapper.show_entries_dialog.emit = Mock()
 
     wrapper.find_entries_in_file(file)
 

--- a/tests/test_nexus_wrapper.py
+++ b/tests/test_nexus_wrapper.py
@@ -1,4 +1,5 @@
 from nexus_constructor.nexus.nexus_wrapper import NexusWrapper, append_nxs_extension
+from tests.test_nexus_to_json import create_in_memory_file
 
 
 def test_GIVEN_nothing_WHEN_creating_nexus_wrapper_THEN_file_contains_entry_group_with_correct_nx_class():
@@ -24,3 +25,40 @@ def test_nxs_is_appended_to_filename():
 def test_nxs_not_appended_to_filename_if_already_present():
     test_filename = "banana.nxs"
     assert append_nxs_extension(test_filename) == f"{test_filename}"
+
+
+def test_GIVEN_entry_group_with_one_instrument_group_WHEN_getting_instrument_group_from_entry_THEN_group_is_returned():
+    file = create_in_memory_file("test_nw1")
+
+    entry = file.create_group("entry")
+    entry.attrs["NX_class"] = "NXentry"
+
+    inst_group = entry.create_group("instrument")
+    inst_group.attrs["NX_class"] = "NXinstrument"
+
+    wrapper = NexusWrapper(filename="test_nw")
+    wrapper.load_file(entry, file)
+
+    assert wrapper.instrument == inst_group
+    assert wrapper.entry == entry
+    assert wrapper.nexus_file == file
+
+
+def test_GIVEN_multiple_entry_groups_WHEN_getting_instrument_group_from_entry_THEN_first_group_is_returned_and_others_are_ignored():
+    file = create_in_memory_file("test_nw3")
+
+    entry = file.create_group("entry")
+    entry.attrs["NX_class"] = "NXentry"
+
+    inst_group = entry.create_group("instrument")
+    inst_group.attrs["NX_class"] = "NXinstrument"
+
+    inst_group2 = entry.create_group("instrument2")
+    inst_group2.attrs["NX_class"] = "NXinstrument"
+
+    wrapper = NexusWrapper(filename="test_nw2")
+    wrapper.load_file(entry, file)
+
+    assert wrapper.nexus_file == file
+    assert wrapper.entry == entry
+    assert wrapper.instrument == inst_group

--- a/tests/test_nexus_wrapper.py
+++ b/tests/test_nexus_wrapper.py
@@ -84,7 +84,7 @@ def test_GIVEN_single_entry_group_with_instrument_group_WHEN_finding_entry_THEN_
     assert wrapper.instrument == inst_group
 
 
-def test_GIVEN_multiple_entry_groups_in_file_WHEN_finding_entry_THEN_signal_is_emitted_with_correct_arguments():
+def test_GIVEN_multiple_entry_groups_in_file_WHEN_finding_entry_THEN_signal_is_emitted_with_entry_options():
     file = create_in_memory_file("test_nw6")
 
     entry = file.create_group("entry")


### PR DESCRIPTION
### Issue

Closes #348 

### Description of work
Adds a dialog that allows the user to choose between `NXentry`s if there are multiple in a file. 

- Added signal for when there are multiple entries in a file
- Added dialog with combo box that shows the names of the entries in a file
- Added function for finding the first `NXinstrument` group in an entry group 

### Acceptance Criteria 

Unit tests should cover all of the new added functionality minus the UI parts until we can get those working. 

Should load nexus files as before but if there are multiple entries it should show the dialog and when selected should select the entry and instrument correctly. to test this add a new component then check the tree view. 

### UI tests

n/a

### Nominate for Group Code Review

- [ ] Nominate for code review 
