### PR TITLE
Fixing floating point array field UI issues 

### DIFF
--- a/nexus_constructor/array_dataset_table_widget.py
+++ b/nexus_constructor/array_dataset_table_widget.py
@@ -157,7 +157,7 @@ class ValueDelegate(QItemDelegate):
         super().__init__(parent)
         self.dtype = dtype
 
-    def commit(self, editor, _):
+    def commit(self, editor):
         """
         Calls the commitData signal to update the model when text is being edited rather than when it has finished being edited and loses focus.
         :param editor: The line edit in the item delegate.
@@ -179,7 +179,7 @@ class ValueDelegate(QItemDelegate):
         )
 
         # Update the model when the item is being edited rather than when it has lost focus and finished.
-        editor.textEdited.connect(partial(self.commit, editor))
+        editor.editingFinished.connect(partial(self.commit, editor))
         return editor
 
     def setEditorData(self, editor: QWidget, index: QModelIndex):

--- a/nexus_constructor/array_dataset_table_widget.py
+++ b/nexus_constructor/array_dataset_table_widget.py
@@ -161,7 +161,6 @@ class ValueDelegate(QItemDelegate):
         """
         Calls the commitData signal to update the model when text is being edited rather than when it has finished being edited and loses focus.
         :param editor: The line edit in the item delegate.
-        :param _: Not used, just satisfying the signal parameters
         """
         self.commitData.emit(editor)
 


### PR DESCRIPTION
### Issue

Closes #412 

### Description of work


Quick and easy fix - fixes the weird behaviour when typing doubles in the array fields editor. This was due to the validator validating every time a character was entered, and rounding up to the nearest integer. To solve this, I have connected the `editingFinished` signal of the lineEdit to the validate function. This works even if the window is closed as focus is lost. 

### Acceptance Criteria 

Test entering floating point values as a `double` type in the array fields editing box. Previously this would replace your input of `1.2` with `1.0.2`. 

Also test closing the edit box when text has been entered into a cell - when opening the edit window it should still be there. 

### UI tests

N/A

### Nominate for Group Code Review

- [ ] Nominate for code review 
