### PR TITLE
Remove generic chopper checker class and use free functions

### DIFF
--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -357,7 +357,7 @@ class AddComponentDialog(Ui_AddComponentDialog, QObject):
                 and chopper_checker.validate_chopper()
             ):
                 geometry_model = DiskChopperGeometryCreator(
-                    chopper_checker.get_chopper_details()
+                    chopper_checker.chopper_details
                 ).create_disk_chopper_geometry()
             else:
                 geometry_model = NoShapeGeometry()

--- a/nexus_constructor/chopper_component.py
+++ b/nexus_constructor/chopper_component.py
@@ -21,7 +21,7 @@ class ChopperComponent(Component):
         chopper_checker = NexusDefinedChopperChecker(self.group)
         if chopper_checker.validate_chopper():
             return DiskChopperGeometryCreator(
-                chopper_checker.get_chopper_details()
+                chopper_checker.chopper_details
             ).create_disk_chopper_geometry()
         else:
             print("Validation failed. Unable to create disk chopper mesh.")

--- a/nexus_constructor/geometry/disk_chopper/disk_chopper_checker.py
+++ b/nexus_constructor/geometry/disk_chopper/disk_chopper_checker.py
@@ -181,7 +181,8 @@ class UserDefinedChopperChecker:
             widget = fields_widget.itemWidget(fields_widget.item(i))
             self.fields_dict[widget.name] = widget
 
-    def get_chopper_details(self):
+    @property
+    def chopper_details(self):
         """
         :return: The ChopperDetails object of the user-defined disk chopper.
         """
@@ -243,7 +244,8 @@ class NexusDefinedChopperChecker:
 
         self._disk_chopper = disk_chopper
 
-    def get_chopper_details(self):
+    @property
+    def chopper_details(self):
         """
         :return: The ChopperDetails object of the NeXus-defined disk chopper.
         """

--- a/nexus_constructor/geometry/disk_chopper/disk_chopper_checker.py
+++ b/nexus_constructor/geometry/disk_chopper/disk_chopper_checker.py
@@ -27,7 +27,7 @@ INT_TYPES = [value for value in DATASET_TYPE.values() if "int" in str(value)]
 FLOAT_TYPES = [value for value in DATASET_TYPE.values() if "float" in str(value)]
 
 
