### PR TITLE
Replacing line edits with spin boxes for transformation frames

### DIFF
--- a/nexus_constructor/transformation_view.py
+++ b/nexus_constructor/transformation_view.py
@@ -14,11 +14,11 @@ class EditTransformation(QGroupBox):
         self.transformation_frame.setupUi(self)
         self.transformation = transformation
         current_vector = self.transformation.vector
-        self.transformation_frame.xLineEdit.setText(str(current_vector.x()))
-        self.transformation_frame.yLineEdit.setText(str(current_vector.y()))
-        self.transformation_frame.zLineEdit.setText(str(current_vector.z()))
+        self.transformation_frame.xLineEdit.setValue(current_vector.x())
+        self.transformation_frame.yLineEdit.setValue(current_vector.y())
+        self.transformation_frame.zLineEdit.setValue(current_vector.z())
         self.transformation_frame.nameLineEdit.setText(self.transformation.name)
-        self.transformation_frame.valueLineEdit.setText(str(self.transformation.value))
+        self.transformation_frame.valueLineEdit.setValue(self.transformation.value)
         self.disable()
 
     def disable(self):
@@ -39,20 +39,12 @@ class EditTransformation(QGroupBox):
 
     def saveChanges(self):
         self.transformation.name = self.transformation_frame.nameLineEdit.text()
-        try:
-            self.transformation.vector = QVector3D(
-                float(self.transformation_frame.xLineEdit.text()),
-                float(self.transformation_frame.yLineEdit.text()),
-                float(self.transformation_frame.zLineEdit.text()),
-            )
-        except ValueError as e:
-            print("Unable to convert vectors: " + str(e))
-        try:
-            self.transformation.value = float(
-                self.transformation_frame.valueLineEdit.text()
-            )
-        except ValueError as e:
-            print("Unable to convert length: " + str(e))
+        self.transformation.vector = QVector3D(
+            self.transformation_frame.xLineEdit.value(),
+            self.transformation_frame.yLineEdit.value(),
+            self.transformation_frame.zLineEdit.value(),
+        )
+        self.transformation.value = self.transformation_frame.valueLineEdit.value()
 
 
 class EditTranslation(EditTransformation):

--- a/nexus_constructor/transformation_view.py
+++ b/nexus_constructor/transformation_view.py
@@ -14,37 +14,37 @@ class EditTransformation(QGroupBox):
         self.transformation_frame.setupUi(self)
         self.transformation = transformation
         current_vector = self.transformation.vector
-        self.transformation_frame.xLineEdit.setValue(current_vector.x())
-        self.transformation_frame.yLineEdit.setValue(current_vector.y())
-        self.transformation_frame.zLineEdit.setValue(current_vector.z())
+        self.transformation_frame.xSpinBox.setValue(current_vector.x())
+        self.transformation_frame.ySpinBox.setValue(current_vector.y())
+        self.transformation_frame.zSpinBox.setValue(current_vector.z())
         self.transformation_frame.nameLineEdit.setText(self.transformation.name)
-        self.transformation_frame.valueLineEdit.setValue(self.transformation.value)
+        self.transformation_frame.valueSpinBox.setValue(self.transformation.value)
         self.disable()
 
     def disable(self):
-        self.transformation_frame.xLineEdit.setEnabled(False)
-        self.transformation_frame.yLineEdit.setEnabled(False)
-        self.transformation_frame.zLineEdit.setEnabled(False)
-        self.transformation_frame.valueLineEdit.setEnabled(False)
+        self.transformation_frame.xSpinBox.setEnabled(False)
+        self.transformation_frame.ySpinBox.setEnabled(False)
+        self.transformation_frame.zSpinBox.setEnabled(False)
+        self.transformation_frame.valueSpinBox.setEnabled(False)
         self.transformation_frame.nameLineEdit.setEnabled(False)
         self.transformation_frame.editButton.setText("Edit")
 
     def enable(self):
-        self.transformation_frame.xLineEdit.setEnabled(True)
-        self.transformation_frame.yLineEdit.setEnabled(True)
-        self.transformation_frame.zLineEdit.setEnabled(True)
-        self.transformation_frame.valueLineEdit.setEnabled(True)
+        self.transformation_frame.xSpinBox.setEnabled(True)
+        self.transformation_frame.ySpinBox.setEnabled(True)
+        self.transformation_frame.zSpinBox.setEnabled(True)
+        self.transformation_frame.valueSpinBox.setEnabled(True)
         self.transformation_frame.nameLineEdit.setEnabled(True)
         self.transformation_frame.editButton.setText("Done")
 
     def saveChanges(self):
         self.transformation.name = self.transformation_frame.nameLineEdit.text()
         self.transformation.vector = QVector3D(
-            self.transformation_frame.xLineEdit.value(),
-            self.transformation_frame.yLineEdit.value(),
-            self.transformation_frame.zLineEdit.value(),
+            self.transformation_frame.xSpinBox.value(),
+            self.transformation_frame.ySpinBox.value(),
+            self.transformation_frame.zSpinBox.value(),
         )
