### PR TITLE
using qcylindermesh instead of OFFmesh for cylinders

### DIFF
--- a/nexus_constructor/geometry/cylindrical_geometry.py
+++ b/nexus_constructor/geometry/cylindrical_geometry.py
@@ -111,7 +111,7 @@ class CylindricalGeometry:
         return cylinder_axis.normalized()
 
     @property
-    def mesh(self) -> Qt3DExtras.QCylinderGeometry:
+    def mesh(self) -> Qt3DExtras.QCylinderMesh:
         geom = Qt3DExtras.QCylinderMesh()
         geom.setLength(self.height)
         geom.setRadius(self.radius)

--- a/nexus_constructor/geometry/cylindrical_geometry.py
+++ b/nexus_constructor/geometry/cylindrical_geometry.py
@@ -1,7 +1,6 @@
 from PySide2.QtGui import QVector3D, QMatrix4x4
 from PySide2.Qt3DExtras import Qt3DExtras
-from nexus_constructor.unit_converter import calculate_unit_conversion_factor
-from math import sin, cos, pi, acos, degrees
+from math import acos, degrees
 import h5py
 import numpy as np
 from nexus_constructor.nexus import nexus_wrapper as nx
@@ -15,7 +14,6 @@ from nexus_constructor.ui_utils import (
     qvector3d_to_numpy_array,
 )
 from nexus_constructor.geometry.utils import get_an_orthogonal_unit_vector
-from nexus_constructor.geometry.off_geometry import OFFGeometry, OFFGeometryNoNexus
 from typing import Tuple
 
 

--- a/nexus_constructor/geometry/cylindrical_geometry.py
+++ b/nexus_constructor/geometry/cylindrical_geometry.py
@@ -3,6 +3,8 @@ from PySide2.Qt3DExtras import Qt3DExtras
 from math import acos, degrees
 import h5py
 import numpy as np