-def incorrect_field_type_message(fields_dict: dict, field_name: str):
+def _incorrect_field_type_message(fields_dict: dict, field_name: str):
     """
     Creates a string explaining to the user that the field input did not have the expected type.
     :param fields_dict: The dictionary containing the different data fields for the disk chopper.
@@ -39,143 +39,132 @@ def incorrect_field_type_message(fields_dict: dict, field_name: str):
     )
 
 
-def check_data_type(data_type, expected_types):
+def _check_data_type(data_type, expected_types):
     try:
         return data_type.dtype in expected_types
     except AttributeError:
         return False
 
 
-class GenericChopperChecker:
-    def __init__(self):
+def _fields_have_correct_type(fields_dict: dict):
+    correct_slits_type = _check_data_type(fields_dict[SLITS_NAME], INT_TYPES)
+    correct_radius_type = _check_data_type(fields_dict[RADIUS_NAME], FLOAT_TYPES)
+    correct_slit_height_type = _check_data_type(
+        fields_dict[SLIT_HEIGHT_NAME], FLOAT_TYPES
+    )
+    correct_slit_edges_type = _check_data_type(
+        fields_dict[SLIT_EDGES_NAME], FLOAT_TYPES
+    )
 
-        self._chopper_details = None
-        self._angle_units = None
-        self._slit_height_units = None
-        self._radius_units = None
+    if (
+        correct_slits_type
+        and correct_radius_type
+        and correct_slit_height_type
+        and correct_slit_edges_type
+    ):
+        return True
 
-    @staticmethod
-    def fields_have_correct_type(fields_dict: dict):
+    problems = []
 
-        correct_slits_type = check_data_type(fields_dict[SLITS_NAME], INT_TYPES)
-        correct_radius_type = check_data_type(fields_dict[RADIUS_NAME], FLOAT_TYPES)
-        correct_slit_height_type = check_data_type(
-            fields_dict[SLIT_HEIGHT_NAME], FLOAT_TYPES
+    if not correct_slits_type:
+        problems.append(_incorrect_field_type_message(fields_dict, SLITS_NAME))
+
+    if not correct_radius_type:
+        problems.append(_incorrect_field_type_message(fields_dict, RADIUS_NAME))
+
+    if not correct_slit_height_type:
+        problems.append(_incorrect_field_type_message(fields_dict, SLIT_HEIGHT_NAME))
+
+    if not correct_slit_edges_type:
+        problems.append(_incorrect_field_type_message(fields_dict, SLIT_EDGES_NAME))
+
+    print(UNABLE + "\n".join(problems))
+    return False
+
+
+def _edges_array_has_correct_shape(edges_dim: int, edges_shape: tuple):
+    """
+    Checks that the edges array consists of either one row or one column.
+    :return: True if the edges array is 1D. False otherwise.
+    """
+    if edges_dim > 2:
+        print(
+            UNABLE
+            + "Expected slit edges array to be 1D but it has {} dimensions.".format(
+                edges_dim
+            )
         )
-        correct_slit_edges_type = check_data_type(
-            fields_dict[SLIT_EDGES_NAME], FLOAT_TYPES
-        )
-
-        if (
-            correct_slits_type
-            and correct_radius_type
-            and correct_slit_height_type
-            and correct_slit_edges_type
-        ):
-            return True
-
-        problems = []
-
-        if not correct_slits_type:
-            problems.append(incorrect_field_type_message(fields_dict, SLITS_NAME))
-
-        if not correct_radius_type:
-            problems.append(incorrect_field_type_message(fields_dict, RADIUS_NAME))
-
-        if not correct_slit_height_type:
-            problems.append(incorrect_field_type_message(fields_dict, SLIT_HEIGHT_NAME))
-
-        if not correct_slit_edges_type:
-            problems.append(incorrect_field_type_message(fields_dict, SLIT_EDGES_NAME))
-
-        print(UNABLE + "\n".join(problems))
         return False
 
-    @staticmethod
-    def edges_array_has_correct_shape(edges_dim: int, edges_shape: tuple):
-        """
-        Checks that the edges array consists of either one row or one column.
-        :return: True if the edges array is 1D. False otherwise.
-        """
-        if edges_dim > 2:
+    if edges_dim == 2:
+        if edges_shape[0] != 1 and edges_shape[1] != 1:
             print(
                 UNABLE
-                + "Expected slit edges array to be 1D but it has {} dimensions.".format(
-                    edges_dim
+                + "Expected slit edges array to be 1D but it has shape {}.".format(
+                    edges_shape
                 )
             )
             return False
 
-        if edges_dim == 2:
-            if edges_shape[0] != 1 and edges_shape[1] != 1:
-                print(
-                    UNABLE
-                    + "Expected slit edges array to be 1D but it has shape {}.".format(
-                        edges_shape
-                    )
-                )
-                return False
+    return True
 
-        return True
 
-    @staticmethod
-    def input_describes_valid_chopper(
-        chopper_details: ChopperDetails, slit_edges: Sequence
+def _input_describes_valid_chopper(
+    chopper_details: ChopperDetails, slit_edges: Sequence
+):
+    """
+    A final check that the input has the following properties:
+        - The length of the slit edges array is twice the number of slits
+        - The slit height is smaller than the radius
+        - The slit edges array is sorted.
+        - The slit edges array doesn't contain repeated angles.
+        - The slit edges array doesn't contain overlapping slits.
+    If this is all true then a chopper mesh can be created.
+    :return: True if all the conditions above are met. False otherwise.
+    """
+    # Check that the number of slit edges is equal to two times the number of slits
+    if len(chopper_details.slit_edges) != 2 * chopper_details.slits:
+        print(
+            UNABLE
+            + "Size of slit edges array should be twice the number of slits. Instead there are {} slits and {} slit edges.".format(
+                chopper_details.slits, len(chopper_details.slit_edges)
+            )
+        )
+        return False
+
+    # Check that the slit height is smaller than the radius
+    if chopper_details.slit_height >= chopper_details.radius:
+        print(
+            UNABLE
+            + "Slit height should be smaller than radius. Instead slit height is {} and radius is {}".format(
+                chopper_details.slit_height, chopper_details.radius
+            )
+        )
+        return False
+
+    # Check that the list of slit edges is sorted
+    if not (np.diff(slit_edges) >= 0).all():
+        print(UNABLE + "Slit edges array is not sorted. Found values:", slit_edges)
+        return False
+
+    # Check that there are no repeated angles
+    if len(slit_edges) != len(np.unique(slit_edges)):
+        print(
+            UNABLE + "Angles in slit edges array should be unique. Found values:",
+            slit_edges,
+        )
+        return False
+
+    # Check that the first and last edges do not overlap
+    if (chopper_details.slit_edges != sorted(chopper_details.slit_edges)) and (
+        chopper_details.slit_edges[-1] >= chopper_details.slit_edges[0]
     ):
-        """
-        A final check that the input has the following properties:
-            - The length of the slit edges array is twice the number of slits
-            - The slit height is smaller than the radius
-            - The slit edges array is sorted.
-            - The slit edges array doesn't contain repeated angles.
-            - The slit edges array doesn't contain overlapping slits.
-        If this is all true then a chopper mesh can be created.
-        :return: True if all the conditions above are met. False otherwise.
-        """
-        # Check that the number of slit edges is equal to two times the number of slits
-        if len(chopper_details.slit_edges) != 2 * chopper_details.slits:
-            print(
-                UNABLE
-                + "Size of slit edges array should be twice the number of slits. Instead there are {} slits and {} slit edges.".format(
-                    chopper_details.slits, len(chopper_details.slit_edges)
-                )
-            )
-            return False
+        print(
+            UNABLE + "Slit edges contains overlapping slits. Found values:", slit_edges
+        )
+        return False
 
-        # Check that the slit height is smaller than the radius
-        if chopper_details.slit_height >= chopper_details.radius:
-            print(
-                UNABLE
-                + "Slit height should be smaller than radius. Instead slit height is {} and radius is {}".format(
-                    chopper_details.slit_height, chopper_details.radius
-                )
-            )
-            return False
-
-        # Check that the list of slit edges is sorted
-        if not (np.diff(slit_edges) >= 0).all():
-            print(UNABLE + "Slit edges array is not sorted. Found values:", slit_edges)
-            return False
-
-        # Check that there are no repeated angles
-        if len(slit_edges) != len(np.unique(slit_edges)):
-            print(
-                UNABLE + "Angles in slit edges array should be unique. Found values:",
-                slit_edges,
-            )
-            return False
-
-        # Check that the first and last edges do not overlap
-        if (chopper_details.slit_edges != sorted(chopper_details.slit_edges)) and (
-            chopper_details.slit_edges[-1] >= chopper_details.slit_edges[0]
-        ):
-            print(
-                UNABLE + "Slit edges contains overlapping slits. Found values:",
-                slit_edges,
-            )
-            return False
-
-        return True
+    return True
 
 
 class UserDefinedChopperChecker:
@@ -191,8 +180,6 @@ class UserDefinedChopperChecker:
         for i in range(fields_widget.count()):
             widget = fields_widget.itemWidget(fields_widget.item(i))
             self.fields_dict[widget.name] = widget
-
-        self._generic_chopper_checker = GenericChopperChecker()
 
     def get_chopper_details(self):
         """
