### PR TITLE
Pin version of black

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ git+https://github.com/anthony-tuininga/cx_Freeze.git@master
 jsonschema==2.6.0
 
 # Formatting/linting
-black
+black==19.3b0
 pre-commit
 flake8
 


### PR DESCRIPTION
No ticket.
Pins version of `black` because I think different devs have different versions and it is causing unnecessary formatting changes in every PR.