### PR TITLE
Adding Mutmut config file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,10 @@ max-line-length = 119
 
 [tool:pytest]
 addopts = --ignore=prototype/
+
+[mutmut]
+paths_to_mutate=nexus_constructor/
+backup=False
+runner=pytest .
+tests_dir=tests/
+dict_synonyms=Struct, NamedStruct


### PR DESCRIPTION
### Issue

Relates to #194 but does not close.

### Description of work

I configured mutmut and ran mutation tests on the nexus-constructor as a bit of an experiment after a PD session on mutation testing. The results were as follows: 

Legend for output:
🎉 Killed mutants.   The goal is for everything to end up in this bucket.
⏰ Timeout.          Test suite took 10 times as long as the baseline so were killed.
🤔 Suspicious.       Tests took a long time, but not long enough to be fatal.
🙁 Survived.         This means your tests needs to be expanded.

⠏ 2061/2061  🎉 766  ⏰ 1  🤔 0  🙁 1294


As you can see our tests need some work! Although i was expecting to see a lower number on the mutants that were killed.

I have added the `setup.cfg` config file for future use so we could automate it at some point. Let me know if you want a copy of the cache to run `mutmut results` on and find out where our tests went wrong.  

The tests took quite a while to run, so wouldn't recommend running mutmut on PR builds or anything, perhaps a nightly job would be more appropriate if we are going to use it. 

the worst culprits for surviving mutations were: 

- `nexus/geometry.py` with 188 
- `gnomon.py` with 182 
- `main_window.py` with 146 
- `geometry_types.py` with 109 

The rest were just scattered throughout the rest of the files. 

### Acceptance Criteria 

No functional changes, have just added a mutmut config.

### UI tests

N/A

### Nominate for Group Code Review

- [ ] Nominate for code review 
