### PR TITLE
Decode bytes attribute as utf8 string

### DIFF
--- a/nexus_constructor/component.py
+++ b/nexus_constructor/component.py
@@ -268,7 +268,7 @@ class Component:
         axis_direction: QVector3D = QVector3D(0.0, 0.0, 1.0),
         height: float = 1.0,
         radius: float = 1.0,
-        units: str = "m",
+        units: Union[str, bytes] = "m",
         pixel_data: PixelData = None,
     ) -> CylindricalGeometry:
         """

--- a/nexus_constructor/geometry/cylindrical_geometry.py
+++ b/nexus_constructor/geometry/cylindrical_geometry.py
@@ -98,7 +98,7 @@ class CylindricalGeometry:
 
     @property
     def units(self) -> str:
-        return str(self.group["vertices"].attrs["units"])
+        return self.file.get_attribute_value(self.group["vertices"], "units")
 
     @property
     def height(self) -> float:

--- a/nexus_constructor/nexus/nexus_wrapper.py
+++ b/nexus_constructor/nexus/nexus_wrapper.py
@@ -219,7 +219,10 @@ class NexusWrapper(QObject):
     @staticmethod
     def get_attribute_value(node: h5Node, name: str) -> Optional[Any]:
         if name in node.attrs.keys():
-            return node.attrs[name]
+            value = node.attrs[name]
+            if isinstance(value, bytes):
+                return value.decode("utf-8")
+            return value
 
     def set_attribute_value(self, node: h5Node, name: str, value: Any):
         # Deal with arrays of strings

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ build_exe_options = {
         "sphinx",
     ],
     "bin_includes": ["libssl.so"],
-    "include_files": ["ui", "Instrument.schema.json", "definitions"],
+    "include_files": ["ui", "definitions"],
 }
 
 # GUI applications require a different base on Windows (the default is for a console application).

--- a/tests/test_cylindrical_geometry.py
+++ b/tests/test_cylindrical_geometry.py
@@ -41,6 +41,18 @@ def test_cylinder_has_property_values_it_was_created_with():
     assert cylinder.geometry_str == "Cylinder"
 
 
+def test_cylinder_units_returns_str_if_bytes_in_file():
+    nexus_wrapper = create_nexus_wrapper()
+    component = add_component_to_file(nexus_wrapper)
+    units_bytes = b"cubits"
+    cylinder = component.set_cylinder_shape(
+        axis_direction=QVector3D(1, 0, 0), height=3, radius=4, units=units_bytes
+    )
+    units_str = units_bytes.decode("utf-8")
+
+    assert cylinder.units == units_str
+
+
 def test_axis_direction_must_be_non_zero():
     nexus_wrapper = create_nexus_wrapper()
     component = add_component_to_file(nexus_wrapper)

--- a/tests/test_nexus_wrapper.py
+++ b/tests/test_nexus_wrapper.py
@@ -135,3 +135,15 @@ def test_GIVEN_group_with_nx_class_as_bytes_WHEN_getting_nx_class_THEN_returns_n
     nx_class = b"NXentry"
     entry.attrs["NX_class"] = nx_class
     assert get_nx_class(entry) == str(nx_class, encoding="utf-8")
+
+
+def test_GIVEN_group_with_bytes_attribute_WHEN_getting_attribute_value_THEN_returns_value_as_str():
+    wrapper = NexusWrapper(filename="test_attr_as_str")
+    test_group = wrapper.nexus_file.create_group("test_group")
+    attr_value = b"test_attr_value"
+    attr_name = "test_attr"
+    test_group.attrs[attr_name] = attr_value
+
+    attr_value_as_str = attr_value.decode("utf-8")
+
+    assert wrapper.get_attribute_value(test_group, attr_name) == attr_value_as_str


### PR DESCRIPTION
### Issue

No ticket, this is a quick fix for a bug I found when opening an existing NeXus file.
The NeXus Constructor was failing to get a cylindrical geometry from the file if the units attribute was `bytes`.

### Description of work

- In the NeXus wrapper `get_attribute_value()`: if attributes are `bytes` in file then now decodes as uft-8 string.
- Cylinder `units` property now makes use of the `get_attribute_value()` wrapper method.
- Added unit tests for NeXus wrapper and cylinder.

### Nominate for Group Code Review

- [ ] Nominate for code review 