@@ -222,8 +209,8 @@ class UserDefinedChopperChecker:
         """
         if not (
             self.required_fields_present()
-            and self._generic_chopper_checker.fields_have_correct_type(self.fields_dict)
-            and self._generic_chopper_checker.edges_array_has_correct_shape(
+            and _fields_have_correct_type(self.fields_dict)
+            and _edges_array_has_correct_shape(
                 self.fields_dict[SLIT_EDGES_NAME].value.ndim,
                 self.fields_dict[SLIT_EDGES_NAME].value.shape,
             )
@@ -240,7 +227,7 @@ class UserDefinedChopperChecker:
             self._radius_units,
         )
 
-        return self._generic_chopper_checker.input_describes_valid_chopper(
+        return _input_describes_valid_chopper(
             self._chopper_details, self.fields_dict[SLIT_EDGES_NAME].value
         )
 
@@ -254,7 +241,6 @@ class NexusDefinedChopperChecker:
         self._slit_height_units = None
         self._radius_units = None
 
-        self._generic_chopper_checker = GenericChopperChecker()
         self._disk_chopper = disk_chopper
 
     def get_chopper_details(self):
@@ -299,8 +285,8 @@ class NexusDefinedChopperChecker:
         """
         if not (
             self.required_fields_present()
-            and self._generic_chopper_checker.fields_have_correct_type(self.fields_dict)
-            and self._generic_chopper_checker.edges_array_has_correct_shape(
+            and _fields_have_correct_type(self.fields_dict)
+            and _edges_array_has_correct_shape(
                 self.fields_dict[SLIT_EDGES_NAME].ndim,
                 self.fields_dict[SLIT_EDGES_NAME].shape,
             )
@@ -317,6 +303,6 @@ class NexusDefinedChopperChecker:
             self._radius_units,
         )
 
-        return self._generic_chopper_checker.input_describes_valid_chopper(
+        return _input_describes_valid_chopper(
             self._chopper_details, self.fields_dict[SLIT_EDGES_NAME]
         )

--- a/tests/test_disk_chopper_checker.py
+++ b/tests/test_disk_chopper_checker.py
@@ -414,7 +414,7 @@ def test_GIVEN_chopper_details_WHEN_creating_chopper_geometry_THEN_details_match
 ):
 
     user_defined_chopper_checker.validate_chopper()
-    details = user_defined_chopper_checker.get_chopper_details()
+    details = user_defined_chopper_checker.chopper_details
 
     radian_slit_edges = CONVERT_DEGREES_TO_RADIANS(mock_slit_edges_widget.value)
 
@@ -429,7 +429,7 @@ def test_GIVEN_nothing_WHEN_calling_get_chopper_details_THEN_expected_chopper_de
 ):
 
     user_defined_chopper_checker.validate_chopper()
