### PR TITLE
removing minimum values from cylinder options

### DIFF
--- a/tests/ui_tests/test_ui_add_component_window.py
+++ b/tests/ui_tests/test_ui_add_component_window.py
@@ -886,8 +886,8 @@ def test_UI_GIVEN_cylinder_shape_selected_WHEN_adding_component_THEN_default_val
     systematic_button_press(qtbot, template, dialog.CylinderRadioButton)
 
     assert dialog.cylinderOptionsBox.isVisible()
-    assert dialog.cylinderHeightLineEdit.value() == 1.0
-    assert dialog.cylinderRadiusLineEdit.value() == 1.0
+    assert dialog.cylinderHeightLineEdit.value() == 0.0
+    assert dialog.cylinderRadiusLineEdit.value() == 0.0
     assert dialog.cylinderXLineEdit.value() == 0.0
     assert dialog.cylinderYLineEdit.value() == 0.0
     assert dialog.cylinderZLineEdit.value() == 1.0

--- a/ui/add_component.py
+++ b/ui/add_component.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
-# Form implementation generated from reading ui file 'ui/add_component.ui',
-# licensing of 'ui/add_component.ui' applies.
+# Form implementation generated from reading ui file 'add_component.ui',
+# licensing of 'add_component.ui' applies.
 #
-# Created: Thu Aug  8 10:10:21 2019
+# Created: Mon Sep 30 11:55:40 2019
 #      by: pyside2-uic  running on PySide2 5.13.0
 #
 # WARNING! All changes made in this file will be lost!
@@ -124,7 +124,6 @@ class Ui_AddComponentDialog(object):
         self.cylinderXLineEdit.setObjectName("cylinderXLineEdit")
         self.gridLayout.addWidget(self.cylinderXLineEdit, 2, 1, 1, 1)
         self.cylinderRadiusLineEdit = QtWidgets.QDoubleSpinBox(self.cylinderOptionsBox)
-        self.cylinderRadiusLineEdit.setMinimum(1.0)
         self.cylinderRadiusLineEdit.setMaximum(100000.0)
         self.cylinderRadiusLineEdit.setObjectName("cylinderRadiusLineEdit")
         self.gridLayout.addWidget(self.cylinderRadiusLineEdit, 0, 3, 1, 1)
@@ -148,7 +147,6 @@ class Ui_AddComponentDialog(object):
         self.label_8.setObjectName("label_8")
         self.gridLayout.addWidget(self.label_8, 2, 4, 1, 1)
         self.cylinderHeightLineEdit = QtWidgets.QDoubleSpinBox(self.cylinderOptionsBox)
-        self.cylinderHeightLineEdit.setMinimum(1.0)
         self.cylinderHeightLineEdit.setMaximum(100000.0)
         self.cylinderHeightLineEdit.setObjectName("cylinderHeightLineEdit")
         self.gridLayout.addWidget(self.cylinderHeightLineEdit, 0, 1, 1, 1)

--- a/ui/add_component.ui
+++ b/ui/add_component.ui
@@ -203,9 +203,6 @@
               </item>
               <item row="0" column="3">
                <widget class="QDoubleSpinBox" name="cylinderRadiusLineEdit">
-                <property name="minimum">
-                 <double>1.000000000000000</double>
-                </property>
                 <property name="maximum">
                  <double>100000.000000000000000</double>
                 </property>
@@ -255,9 +252,6 @@
               </item>
               <item row="0" column="1">
                <widget class="QDoubleSpinBox" name="cylinderHeightLineEdit">
-                <property name="minimum">
-                 <double>1.000000000000000</double>
-                </property>
                 <property name="maximum">
                  <double>100000.000000000000000</double>
                 </property>


### PR DESCRIPTION
### Issue

Closes #445 

### Description of work

Removes the minimum values set in the UI files so the user can enter cylinder height and radius values that are less than 1.0 

### Acceptance Criteria 

Removed minimum properties from UI file and converted to python, check that this works as before but allows you to put in values less than 1.0 in the cylinder height and radius fields. 

### UI tests

N/A

### Nominate for Group Code Review

- [ ] Nominate for code review 
