### PR TITLE
Fixes 3d components not being loaded when file is opened

### DIFF
--- a/nexus_constructor/component.py
+++ b/nexus_constructor/component.py
@@ -340,8 +340,12 @@ class Component:
         return shape_group
 
     def get_shape(self) -> Optional[Union[OFFGeometry, CylindricalGeometry]]:
-        if SHAPE_GROUP_NAME in self.group:
-            shape_group = self.group[SHAPE_GROUP_NAME]
+        if SHAPE_GROUP_NAME in self.group or PIXEL_SHAPE_GROUP_NAME in self.group:
+            shape_group = self.group[
+                SHAPE_GROUP_NAME
+                if SHAPE_GROUP_NAME in self.group
+                else PIXEL_SHAPE_GROUP_NAME
+            ]
             nx_class = get_nx_class(shape_group)
             if nx_class == CYLINDRICAL_GEOMETRY_NEXUS_NAME:
                 return CylindricalGeometry(self.file, shape_group)


### PR DESCRIPTION
### Issue

Closes #442 

### Description of work

Fixes components not being opened with their correct shape descriptions when nexus files are loaded. I'm not sure if this is intentional, but I couldn't find an issue with it besides #442 so I have patched it with this PR. 

### Acceptance Criteria 

Save + load a file with geometry information 
load file and check component view is updated. 

### UI tests

N/A - 3d view is hard to UI test. 

### Nominate for Group Code Review

- [ ] Nominate for code review 
