### PR TITLE
377: Fix crash on exit (segfault)

### DIFF
--- a/nexus_constructor/instrument_view.py
+++ b/nexus_constructor/instrument_view.py
@@ -24,7 +24,9 @@ class InstrumentView(QWidget):
     """
 
     def delete(self):
-        """Fixes Qt3D segfault"""
+        """
+        Fixes Qt3D segfault - this needs to be called when the program closes otherwise Qt tries to draw objects as python is cleaning them up.
+        """
         self.clear_all_components()
         del self.root_entity
         del self.view

--- a/nexus_constructor/instrument_view.py
+++ b/nexus_constructor/instrument_view.py
@@ -4,7 +4,7 @@ from PySide2.Qt3DCore import Qt3DCore
 from PySide2.Qt3DExtras import Qt3DExtras
 from PySide2.Qt3DRender import Qt3DRender
 from PySide2.QtCore import QRectF
-from PySide2.QtGui import QVector3D, QColor, QCloseEvent
+from PySide2.QtGui import QVector3D, QColor
 from PySide2.QtWidgets import QWidget, QVBoxLayout
 
 from nexus_constructor.gnomon import Gnomon

--- a/nexus_constructor/instrument_view.py
+++ b/nexus_constructor/instrument_view.py
@@ -23,6 +23,12 @@ class InstrumentView(QWidget):
                    argument in order to appease Qt Designer.
     """
 
+    def __del__(self):
+        """Fixes Qt3D segfault"""
+        self.clear_all_components()
+        del self.root_entity
+        del self.view
+
     def __init__(self, parent):
 
         super().__init__()

--- a/nexus_constructor/instrument_view.py
+++ b/nexus_constructor/instrument_view.py
@@ -4,7 +4,7 @@ from PySide2.Qt3DCore import Qt3DCore
 from PySide2.Qt3DExtras import Qt3DExtras
 from PySide2.Qt3DRender import Qt3DRender
 from PySide2.QtCore import QRectF
-from PySide2.QtGui import QVector3D, QColor
+from PySide2.QtGui import QVector3D, QColor, QCloseEvent
 from PySide2.QtWidgets import QWidget, QVBoxLayout
 
 from nexus_constructor.gnomon import Gnomon
@@ -23,7 +23,7 @@ class InstrumentView(QWidget):
                    argument in order to appease Qt Designer.
     """
 
-    def __del__(self):
+    def delete(self):
         """Fixes Qt3D segfault"""
         self.clear_all_components()
         del self.root_entity

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -1,6 +1,14 @@
 from PySide2.QtCore import QObject
-from PySide2.QtWidgets import QAction, QToolBar, QAbstractItemView, QInputDialog
-from PySide2.QtGui import QIcon
+from PySide2.QtWidgets import (
+    QAction,
+    QToolBar,
+    QAbstractItemView,
+    QInputDialog,
+    QWidget,
+    QMainWindow,
+    QApplication,
+)
+from PySide2.QtGui import QIcon, QCloseEvent
 from PySide2.QtWidgets import QDialog, QLabel, QGridLayout, QComboBox, QPushButton
 
 import silx.gui.hdf5
@@ -24,7 +32,7 @@ NEXUS_FILE_TYPES = {"NeXus Files": ["nxs", "nex", "nx5"]}
 JSON_FILE_TYPES = {"JSON Files": ["json", "JSON"]}
 
 
-class MainWindow(Ui_MainWindow, QObject):
+class MainWindow(Ui_MainWindow, QMainWindow):
     def __init__(self, instrument: Instrument):
         super().__init__()
         self.instrument = instrument
@@ -37,6 +45,9 @@ class MainWindow(Ui_MainWindow, QObject):
         self.actionExport_to_Filewriter_JSON.triggered.connect(
             self.save_to_filewriter_json
         )
+
+        # Clear the 3d view when closed
+        QApplication.instance().aboutToQuit.connect(self.sceneWidget.delete)
 
         self.widget = silx.gui.hdf5.Hdf5TreeView()
         self.widget.setAcceptDrops(True)

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -1,14 +1,12 @@
-from PySide2.QtCore import QObject
 from PySide2.QtWidgets import (
     QAction,
     QToolBar,
     QAbstractItemView,
     QInputDialog,
-    QWidget,
     QMainWindow,
     QApplication,
 )
-from PySide2.QtGui import QIcon, QCloseEvent
+from PySide2.QtGui import QIcon
 from PySide2.QtWidgets import QDialog, QLabel, QGridLayout, QComboBox, QPushButton
 
 import silx.gui.hdf5


### PR DESCRIPTION
### Issue

Closes #377 

### Description of work

Fixes the segfault caused by python not clearing stuff up correctly with qt3d. 

Deleted the entities before qt3d tries to reference them to draw the next frame in between closing the application. 

### Acceptance Criteria

- The program exits with  exit code 0 instead of `SIGSEGV`

### UI tests

N/A

### Nominate for Group Code Review

- [ ] Nominate for code review 
