### PR TITLE
Allow spinboxes in cylinder editing section to take doubles/floats

### DIFF
--- a/ui/add_component.py
+++ b/ui/add_component.py
@@ -3,7 +3,7 @@
 # Form implementation generated from reading ui file 'add_component.ui',
 # licensing of 'add_component.ui' applies.
 #
-# Created: Thu Jun 13 16:16:47 2019
+# Created: Wed Jul 10 10:28:16 2019
 #      by: pyside2-uic  running on PySide2 5.12.3
 #
 # WARNING! All changes made in this file will be lost!
@@ -117,11 +117,11 @@ class Ui_AddComponentDialog(object):
         self.cylinderOptionsBox.setObjectName("cylinderOptionsBox")
         self.gridLayout = QtWidgets.QGridLayout(self.cylinderOptionsBox)
         self.gridLayout.setObjectName("gridLayout")
-        self.cylinderXLineEdit = QtWidgets.QSpinBox(self.cylinderOptionsBox)
+        self.cylinderXLineEdit = QtWidgets.QDoubleSpinBox(self.cylinderOptionsBox)
         self.cylinderXLineEdit.setMaximum(100000)
         self.cylinderXLineEdit.setObjectName("cylinderXLineEdit")
         self.gridLayout.addWidget(self.cylinderXLineEdit, 2, 1, 1, 1)
-        self.cylinderRadiusLineEdit = QtWidgets.QSpinBox(self.cylinderOptionsBox)
+        self.cylinderRadiusLineEdit = QtWidgets.QDoubleSpinBox(self.cylinderOptionsBox)
         self.cylinderRadiusLineEdit.setMinimum(1)
         self.cylinderRadiusLineEdit.setMaximum(100000)
         self.cylinderRadiusLineEdit.setObjectName("cylinderRadiusLineEdit")
@@ -129,7 +129,7 @@ class Ui_AddComponentDialog(object):
         self.label_6 = QtWidgets.QLabel(self.cylinderOptionsBox)
         self.label_6.setObjectName("label_6")
         self.gridLayout.addWidget(self.label_6, 2, 0, 1, 1)
-        self.cylinderYLineEdit = QtWidgets.QSpinBox(self.cylinderOptionsBox)
+        self.cylinderYLineEdit = QtWidgets.QDoubleSpinBox(self.cylinderOptionsBox)
         self.cylinderYLineEdit.setMaximum(100000)
         self.cylinderYLineEdit.setObjectName("cylinderYLineEdit")
         self.gridLayout.addWidget(self.cylinderYLineEdit, 2, 3, 1, 1)
@@ -145,12 +145,12 @@ class Ui_AddComponentDialog(object):
         self.label_8 = QtWidgets.QLabel(self.cylinderOptionsBox)
         self.label_8.setObjectName("label_8")
         self.gridLayout.addWidget(self.label_8, 2, 4, 1, 1)
-        self.cylinderHeightLineEdit = QtWidgets.QSpinBox(self.cylinderOptionsBox)
+        self.cylinderHeightLineEdit = QtWidgets.QDoubleSpinBox(self.cylinderOptionsBox)
         self.cylinderHeightLineEdit.setMinimum(1)
         self.cylinderHeightLineEdit.setMaximum(100000)
         self.cylinderHeightLineEdit.setObjectName("cylinderHeightLineEdit")
         self.gridLayout.addWidget(self.cylinderHeightLineEdit, 0, 1, 1, 1)
-        self.cylinderZLineEdit = QtWidgets.QSpinBox(self.cylinderOptionsBox)
+        self.cylinderZLineEdit = QtWidgets.QDoubleSpinBox(self.cylinderOptionsBox)
         self.cylinderZLineEdit.setMaximum(100000)
         self.cylinderZLineEdit.setProperty("value", 1)
         self.cylinderZLineEdit.setObjectName("cylinderZLineEdit")

--- a/ui/add_component.ui
+++ b/ui/add_component.ui
@@ -184,14 +184,14 @@
              </property>
              <layout class="QGridLayout" name="gridLayout" columnstretch="0,1,0,1,0,1">
               <item row="2" column="1">
-               <widget class="QSpinBox" name="cylinderXLineEdit">
+               <widget class="QDoubleSpinBox" name="cylinderXLineEdit">
                 <property name="maximum">
                  <number>100000</number>
                 </property>
                </widget>
               </item>
               <item row="0" column="3">
-               <widget class="QSpinBox" name="cylinderRadiusLineEdit">
+               <widget class="QDoubleSpinBox" name="cylinderRadiusLineEdit">
                 <property name="minimum">
                  <number>1</number>
                 </property>
@@ -208,7 +208,7 @@
                </widget>
               </item>
               <item row="2" column="3">
-               <widget class="QSpinBox" name="cylinderYLineEdit">
+               <widget class="QDoubleSpinBox" name="cylinderYLineEdit">
                 <property name="maximum">
                  <number>100000</number>
                 </property>
@@ -243,7 +243,7 @@
                </widget>
               </item>
               <item row="0" column="1">
-               <widget class="QSpinBox" name="cylinderHeightLineEdit">
+               <widget class="QDoubleSpinBox" name="cylinderHeightLineEdit">
                 <property name="minimum">
                  <number>1</number>
                 </property>
@@ -253,7 +253,7 @@
                </widget>
               </item>
               <item row="2" column="5">
-               <widget class="QSpinBox" name="cylinderZLineEdit">
+               <widget class="QDoubleSpinBox" name="cylinderZLineEdit">
                 <property name="maximum">
                  <number>100000</number>
                 </property>


### PR DESCRIPTION
### Issue

Closes #387 

### Description of work

- Replaced `QSpinBox` instances in `add_component.ui` with `QDoubleSpinBox`
- Re-generated the python file from the .ui file

### Acceptance Criteria 

Cylinders now take floats as well as integers. 

### UI tests

N/A

### Nominate for Group Code Review

- [ ] Nominate for code review 
