### PR TITLE
363: Gnomon is affected by aspect ratio of window

### DIFF
--- a/tests/test_instrument_view.py
+++ b/tests/test_instrument_view.py
@@ -13,7 +13,7 @@ def test_GIVEN_material_properties_WHEN_calling_set_material_properties_THEN_pro
     mock_material.setDiffuse = Mock()
 
     # This method doesn't exist for QPhongMaterial but is mocked all the same to make sure that it isn't called when an
-    # alpha argument isn't given
+    #  alpha argument isn't given
     mock_material.setAlpha = Mock()
 
     InstrumentView.set_material_properties(mock_material, ambient, diffuse)
@@ -69,3 +69,25 @@ def test_GIVEN_components_WHEN_calling_add_components_to_entity_THEN_components_
     InstrumentView.add_qcomponents_to_entity(mock_entity, mock_components)
 
     mock_entity.addComponent.assert_has_calls(calls)
+
+
+def test_GIVEN_3D_view_and_gnomon_sizes_WHEN_calling_calculate_gnomon_rect_THEN_correct_ratios_returned():
+
+    expected_width_ratio = 0.2
+    expected_height_ratio = 0.25
+
+    view_width = 1000
+    view_height = 800
+
+    gnomon_width = view_width * expected_width_ratio
+    gnomon_height = view_height * expected_height_ratio
+
+    # Use the ratio values and the width/height values of an imaginary 3D view to determine the width/height of an
+    #  imaginary gnomon (in this case the gnomon is 200x200). These same ratio values should then be returned when
+    #  calling calculate_gnomon_rect
+    actual_width_ratio, actual_height_ratio = InstrumentView.calculate_gnomon_rect(
+        view_width, view_height, gnomon_width, gnomon_height
+    )
+
+    assert expected_width_ratio == actual_width_ratio
+    assert expected_height_ratio == actual_height_ratio


### PR DESCRIPTION
### Issue

Closes #363

### Description of work

- Added `update_gnomon_rect` and `calculate_gnomon_rect` methods for changing the size of the gnomon viewport when the size of the 3D view changes
- The view's `heightChanged` and `widthChanged` signals are now connected to `update_gnomon_size`
- Gnomon height/width are fixed at 140
- Added a test for `calculate_gnomon_rect`

### Acceptance Criteria 

Resize the window and check that the gnomon stays the same size. Check that the new test passes.

### UI tests

n/a

### Nominate for Group Code Review

- [ ] Nominate for code review 