-    chopper_details = user_defined_chopper_checker.get_chopper_details()
+    chopper_details = user_defined_chopper_checker.chopper_details
 
     assert chopper_details.slits == N_SLITS
     assert chopper_details.radius == RADIUS_LENGTH
@@ -549,7 +549,7 @@ def test_GIVEN_validation_passes_WHEN_validating_nexus_disk_chopper_THEN_chopper
 ):
 
     nexus_defined_chopper_checker.validate_chopper()
-    chopper_details = nexus_defined_chopper_checker.get_chopper_details()
+    chopper_details = nexus_defined_chopper_checker.chopper_details
 
     assert chopper_details.slits == N_SLITS
     assert np.array_equal(chopper_details.slit_edges, EDGES_ARR)

--- a/tests/test_disk_chopper_checker.py
+++ b/tests/test_disk_chopper_checker.py
@@ -12,11 +12,12 @@ from nexus_constructor.geometry.disk_chopper.disk_chopper_checker import (
     UserDefinedChopperChecker,
     INT_TYPES,
     FLOAT_TYPES,
-    incorrect_field_type_message,
+    _incorrect_field_type_message,
     NexusDefinedChopperChecker,
     NAME,
-    check_data_type,
-    GenericChopperChecker,
+    _check_data_type,
+    _fields_have_correct_type,
+    _edges_array_has_correct_shape,
 )
 from tests.chopper_test_resources import (
     N_SLITS,
@@ -142,27 +143,22 @@ def nexus_defined_chopper_checker(nexus_disk_chopper):
     return NexusDefinedChopperChecker(nexus_disk_chopper)
 
 
-@pytest.fixture(scope="function")
-def generic_chopper_checker():
-    return GenericChopperChecker()
-
-
 def test_GIVEN_matching_data_types_WHEN_checking_data_types_THEN_check_data_type_returns_true(
     mock_radius_widget
 ):
-    assert check_data_type(mock_radius_widget, FLOAT_TYPES)
+    assert _check_data_type(mock_radius_widget, FLOAT_TYPES)
 
 
 def test_GIVEN_non_matching_data_types_WHEN_checking_data_types_THEN_check_data_type_returns_false(
     mock_slits_widget
 ):
-    assert not check_data_type(mock_slits_widget, FLOAT_TYPES)
+    assert not _check_data_type(mock_slits_widget, FLOAT_TYPES)
 
 
 def test_GIVEN_fields_information_and_field_name_WHEN_calling_incorrect_field_type_message_THEN_expected_string_is_returned():
 
     field_dict = {RADIUS_NAME: "string"}
-    error_message = incorrect_field_type_message(field_dict, RADIUS_NAME)
+    error_message = _incorrect_field_type_message(field_dict, RADIUS_NAME)
 
     assert (
         error_message
@@ -173,91 +169,73 @@ def test_GIVEN_fields_information_and_field_name_WHEN_calling_incorrect_field_ty
 
 
 def test_GIVEN_valid_fields_information_WHEN_validating_disk_chopper_THEN_fields_have_correct_type_returns_true(
-    generic_chopper_checker, fields_dict_mocks
+    fields_dict_mocks
 ):
-    assert generic_chopper_checker.fields_have_correct_type(fields_dict_mocks)
+    assert _fields_have_correct_type(fields_dict_mocks)
 
 
 def test_GIVEN_invalid_slits_type_WHEN_validating_disk_chopper_THEN_fields_have_correct_type_returns_false(
-    generic_chopper_checker, fields_dict_mocks
+    fields_dict_mocks
 ):
 
     fields_dict_mocks[SLITS_NAME].dtype = FLOAT_TYPES[0]
-    assert not generic_chopper_checker.fields_have_correct_type(fields_dict_mocks)
+    assert not _fields_have_correct_type(fields_dict_mocks)
 
 
 def test_GIVEN_invalid_radius_type_WHEN_validating_disk_chopper_THEN_fields_have_correct_type_returns_false(
-    generic_chopper_checker, fields_dict_mocks
+    fields_dict_mocks
 ):
 
     fields_dict_mocks[RADIUS_NAME].dtype = INT_TYPES[0]
-    assert not generic_chopper_checker.fields_have_correct_type(fields_dict_mocks)
+    assert not _fields_have_correct_type(fields_dict_mocks)
 
 
 def test_GIVEN_invalid_slit_height_type_WHEN_validating_disk_chopper_THEN_fields_have_correct_type_returns_false(
-    generic_chopper_checker, fields_dict_mocks
+    fields_dict_mocks
 ):
 
     fields_dict_mocks[SLIT_HEIGHT_NAME].dtype = INT_TYPES[0]
-    assert not generic_chopper_checker.fields_have_correct_type(fields_dict_mocks)
+    assert not _fields_have_correct_type(fields_dict_mocks)
 
 
 def test_GIVEN_invalid_slit_edges_type_WHEN_validating_disk_chopper_THEN_fields_have_correct_type_returns_false(
-    generic_chopper_checker, fields_dict_mocks
+    fields_dict_mocks
 ):
 
     fields_dict_mocks[SLIT_EDGES_NAME].dtype = INT_TYPES[0]
-    assert not generic_chopper_checker.fields_have_correct_type(fields_dict_mocks)
+    assert not _fields_have_correct_type(fields_dict_mocks)
 
 
-def test_GIVEN_edges_array_with_valid_shape_WHEN_validating_disk_chopper_THEN_edges_array_has_correct_shape_returns_true(
-    generic_chopper_checker
-):
+def test_GIVEN_edges_array_with_valid_shape_WHEN_validating_disk_chopper_THEN_edges_array_has_correct_shape_returns_true():
 
     valid_array = np.array([i for i in range(6)])
-    assert generic_chopper_checker.edges_array_has_correct_shape(
-        valid_array.ndim, valid_array.shape
-    )
+    assert _edges_array_has_correct_shape(valid_array.ndim, valid_array.shape)
 
 
-def test_GIVEN_edges_array_with_more_than_two_dimensions_WHEN_validating_disk_chopper_THEN_edges_array_has_correct_shape_returns_false(
-    generic_chopper_checker
-):
+def test_GIVEN_edges_array_with_more_than_two_dimensions_WHEN_validating_disk_chopper_THEN_edges_array_has_correct_shape_returns_false():
 
     three_dim_array = np.ones(shape=(5, 5, 5))
-    assert not generic_chopper_checker.edges_array_has_correct_shape(
+    assert not _edges_array_has_correct_shape(
         three_dim_array.ndim, three_dim_array.shape
     )
 
 
-def test_GIVEN_edges_array_with_two_dimensions_WHEN_validating_disk_chopper_THEN_edges_array_has_correct_shape_returns_false(
-    generic_chopper_checker
-):
+def test_GIVEN_edges_array_with_two_dimensions_WHEN_validating_disk_chopper_THEN_edges_array_has_correct_shape_returns_false():
 
     two_dim_array = np.ones(shape=(5, 5))
-    assert not generic_chopper_checker.edges_array_has_correct_shape(
-        two_dim_array.ndim, two_dim_array.shape
-    )
+    assert not _edges_array_has_correct_shape(two_dim_array.ndim, two_dim_array.shape)
 
 
-def test_GIVEN_column_shaped_edges_array_WHEN_validating_disk_chopper_THEN_edges_array_has_correct_shape_returns_true(
-    generic_chopper_checker
-):
+def test_GIVEN_column_shaped_edges_array_WHEN_validating_disk_chopper_THEN_edges_array_has_correct_shape_returns_true():
 
     column_array = np.ones(shape=(5, 1))
-    assert generic_chopper_checker.edges_array_has_correct_shape(
-        column_array.ndim, column_array.shape
-    )
+    assert _edges_array_has_correct_shape(column_array.ndim, column_array.shape)
 
 
-def test_GIVEN_row_shaped_edges_array_WHEN_validating_disk_chopper_THEN_edges_array_has_correct_shape_returns_true(
-    generic_chopper_checker
-):
+def test_GIVEN_row_shaped_edges_array_WHEN_validating_disk_chopper_THEN_edges_array_has_correct_shape_returns_true():
 
     row_array = np.ones(shape=(1, 5))
-    assert generic_chopper_checker.edges_array_has_correct_shape(
-        row_array.ndim, row_array.shape
-    )
+    assert _edges_array_has_correct_shape(row_array.ndim, row_array.shape)
 
 
 def test_GIVEN_valid_values_WHEN_validating_chopper_input_THEN_returns_true(
@@ -274,9 +252,7 @@ def test_GIVEN_slit_edges_array_with_invalid_shape_WHEN_validating_chopper_input
     )
 
     assert user_defined_chopper_checker.required_fields_present()
-    assert user_defined_chopper_checker._generic_chopper_checker.fields_have_correct_type(
-        user_defined_chopper_checker.fields_dict
-    )
+    assert _fields_have_correct_type(user_defined_chopper_checker.fields_dict)
     assert not user_defined_chopper_checker.validate_chopper()
 
 
@@ -286,10 +262,8 @@ def test_GIVEN_mismatch_between_slits_and_slit_edges_array_WHEN_validating_chopp
     user_defined_chopper_checker.fields_dict[SLITS_NAME].value = 5
 
     assert user_defined_chopper_checker.required_fields_present()
-    assert user_defined_chopper_checker._generic_chopper_checker.fields_have_correct_type(
-        user_defined_chopper_checker.fields_dict
-    )
-    assert user_defined_chopper_checker._generic_chopper_checker.edges_array_has_correct_shape(
+    assert _fields_have_correct_type(user_defined_chopper_checker.fields_dict)
+    assert _edges_array_has_correct_shape(
         user_defined_chopper_checker.fields_dict[SLIT_EDGES_NAME].value.ndim,
         user_defined_chopper_checker.fields_dict[SLIT_EDGES_NAME].value.shape,
     )
@@ -303,10 +277,8 @@ def test_GIVEN_slit_height_is_larger_than_radius_WHEN_validating_chopper_input_T
     user_defined_chopper_checker.fields_dict[SLIT_HEIGHT_NAME].value = 201
 
     assert user_defined_chopper_checker.required_fields_present()
-    assert user_defined_chopper_checker._generic_chopper_checker.fields_have_correct_type(
-        user_defined_chopper_checker.fields_dict
-    )
-    assert user_defined_chopper_checker._generic_chopper_checker.edges_array_has_correct_shape(
+    assert _fields_have_correct_type(user_defined_chopper_checker.fields_dict)
+    assert _edges_array_has_correct_shape(
         user_defined_chopper_checker.fields_dict[SLIT_EDGES_NAME].value.ndim,
         user_defined_chopper_checker.fields_dict[SLIT_EDGES_NAME].value.shape,
     )
@@ -322,10 +294,8 @@ def test_GIVEN_slit_height_and_radius_are_equal_WHEN_validating_chopper_input_TH
     ].value = user_defined_chopper_checker.fields_dict[RADIUS_NAME].value = 20
 
     assert user_defined_chopper_checker.required_fields_present()
-    assert user_defined_chopper_checker._generic_chopper_checker.fields_have_correct_type(
-        user_defined_chopper_checker.fields_dict
-    )
-    assert user_defined_chopper_checker._generic_chopper_checker.edges_array_has_correct_shape(
+    assert _fields_have_correct_type(user_defined_chopper_checker.fields_dict)
+    assert _edges_array_has_correct_shape(
         user_defined_chopper_checker.fields_dict[SLIT_EDGES_NAME].value.ndim,
         user_defined_chopper_checker.fields_dict[SLIT_EDGES_NAME].value.shape,
     )
@@ -344,10 +314,8 @@ def test_GIVEN_slit_edges_list_is_not_in_order_WHEN_validating_chopper_input_THE
     )
 
     assert user_defined_chopper_checker.required_fields_present()
-    assert user_defined_chopper_checker._generic_chopper_checker.fields_have_correct_type(
-        user_defined_chopper_checker.fields_dict
-    )
-    assert user_defined_chopper_checker._generic_chopper_checker.edges_array_has_correct_shape(
+    assert _fields_have_correct_type(user_defined_chopper_checker.fields_dict)
+    assert _edges_array_has_correct_shape(
         user_defined_chopper_checker.fields_dict[SLIT_EDGES_NAME].value.ndim,
         user_defined_chopper_checker.fields_dict[SLIT_EDGES_NAME].value.shape,
     )
@@ -363,10 +331,8 @@ def test_GIVEN_slit_edges_list_contains_repeated_values_WHEN_validating_chopper_
     ] = user_defined_chopper_checker.fields_dict[SLIT_EDGES_NAME].value[1]
 
     assert user_defined_chopper_checker.required_fields_present()
-    assert user_defined_chopper_checker._generic_chopper_checker.fields_have_correct_type(
-        user_defined_chopper_checker.fields_dict
-    )
-    assert user_defined_chopper_checker._generic_chopper_checker.edges_array_has_correct_shape(
+    assert _fields_have_correct_type(user_defined_chopper_checker.fields_dict)
+    assert _edges_array_has_correct_shape(
         user_defined_chopper_checker.fields_dict[SLIT_EDGES_NAME].value.ndim,
         user_defined_chopper_checker.fields_dict[SLIT_EDGES_NAME].value.shape,
     )
@@ -382,10 +348,8 @@ def test_GIVEN_slit_edges_list_has_overlapping_slits_WHEN_validating_chopper_inp
     )
 
     assert user_defined_chopper_checker.required_fields_present()
-    assert user_defined_chopper_checker._generic_chopper_checker.fields_have_correct_type(
-        user_defined_chopper_checker.fields_dict
-    )
-    assert user_defined_chopper_checker._generic_chopper_checker.edges_array_has_correct_shape(
+    assert _fields_have_correct_type(user_defined_chopper_checker.fields_dict)
+    assert _edges_array_has_correct_shape(
         user_defined_chopper_checker.fields_dict[SLIT_EDGES_NAME].value.ndim,
         user_defined_chopper_checker.fields_dict[SLIT_EDGES_NAME].value.shape,
     )


### PR DESCRIPTION
The GenericChopperChecker didn't actually use any state so I removed it and changed its methods to free functions.
Also used the `@Property` decorator instead of a getter method in the other checker classes.