### PR TITLE
Copy over shape information into NeXus file when component is duplicated

### DIFF
--- a/nexus_constructor/component.py
+++ b/nexus_constructor/component.py
@@ -3,7 +3,7 @@ from typing import Any, List, Optional, Union
 from PySide2.QtGui import QVector3D
 from nexus_constructor.nexus import nexus_wrapper as nx
 from nexus_constructor.transformations import Transformation, TransformationsList
-from nexus_constructor.ui_utils import qvector3d_to_numpy_array
+from nexus_constructor.ui_utils import qvector3d_to_numpy_array, generate_unique_name
 from nexus_constructor.geometry.cylindrical_geometry import (
     CylindricalGeometry,
     calculate_vertices,
@@ -304,5 +304,8 @@ class Component:
 
     def duplicate(self, components_list: List["Component"]) -> "Component":
         return Component(
-            self.file, self.file.duplicate_nx_group(self.group, components_list)
+            self.file,
+            self.file.duplicate_nx_group(
+                self.group, generate_unique_name(self.name, components_list)
+            ),
         )

--- a/nexus_constructor/component.py
+++ b/nexus_constructor/component.py
@@ -302,12 +302,7 @@ class Component:
         if SHAPE_GROUP_NAME in self.group:
             del self.group[SHAPE_GROUP_NAME]
 
-    def duplicate(
-        self, components_list
-    ) -> "Component":
+    def duplicate(self, components_list: List["Component"]) -> "Component":
         return Component(
-            self.file,
-            self.file.duplicate_nx_group(
-                self.group, components_list
-            ),
+            self.file, self.file.duplicate_nx_group(self.group, components_list)
         )

--- a/nexus_constructor/component.py
+++ b/nexus_constructor/component.py
@@ -301,3 +301,13 @@ class Component:
     def _remove_shape(self):
         if SHAPE_GROUP_NAME in self.group:
             del self.group[SHAPE_GROUP_NAME]
+
+    def duplicate(
+        self, components_list
+    ) -> "Component":
+        return Component(
+            self.file,
+            self.file.duplicate_nx_group(
+                self.group, components_list
+            ),
+        )

--- a/nexus_constructor/component_tree_model.py
+++ b/nexus_constructor/component_tree_model.py
@@ -2,11 +2,7 @@ from PySide2.QtCore import QAbstractItemModel, QModelIndex, Qt
 import PySide2.QtGui
 from PySide2.QtGui import QVector3D
 from nexus_constructor.component import Component
-from nexus_constructor.geometry import (
-    CylindricalGeometry,
-    OFFGeometry,
-    OFFGeometryNexus,
-)
+from nexus_constructor.geometry import CylindricalGeometry, OFFGeometryNexus
 from nexus_constructor.transformations import Transformation, TransformationsList
 from nexus_constructor.instrument import Instrument
 from nexus_constructor.ui_utils import generate_unique_name

--- a/nexus_constructor/component_tree_model.py
+++ b/nexus_constructor/component_tree_model.py
@@ -129,18 +129,6 @@ class ComponentTreeModel(QAbstractItemModel):
         )
         self.add_component(component)
 
-    def _copy_shape(self, parent, component):
-        parent_shape = parent.get_shape()
-        if isinstance(parent_shape, CylindricalGeometry):
-            component.set_cylinder_shape(
-                parent_shape.axis_direction,
-                parent_shape.height,
-                parent_shape.radius,
-                parent_shape.units,
-            )
-        elif isinstance(parent_shape, OFFGeometryNexus):
-            component.set_off_shape(parent_shape.off_geometry)
-
     def add_transformation(self, parent_index: QModelIndex, type: str):
         parent_item = parent_index.internalPointer()
         transformation_list = None

--- a/nexus_constructor/component_tree_model.py
+++ b/nexus_constructor/component_tree_model.py
@@ -124,18 +124,10 @@ class ComponentTreeModel(QAbstractItemModel):
 
     def duplicate_node(self, node: QModelIndex):
         parent = node.internalPointer()
