### PR TITLE
Setting mode to r+ instead of read-only when opening nexus file

### DIFF
--- a/nexus_constructor/nexus/nexus_wrapper.py
+++ b/nexus_constructor/nexus/nexus_wrapper.py
@@ -94,7 +94,7 @@ class NexusWrapper(QObject):
         """
         if filename:
             nexus_file = h5py.File(
-                filename, mode="r", backing_store=False, driver="core"
+                filename, mode="r+", backing_store=False, driver="core"
             )
             entries = self.find_entries_in_file(nexus_file)
             self.file_opened.emit(nexus_file)


### PR DESCRIPTION
### Issue

Closes #459 

### Description of work

We were opening it in read-only mode and therefore could not add to the file. 

### Acceptance Criteria 

the file opening mode. 

### UI tests

N/A

### Nominate for Group Code Review

- [ ] Nominate for code review 
