### PR TITLE
Squeeze arrays so 1-dimensional arrays are allowed to exist

### DIFF
--- a/nexus_constructor/component_fields.py
+++ b/nexus_constructor/component_fields.py
@@ -27,6 +27,7 @@ from nexus_constructor.validators import (
     NameValidator,
     HDFLocationExistsValidator,
 )
+import numpy as np
 
 
 class FieldNameLineEdit(QLineEdit):
@@ -177,7 +178,8 @@ class FieldWidget(QFrame):
                 ).create_dataset(name=self.name, dtype=dtype, data=val)
             return dtype(val)
         elif self.field_type == FieldType.array_dataset:
-            return self.table_view.model.array
+            # Squeeze the array so 1D arrays can exist. Should not affect dimensional arrays.
+            return np.squeeze(self.table_view.model.array)
         elif self.field_type == FieldType.link:
             return h5py.SoftLink(self.value_line_edit.text())
 


### PR DESCRIPTION
### Issue

Closes #438 

### Description of work

Squeezes the array every time it is accessed - should allow 1D arrays to exist but multi-dimensional arrays should not be affected. 

### Acceptance Criteria 

Test in the built-in nexus constructor silx tree view as well as in the external nexus file to see if 1D arrays are able to be created. This can be done by adding an array field with 1 row or 1 column. 

### UI tests

N/A

### Nominate for Group Code Review

- [ ] Nominate for code review 