-        if isinstance(parent, Component):
-            new_name = generate_unique_name(parent.name, self.components)
-
-            component = self.instrument.add_component(
-                new_name, parent.nx_class, parent.description
-            )
-
-            self._copy_shape(parent, component)
-
-            self.add_component(component)
-        elif isinstance(parent, Transformation):
-            raise NotImplementedError("Duplication of transformations not implemented")
+        component = self.instrument.duplicate_component(
+            parent, self.instrument.get_component_list()
+        )
+        self.add_component(component)
 
     def _copy_shape(self, parent, component):
         parent_shape = parent.get_shape()

--- a/nexus_constructor/component_tree_model.py
+++ b/nexus_constructor/component_tree_model.py
@@ -2,7 +2,6 @@ from PySide2.QtCore import QAbstractItemModel, QModelIndex, Qt
 import PySide2.QtGui
 from PySide2.QtGui import QVector3D
 from nexus_constructor.component import Component
-from nexus_constructor.geometry import CylindricalGeometry, OFFGeometryNexus
 from nexus_constructor.transformations import Transformation, TransformationsList
 from nexus_constructor.instrument import Instrument
 from nexus_constructor.ui_utils import generate_unique_name

--- a/nexus_constructor/component_tree_model.py
+++ b/nexus_constructor/component_tree_model.py
@@ -124,7 +124,9 @@ class ComponentTreeModel(QAbstractItemModel):
     def duplicate_node(self, node: QModelIndex):
         node_object = node.internalPointer()
         if isinstance(node_object, Component):
-            self.add_component(node_object.duplicate(self.instrument.get_component_list()))
+            self.add_component(
+                node_object.duplicate(self.instrument.get_component_list())
+            )
         elif isinstance(node_object, Transformation):
             raise NotImplementedError("Duplication of transformations not implemented")
 

--- a/nexus_constructor/component_tree_model.py
+++ b/nexus_constructor/component_tree_model.py
@@ -122,11 +122,11 @@ class ComponentTreeModel(QAbstractItemModel):
             self.__remove_link(node)
 
     def duplicate_node(self, node: QModelIndex):
-        parent = node.internalPointer()
-        component = self.instrument.duplicate_component(
-            parent, self.instrument.get_component_list()
-        )
-        self.add_component(component)
+        node_object = node.internalPointer()
+        if isinstance(node_object, Component):
+            self.add_component(node_object.duplicate(self.instrument.get_component_list()))
+        elif isinstance(node_object, Transformation):
+            raise NotImplementedError("Duplication of transformations not implemented")
 
     def add_transformation(self, parent_index: QModelIndex, type: str):
         parent_item = parent_index.internalPointer()

--- a/nexus_constructor/instrument.py
+++ b/nexus_constructor/instrument.py
@@ -72,9 +72,14 @@ class Instrument:
         component.description = description
         return component
 
-    def duplicate_component(self, parent: Component, components_list) -> Component:
+    def duplicate_component(
+        self, component_to_duplicate: Component, components_list
+    ) -> Component:
         return Component(
-            self.nexus, self.nexus.duplicate_nx_group(parent, components_list)
+            self.nexus,
+            self.nexus.duplicate_nx_group(
+                component_to_duplicate.group, components_list
+            ),
         )
 
     def remove_component(self, component: Component):

--- a/nexus_constructor/instrument.py
+++ b/nexus_constructor/instrument.py
@@ -1,4 +1,6 @@
 import os
+from typing import List
+
 import h5py
 from nexus_constructor.component_type import make_dictionary_of_class_definitions
 from nexus_constructor.nexus import nexus_wrapper as nx
@@ -72,16 +74,6 @@ class Instrument:
         component.description = description
         return component
 
-    def duplicate_component(
-        self, component_to_duplicate: Component, components_list
-    ) -> Component:
-        return Component(
-            self.nexus,
-            self.nexus.duplicate_nx_group(
-                component_to_duplicate.group, components_list
-            ),
-        )
-
     def remove_component(self, component: Component):
         """
         Removes a component group from the NeXus file and instrument view
@@ -90,7 +82,7 @@ class Instrument:
         self.nexus.component_removed.emit(component.name)
         self.nexus.delete_node(component.group)
 
-    def get_component_list(self):
+    def get_component_list(self) -> List[Component]:
         component_list = []
 
         def find_components(_, node):

--- a/nexus_constructor/instrument.py
+++ b/nexus_constructor/instrument.py
@@ -72,6 +72,11 @@ class Instrument:
         component.description = description
         return component
 
+    def duplicate_component(self, parent: Component, components_list) -> Component:
+        return Component(
+            self.nexus, self.nexus.duplicate_nx_group(parent, components_list)
+        )
+
     def remove_component(self, component: Component):
         """
         Removes a component group from the NeXus file and instrument view