+
+from nexus_constructor.geometry.mesh import Mesh
 from nexus_constructor.nexus import nexus_wrapper as nx
 from nexus_constructor.nexus.validation import (
     NexusFormatError,
@@ -42,7 +44,7 @@ def calculate_vertices(
     return vertices
 
 
-class CylindricalGeometry:
+class CylindricalGeometry(Mesh):
     """
     Describes the shape of a cylinder in 3D space. The cylinder's centre is the origin of the local coordinate system.
     This wrapper does not have setters, delete cylinder and create a new one if the cylinder needs to change.

--- a/nexus_constructor/geometry/mesh.py
+++ b/nexus_constructor/geometry/mesh.py
@@ -1,0 +1,14 @@
+from abc import ABC, abstractmethod
+
+from PySide2.Qt3DRender import Qt3DRender
+
+
+class Mesh(ABC):
+    """
+    Abstract class for mesh types
+    """
+
+    @property
+    @abstractmethod
+    def mesh(self) -> Qt3DRender.QGeometry:
+        pass

--- a/nexus_constructor/geometry/off_geometry.py
+++ b/nexus_constructor/geometry/off_geometry.py
@@ -9,6 +9,7 @@ from nexus_constructor.nexus.validation import (
     ValidateDataset,
     validate_group,
 )
+from nexus_constructor.off_renderer import OffMesh
 from nexus_constructor.ui_utils import (
     numpy_array_to_qvector3d,
     qvector3d_to_numpy_array,
@@ -38,7 +39,7 @@ class OFFGeometry(ABC):
 
     @property
     @abstractmethod
-    def off_geometry(self) -> "OFFGeometry":
+    def mesh(self) -> OffMesh:
         pass
 
     @property
@@ -89,8 +90,8 @@ class OFFGeometryNoNexus(OFFGeometry):
         return [sum(face_sizes[0:i]) for i in range(len(face_sizes))]
 
     @property
-    def off_geometry(self) -> OFFGeometry:
-        return self
+    def mesh(self) -> OffMesh:
+        return OffMesh(self)
 
     @property
     def vertices(self) -> List[QVector3D]:
@@ -159,7 +160,7 @@ class OFFGeometryNexus(OFFGeometry):
         return [sum(face_sizes[0:i]) for i in range(len(face_sizes))]
 
     @property
-    def off_geometry(self) -> OFFGeometry:
+    def mesh(self) -> "OFFGeometry":
         return OFFGeometryNoNexus(self.vertices, self.faces)
 
     @property

--- a/nexus_constructor/geometry/off_geometry.py
+++ b/nexus_constructor/geometry/off_geometry.py
@@ -1,6 +1,6 @@
 from typing import List
 from PySide2.QtGui import QVector3D
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 
 from nexus_constructor.geometry.mesh import Mesh
 from nexus_constructor.nexus import nexus_wrapper as nx

--- a/nexus_constructor/geometry/off_geometry.py
+++ b/nexus_constructor/geometry/off_geometry.py
@@ -1,6 +1,8 @@
 from typing import List
 from PySide2.QtGui import QVector3D
 from abc import ABC, abstractmethod
+
+from nexus_constructor.geometry.mesh import Mesh
 from nexus_constructor.nexus import nexus_wrapper as nx
 import h5py
 
@@ -17,7 +19,7 @@ from nexus_constructor.ui_utils import (
 import numpy as np
 
 
-class OFFGeometry(ABC):
+class OFFGeometry(Mesh):
     geometry_str = "OFF"
 
     @property

--- a/nexus_constructor/instrument_view.py
+++ b/nexus_constructor/instrument_view.py
@@ -11,7 +11,7 @@ from nexus_constructor.gnomon import Gnomon
 from nexus_constructor.instrument_view_axes import InstrumentViewAxes
 from nexus_constructor.instrument_zooming_3d_window import InstrumentZooming3DWindow
 from nexus_constructor.off_renderer import OffMesh
-from nexus_constructor.geometry import OFFGeometry
+from nexus_constructor.geometry import OFFGeometry, CylindricalGeometry
 from nexus_constructor.qentity_utils import create_qentity, create_material
 
 
@@ -199,7 +199,11 @@ class InstrumentView(QWidget):
         :param name: The name of the component.
         :param geometry: The geometry information of the component that is used to create a mesh.
         """
-        mesh = OffMesh(geometry.off_geometry)
+
+        if isinstance(geometry, CylindricalGeometry):
+            mesh = geometry.mesh
+        else:
+            mesh = OffMesh(geometry.off_geometry)
 
         entity = create_qentity([mesh, self.grey_material], self.component_root_entity)
 

--- a/nexus_constructor/instrument_view.py
+++ b/nexus_constructor/instrument_view.py
@@ -200,10 +200,7 @@ class InstrumentView(QWidget):
         :param geometry: The geometry information of the component that is used to create a mesh.
         """
 
-        if isinstance(geometry, CylindricalGeometry):
-            mesh = geometry.mesh
-        else:
-            mesh = OffMesh(geometry.off_geometry)
+        mesh = geometry.mesh
 
         entity = create_qentity([mesh, self.grey_material], self.component_root_entity)
 

--- a/nexus_constructor/instrument_view.py
+++ b/nexus_constructor/instrument_view.py
@@ -10,8 +10,7 @@ from PySide2.QtWidgets import QWidget, QVBoxLayout
 from nexus_constructor.gnomon import Gnomon
 from nexus_constructor.instrument_view_axes import InstrumentViewAxes
 from nexus_constructor.instrument_zooming_3d_window import InstrumentZooming3DWindow
-from nexus_constructor.off_renderer import OffMesh
-from nexus_constructor.geometry import OFFGeometry, CylindricalGeometry
+from nexus_constructor.geometry import OFFGeometry
 from nexus_constructor.qentity_utils import create_qentity, create_material
 
 

--- a/nexus_constructor/off_renderer.py
+++ b/nexus_constructor/off_renderer.py
@@ -5,16 +5,12 @@ Based off of a qml custom mesh example at https://github.com/iLya84a/qt3d/blob/m
 and a PyQt5 example from
 https://github.com/geehalel/npindi/blob/57c092200dd9cb259ac1c730a1258a378a1a6342/apps/mount3D/world3D-starspheres.py#L86
 """
-
+from nexus_constructor.geometry.mesh import Mesh
 from nexus_constructor.pixel_data import PixelData, PixelGrid
 from PySide2.Qt3DRender import Qt3DRender
 from PySide2.QtGui import QVector3D
 import struct
 import itertools
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:  # pragma: no cover
-    from nexus_constructor.geometry.off_geometry import OFFGeometry
 
 
 def flatten(list_to_flatten):
@@ -99,7 +95,7 @@ class QtOFFGeometry(Qt3DRender.QGeometry):
 
     q_attribute = Qt3DRender.QAttribute
 
-    def __init__(self, model: "OFFGeometry", pixel_data: PixelData, parent=None):
+    def __init__(self, model: Mesh, pixel_data: PixelData, parent=None):
         super().__init__(parent)
 
         if isinstance(pixel_data, PixelGrid):
@@ -140,7 +136,7 @@ class QtOFFGeometry(Qt3DRender.QGeometry):
         attribute.setName(name)
         return attribute
 
-    def repeat_shape_over_grid(self, model: "OFFGeometry", grid: PixelGrid):
+    def repeat_shape_over_grid(self, model: Mesh, grid: PixelGrid):
         faces = []
         vertices = []
         for row in range(grid.rows):
@@ -169,7 +165,7 @@ class OffMesh(Qt3DRender.QGeometryRenderer):
     An implementation of QGeometryRenderer that allows arbitrary OFF geometries to be rendered in Qt3D
     """
 
-    def __init__(self, geometry: "OFFGeometry", pixel_data: PixelData = None):
+    def __init__(self, geometry: Mesh, pixel_data: PixelData = None):
         super().__init__(None)
 
         self.setInstanceCount(1)

--- a/nexus_constructor/off_renderer.py
+++ b/nexus_constructor/off_renderer.py
@@ -13,7 +13,7 @@ import struct
 import itertools
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from nexus_constructor.geometry.off_geometry import OFFGeometry
 
 

--- a/nexus_constructor/off_renderer.py
+++ b/nexus_constructor/off_renderer.py
@@ -7,7 +7,6 @@ https://github.com/geehalel/npindi/blob/57c092200dd9cb259ac1c730a1258a378a1a6342
 """
 
 from nexus_constructor.pixel_data import PixelData, PixelGrid
-from nexus_constructor.geometry import OFFGeometry
 from PySide2.Qt3DRender import Qt3DRender
 from PySide2.QtGui import QVector3D
 import struct
@@ -96,7 +95,7 @@ class QtOFFGeometry(Qt3DRender.QGeometry):
 
     q_attribute = Qt3DRender.QAttribute
 
-    def __init__(self, model: OFFGeometry, pixel_data: PixelData, parent=None):
+    def __init__(self, model: "OFFGeometry", pixel_data: PixelData, parent=None):
         super().__init__(parent)
 
         if isinstance(pixel_data, PixelGrid):
@@ -137,7 +136,7 @@ class QtOFFGeometry(Qt3DRender.QGeometry):
         attribute.setName(name)
         return attribute
 
-    def repeat_shape_over_grid(self, model: OFFGeometry, grid: PixelGrid):
+    def repeat_shape_over_grid(self, model: "OFFGeometry", grid: PixelGrid):
         faces = []
         vertices = []
         for row in range(grid.rows):
@@ -166,7 +165,7 @@ class OffMesh(Qt3DRender.QGeometryRenderer):
     An implementation of QGeometryRenderer that allows arbitrary OFF geometries to be rendered in Qt3D
     """
 
-    def __init__(self, geometry: OFFGeometry, pixel_data: PixelData = None):
+    def __init__(self, geometry: "OFFGeometry", pixel_data: PixelData = None):
         super().__init__(None)
 
         self.setInstanceCount(1)

--- a/nexus_constructor/off_renderer.py
+++ b/nexus_constructor/off_renderer.py
@@ -11,6 +11,10 @@ from PySide2.Qt3DRender import Qt3DRender
 from PySide2.QtGui import QVector3D
 import struct
 import itertools
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nexus_constructor.geometry.off_geometry import OFFGeometry
 
 
 def flatten(list_to_flatten):

--- a/tests/test_off_geometry.py
+++ b/tests/test_off_geometry.py
@@ -52,7 +52,7 @@ def test_GIVEN_faces_WHEN_calling_winding_order_indices_on_OFF_THEN_order_is_cor
     assert expected == geom.winding_order_indices
 
 
-def test_GIVEN_off_geometry_WHEN_calling_off_geometry_on_offGeometry_THEN_original_geometry_is_returned():
+def test_GIVEN_off_geometry_WHEN_calling_mesh_on_offGeometry_THEN_mesh_is_created():
     vertices = [
         QVector3D(0, 0, 1),
         QVector3D(0, 1, 0),
@@ -65,7 +65,7 @@ def test_GIVEN_off_geometry_WHEN_calling_off_geometry_on_offGeometry_THEN_origin
 
     assert geom.faces == faces
     assert geom.vertices == vertices
-    assert geom.off_geometry == geom
+    assert geom.mesh.vertexCount() == 6
 
 
 def test_can_get_off_geometry_properties():


### PR DESCRIPTION
### Issue

Closes #397 
### Description of work

Only spent a few mins on this so if it causes issues i'll come back to it at a later date.
This uses `QCylinderMesh`es instead of drawing cylinders as OFF meshes in the qt3d view. This may give some performance benefits, but mainly it reduces a lot of code that we have to look after (converting cylinders to off meshes) 

### Acceptance Criteria 

Cylinders should be added as usual in the 3d view and the same output should be shown in the nexus file and tree view. 

### UI tests

*How you have updated the UI tests document to fit your changes*

### Nominate for Group Code Review

- [ ] Nominate for code review 
