### PR TITLE
Fixing NXslit typo in components whitelist

### DIFF
--- a/nexus_constructor/component_type.py
+++ b/nexus_constructor/component_type.py
@@ -34,7 +34,7 @@ COMPONENT_TYPES = [
     "NXpositioner",
     "NXsample_component",
     "NXsensor",
-    "NXSlit",
+    "NXslit",
     "NXvelocity_selector",
     "NXxraylens",
 ]


### PR DESCRIPTION
### Issue

None

### Description of work

Fixes the `NXslit` typo (was `NXSlit`) in the components whitelist

### Acceptance Criteria 

Check that NXslit comes up as an option in the `nx_class` combo box when adding component and that the page is displayed correctly. 

### UI tests

N/A

### Nominate for Group Code Review

- [ ] Nominate for code review 