-        self.transformation.value = self.transformation_frame.valueLineEdit.value()
+        self.transformation.value = self.transformation_frame.valueSpinBox.value()
 
 
 class EditTranslation(EditTransformation):

--- a/ui/transformation.py
+++ b/ui/transformation.py
@@ -3,8 +3,8 @@
 # Form implementation generated from reading ui file 'transformation.ui',
 # licensing of 'transformation.ui' applies.
 #
-# Created: Thu Jul  4 23:55:45 2019
-#      by: pyside2-uic  running on PySide2 5.12.3
+# Created: Wed Jul 17 14:07:33 2019
+#      by: pyside2-uic  running on PySide2 5.13.0
 #
 # WARNING! All changes made in this file will be lost!
 
@@ -54,19 +54,19 @@ class Ui_Transformation(object):
         self.xPosLabel = QtWidgets.QLabel(Transformation)
         self.xPosLabel.setObjectName("xPosLabel")
         self.vectorLayout.addWidget(self.xPosLabel)
-        self.xLineEdit = QtWidgets.QLineEdit(Transformation)
+        self.xLineEdit = QtWidgets.QDoubleSpinBox(Transformation)
         self.xLineEdit.setObjectName("xLineEdit")
         self.vectorLayout.addWidget(self.xLineEdit)
         self.yPosLabel = QtWidgets.QLabel(Transformation)
         self.yPosLabel.setObjectName("yPosLabel")
         self.vectorLayout.addWidget(self.yPosLabel)
-        self.yLineEdit = QtWidgets.QLineEdit(Transformation)
+        self.yLineEdit = QtWidgets.QDoubleSpinBox(Transformation)
         self.yLineEdit.setObjectName("yLineEdit")
         self.vectorLayout.addWidget(self.yLineEdit)
         self.zPosLabel = QtWidgets.QLabel(Transformation)
         self.zPosLabel.setObjectName("zPosLabel")
         self.vectorLayout.addWidget(self.zPosLabel)
-        self.zLineEdit = QtWidgets.QLineEdit(Transformation)
+        self.zLineEdit = QtWidgets.QDoubleSpinBox(Transformation)
         self.zLineEdit.setObjectName("zLineEdit")
         self.vectorLayout.addWidget(self.zLineEdit)
         self.mainLayout.addLayout(self.vectorLayout)
@@ -81,7 +81,7 @@ class Ui_Transformation(object):
         self.valueLabel = QtWidgets.QLabel(Transformation)
         self.valueLabel.setObjectName("valueLabel")
         self.lengthLayout.addWidget(self.valueLabel)
-        self.valueLineEdit = QtWidgets.QLineEdit(Transformation)
+        self.valueLineEdit = QtWidgets.QDoubleSpinBox(Transformation)
         self.valueLineEdit.setMaximumSize(QtCore.QSize(100, 16777215))
         self.valueLineEdit.setObjectName("valueLineEdit")
         self.lengthLayout.addWidget(self.valueLineEdit)

--- a/ui/transformation.py
+++ b/ui/transformation.py
@@ -3,7 +3,7 @@
 # Form implementation generated from reading ui file 'transformation.ui',
 # licensing of 'transformation.ui' applies.
 #
-# Created: Wed Jul 17 14:07:33 2019
+# Created: Wed Jul 17 14:31:45 2019
 #      by: pyside2-uic  running on PySide2 5.13.0
 #
 # WARNING! All changes made in this file will be lost!
@@ -54,21 +54,21 @@ class Ui_Transformation(object):
         self.xPosLabel = QtWidgets.QLabel(Transformation)
         self.xPosLabel.setObjectName("xPosLabel")
         self.vectorLayout.addWidget(self.xPosLabel)
-        self.xLineEdit = QtWidgets.QDoubleSpinBox(Transformation)
-        self.xLineEdit.setObjectName("xLineEdit")
-        self.vectorLayout.addWidget(self.xLineEdit)
+        self.xSpinBox = QtWidgets.QDoubleSpinBox(Transformation)
+        self.xSpinBox.setObjectName("xSpinBox")
+        self.vectorLayout.addWidget(self.xSpinBox)
         self.yPosLabel = QtWidgets.QLabel(Transformation)
         self.yPosLabel.setObjectName("yPosLabel")
         self.vectorLayout.addWidget(self.yPosLabel)