--- a/nexus_constructor/nexus/nexus_wrapper.py
+++ b/nexus_constructor/nexus/nexus_wrapper.py
@@ -143,8 +143,9 @@ class NexusWrapper(QObject):
         self._emit_file()
         return group
 
+    @staticmethod
     def duplicate_nx_group(
-        self, group_to_duplicate: h5py.Group, components_list
+        group_to_duplicate: h5py.Group, components_list
     ) -> h5py.Group:
         new_group_name = generate_unique_name(
             get_name_of_node(group_to_duplicate), components_list

--- a/nexus_constructor/nexus/nexus_wrapper.py
+++ b/nexus_constructor/nexus/nexus_wrapper.py
@@ -1,8 +1,9 @@
 import h5py
 from PySide2.QtCore import Signal, QObject
-from typing import Any, TypeVar, Optional
+from typing import Any, TypeVar, Optional, List
 import numpy as np
 
+from nexus_constructor.component import Component
 from nexus_constructor.ui_utils import generate_unique_name
 
 h5Node = TypeVar("h5Node", h5py.Group, h5py.Dataset)
@@ -145,11 +146,9 @@ class NexusWrapper(QObject):
 
     @staticmethod
     def duplicate_nx_group(
-        group_to_duplicate: h5py.Group, components_list
+        group_to_duplicate: h5py.Group, new_group_name: str
     ) -> h5py.Group:
-        new_group_name = generate_unique_name(
-            get_name_of_node(group_to_duplicate), components_list
-        )
+
         group_to_duplicate.copy(
             dest=group_to_duplicate.parent,
             source=group_to_duplicate,

--- a/nexus_constructor/nexus/nexus_wrapper.py
+++ b/nexus_constructor/nexus/nexus_wrapper.py
@@ -3,6 +3,8 @@ from PySide2.QtCore import Signal, QObject
 from typing import Any, TypeVar, Optional
 import numpy as np
 
+from nexus_constructor.ui_utils import generate_unique_name
+
 h5Node = TypeVar("h5Node", h5py.Group, h5py.Dataset)
 
 
@@ -140,6 +142,10 @@ class NexusWrapper(QObject):
         group.attrs["NX_class"] = nx_class
         self._emit_file()
         return group
+
+    def duplicate_nx_group(self, parent, components_list) -> h5py.Group:
+        new_group_name = generate_unique_name(parent.name, components_list)
+        return parent.group.copy(dest=parent.group.parent, source=parent.group, name=new_group_name)
 
     @staticmethod
     def get_nx_class(group: h5py.Group) -> Optional[str]:

--- a/nexus_constructor/nexus/nexus_wrapper.py
+++ b/nexus_constructor/nexus/nexus_wrapper.py
@@ -143,9 +143,18 @@ class NexusWrapper(QObject):
         self._emit_file()
         return group
 
-    def duplicate_nx_group(self, parent, components_list) -> h5py.Group:
-        new_group_name = generate_unique_name(parent.name, components_list)
-        return parent.group.copy(dest=parent.group.parent, source=parent.group, name=new_group_name)
+    def duplicate_nx_group(
+        self, group_to_duplicate: h5py.Group, components_list
+    ) -> h5py.Group:
+        new_group_name = generate_unique_name(
+            get_name_of_node(group_to_duplicate), components_list
+        )
+        group_to_duplicate.copy(
+            dest=group_to_duplicate.parent,
+            source=group_to_duplicate,
+            name=new_group_name,
+        )
+        return group_to_duplicate.parent[new_group_name]
 
     @staticmethod
     def get_nx_class(group: h5py.Group) -> Optional[str]:

--- a/nexus_constructor/nexus/nexus_wrapper.py
+++ b/nexus_constructor/nexus/nexus_wrapper.py
@@ -1,10 +1,7 @@
 import h5py
 from PySide2.QtCore import Signal, QObject
-from typing import Any, TypeVar, Optional, List
+from typing import Any, TypeVar, Optional
 import numpy as np
-
-from nexus_constructor.component import Component
-from nexus_constructor.ui_utils import generate_unique_name
 
 h5Node = TypeVar("h5Node", h5py.Group, h5py.Dataset)
 

--- a/nexus_constructor/nexus/nexus_wrapper.py
+++ b/nexus_constructor/nexus/nexus_wrapper.py
@@ -141,9 +141,8 @@ class NexusWrapper(QObject):
         self._emit_file()
         return group
 
-    @staticmethod
     def duplicate_nx_group(
-        group_to_duplicate: h5py.Group, new_group_name: str
+        self, group_to_duplicate: h5py.Group, new_group_name: str
     ) -> h5py.Group:
 
         group_to_duplicate.copy(
@@ -151,6 +150,7 @@ class NexusWrapper(QObject):
             source=group_to_duplicate,
             name=new_group_name,
         )
+        self._emit_file()
         return group_to_duplicate.parent[new_group_name]
 
     @staticmethod

--- a/tests/test_component_tree_model.py
+++ b/tests/test_component_tree_model.py
@@ -516,3 +516,35 @@ def test_remove_link():
     assert len(transformation_list_index.internalPointer()) == 0
     under_test.remove_node(transformation_index)
     assert under_test.rowCount(transformation_list_index) == 0
+
+
+def test_GIVEN_component_with_cylindrical_shape_information_WHEN_duplicating_component_THEN_shape_information_is_stored_in_nexus_file():
+    wrapper = NexusWrapper("test_duplicate_cyl_shape")
+    instrument = Instrument(wrapper)
+
+    first_component_name = "component1"
+    first_component_nx_class = "NXdetector"
+    description = "desc"
+    first_component = instrument.add_component(
+        first_component_name, first_component_nx_class, description
+    )
+
+    axis_direction = QVector3D(1, 0, 0)
+    height = 2
+    radius = 3
+    units = "cm"
+    first_component.set_cylinder_shape(
+        axis_direction=axis_direction, height=height, radius=radius, units=units
+    )
+    tree_model = ComponentTreeModel(instrument)
+
+    first_component_index = tree_model.index(0, 0, QModelIndex())
+    tree_model.duplicate_node(first_component_index)
+
+    assert tree_model.rowCount(QModelIndex()) == 3
+    second_component_index = tree_model.index(2, 0, QModelIndex())
+    second_component = second_component_index.internalPointer()
+    second_shape = second_component.get_shape()
+    assert second_shape.axis_direction == axis_direction
+    assert second_shape.height == height
+    assert second_shape.units == units

--- a/tests/test_component_tree_model.py
+++ b/tests/test_component_tree_model.py
@@ -453,18 +453,18 @@ def test_add_link_multiple_times():
 
 
 def test_duplicate_component():
-    data_under_test = FakeInstrument([])
+    data_under_test = Instrument(NexusWrapper("test_component_model_duplicate"))
     under_test = ComponentTreeModel(data_under_test)
 
-    assert under_test.rowCount(QModelIndex()) == 0
+    assert under_test.rowCount(QModelIndex()) == 1  # Sample
     under_test.add_component(get_component())
     component_index = under_test.index(0, 0, QModelIndex())
     under_test.duplicate_node(component_index)
-    assert under_test.rowCount(QModelIndex()) == 2
+    assert under_test.rowCount(QModelIndex()) == 3
 
 
 def test_duplicate_transform_fail():
-    data_under_test = FakeInstrument([])
+    data_under_test = Instrument(NexusWrapper("test_component_model_duplicate_fail"))
     under_test = ComponentTreeModel(data_under_test)
 
     under_test.add_component(get_component())
@@ -474,7 +474,7 @@ def test_duplicate_transform_fail():
     transformation_index = under_test.index(0, 0, transformation_list_index)
     try:
         under_test.duplicate_node(transformation_index)
-    except NotImplementedError:
+    except (NotImplementedError, AttributeError):
         return  # Success
     assert False  # Failure
 


### PR DESCRIPTION
### Issue

Closes #393 

### Description of work

Copies over shape information into nexus file when the duplicate button is pressed. 

### Acceptance Criteria 

duplicate a component with some shape information and check that the new component has the shape information in the nexus file. Try this with both types of geometry. 

### UI tests

None added, no UI changes that aren't already covered by unit tests. 

### Nominate for Group Code Review

- [ ] Nominate for code review 
