### PR TITLE
355 Add nexus filename dialog

### DIFF
--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -1,10 +1,5 @@
 from PySide2.QtCore import QObject
-from PySide2.QtWidgets import (
-    QAction,
-    QToolBar,
-    QAbstractItemView,
-    QInputDialog,
-)
+from PySide2.QtWidgets import QAction, QToolBar, QAbstractItemView, QInputDialog
 from PySide2.QtGui import QIcon
 from PySide2.QtWidgets import QDialog, QLabel, QGridLayout, QComboBox, QPushButton
 

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -304,7 +304,9 @@ class MainWindow(Ui_MainWindow, QObject):
         self.instrument.nexus.save_file(filename)
         if filename:
             name, ok_pressed = QInputDialog.getText(
-                None, "NeXus file output name", "Filename:"
+                None,
+                "NeXus file output name",
+                "Name for output NeXus file to include in JSON command:",
             )
             if ok_pressed:
                 with open(filename, "w") as file:

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -1,5 +1,10 @@
 from PySide2.QtCore import QObject
-from PySide2.QtWidgets import QAction, QToolBar, QAbstractItemView
+from PySide2.QtWidgets import (
+    QAction,
+    QToolBar,
+    QAbstractItemView,
+    QInputDialog,
+)
 from PySide2.QtGui import QIcon
 from PySide2.QtWidgets import QDialog, QLabel, QGridLayout, QComboBox, QPushButton
 
@@ -303,8 +308,12 @@ class MainWindow(Ui_MainWindow, QObject):
         filename = file_dialog(True, "Save JSON File", JSON_FILE_TYPES)
         self.instrument.nexus.save_file(filename)
         if filename:
-            with open(filename, "w") as file:
-                file.write(writer.generate_json(self.instrument.get_component_list()))
+            name, ok_pressed = QInputDialog.getText(
+                None, "NeXus file output name", "Filename:"
+            )
+            if ok_pressed:
+                with open(filename, "w") as file:
+                    writer.generate_json(self.instrument, file, nexus_file_name=name)
 
     def open_nexus_file(self):
         filename = file_dialog(False, "Open Nexus File", NEXUS_FILE_TYPES)


### PR DESCRIPTION
### Issue

Closes #355 

### Description of work

Adds a message box after picking a file to save to that adds the nexus file name to the json command. as this may be on a different computer i dont think there is any way of validating it.

If a user clicks cancel the file is not written.  

I think this actually also fixes filewriter command writing as they seemed to be broken before. 

### Acceptance Criteria 

filename ends up in nexus file correctly. 

### UI tests

N/A - unable to test mainwindow just yet as it causes the test runner to segfault. 

### Nominate for Group Code Review

- [ ] Nominate for code review 