-        self.yLineEdit = QtWidgets.QDoubleSpinBox(Transformation)
-        self.yLineEdit.setObjectName("yLineEdit")
-        self.vectorLayout.addWidget(self.yLineEdit)
+        self.ySpinBox = QtWidgets.QDoubleSpinBox(Transformation)
+        self.ySpinBox.setObjectName("ySpinBox")
+        self.vectorLayout.addWidget(self.ySpinBox)
         self.zPosLabel = QtWidgets.QLabel(Transformation)
         self.zPosLabel.setObjectName("zPosLabel")
         self.vectorLayout.addWidget(self.zPosLabel)
-        self.zLineEdit = QtWidgets.QDoubleSpinBox(Transformation)
-        self.zLineEdit.setObjectName("zLineEdit")
-        self.vectorLayout.addWidget(self.zLineEdit)
+        self.zSpinBox = QtWidgets.QDoubleSpinBox(Transformation)
+        self.zSpinBox.setObjectName("zSpinBox")
+        self.vectorLayout.addWidget(self.zSpinBox)
         self.mainLayout.addLayout(self.vectorLayout)
         self.line_3 = QtWidgets.QFrame(Transformation)
         self.line_3.setFrameShape(QtWidgets.QFrame.HLine)
@@ -81,10 +81,10 @@ class Ui_Transformation(object):
         self.valueLabel = QtWidgets.QLabel(Transformation)
         self.valueLabel.setObjectName("valueLabel")
         self.lengthLayout.addWidget(self.valueLabel)
-        self.valueLineEdit = QtWidgets.QDoubleSpinBox(Transformation)
-        self.valueLineEdit.setMaximumSize(QtCore.QSize(100, 16777215))
-        self.valueLineEdit.setObjectName("valueLineEdit")
-        self.lengthLayout.addWidget(self.valueLineEdit)
+        self.valueSpinBox = QtWidgets.QDoubleSpinBox(Transformation)
+        self.valueSpinBox.setMaximumSize(QtCore.QSize(100, 16777215))
+        self.valueSpinBox.setObjectName("valueSpinBox")
+        self.lengthLayout.addWidget(self.valueSpinBox)
         spacerItem = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
         self.lengthLayout.addItem(spacerItem)
         self.line_2 = QtWidgets.QFrame(Transformation)

--- a/ui/transformation.ui
+++ b/ui/transformation.ui
@@ -91,7 +91,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QLineEdit" name="xLineEdit"/>
+        <widget class="QDoubleSpinBox" name="xLineEdit"/>
        </item>
        <item>
         <widget class="QLabel" name="yPosLabel">
@@ -101,7 +101,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QLineEdit" name="yLineEdit"/>
+        <widget class="QDoubleSpinBox" name="yLineEdit"/>
        </item>
        <item>
         <widget class="QLabel" name="zPosLabel">
@@ -111,7 +111,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QLineEdit" name="zLineEdit"/>
+        <widget class="QDoubleSpinBox" name="zLineEdit"/>
        </item>
       </layout>
      </item>
@@ -135,7 +135,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QLineEdit" name="valueLineEdit">
+        <widget class="QDoubleSpinBox" name="valueLineEdit">
          <property name="maximumSize">
           <size>
            <width>100</width>

--- a/ui/transformation.ui
+++ b/ui/transformation.ui
@@ -91,7 +91,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QDoubleSpinBox" name="xLineEdit"/>
+        <widget class="QDoubleSpinBox" name="xSpinBox"/>
        </item>
        <item>
         <widget class="QLabel" name="yPosLabel">
@@ -101,7 +101,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QDoubleSpinBox" name="yLineEdit"/>
+        <widget class="QDoubleSpinBox" name="ySpinBox"/>
        </item>
        <item>
         <widget class="QLabel" name="zPosLabel">
@@ -111,7 +111,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QDoubleSpinBox" name="zLineEdit"/>
+        <widget class="QDoubleSpinBox" name="zSpinBox"/>
        </item>
       </layout>
      </item>
@@ -135,7 +135,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QDoubleSpinBox" name="valueLineEdit">
+        <widget class="QDoubleSpinBox" name="valueSpinBox">
          <property name="maximumSize">
           <size>
            <width>100</width>


### PR DESCRIPTION
### Issue

Closes #376 

### Description of work

Just thought i'd do this really quickly as it'll make the program quite a bit more robust.

I have replaced the line edits in the transformation frames so that a user cannot input anything other than numerical values, previously they could put "asdfisdfi" and it would still work (or do nothing) 

no more casting from float to str! and vice versa. 

### Acceptance Criteria 

Jenkins passes
Check no errors occur when adding transformations 

### UI tests

I haven't added any, because the UI for this part of the program is likely about to change anyway. #404 should cover the transformations stuff when done. 

### Nominate for Group Code Review

- [ ] Nominate for code review 
