### PR TITLE
455 remove NCstream NX_class from json

### DIFF
--- a/nexus_constructor/nexus_filewriter_json/writer.py
+++ b/nexus_constructor/nexus_filewriter_json/writer.py
@@ -96,7 +96,12 @@ class NexusToDictConverter:
     def _handle_attributes(root, root_dict):
         if "NX_class" in root.attrs:
             nx_class = root.attrs["NX_class"]
-            if nx_class and nx_class != "NXfield" and nx_class != "NXgroup" and nx_class != "NCstream":
+            if (
+                nx_class
+                and nx_class != "NXfield"
+                and nx_class != "NXgroup"
+                and nx_class != "NCstream"
+            ):
                 root_dict["attributes"] = [{"name": "NX_class", "values": nx_class}]
             if len(root.attrs) > 1:
                 if "attributes" not in root_dict:

--- a/nexus_constructor/nexus_filewriter_json/writer.py
+++ b/nexus_constructor/nexus_filewriter_json/writer.py
@@ -96,7 +96,7 @@ class NexusToDictConverter:
     def _handle_attributes(root, root_dict):
         if "NX_class" in root.attrs:
             nx_class = root.attrs["NX_class"]
-            if nx_class and nx_class != "NXfield" and nx_class != "NXgroup":
+            if nx_class and nx_class != "NXfield" and nx_class != "NXgroup" and nx_class != "NCstream":
                 root_dict["attributes"] = [{"name": "NX_class", "values": nx_class}]
             if len(root.attrs) > 1:
                 if "attributes" not in root_dict:


### PR DESCRIPTION
### Issue

Closes #455 

### Description of work

Removes the NX_class attribute from stream objects in the filewriter JSON output as it is not needed. 

### Acceptance Criteria 

Command is otherwise unaffected. 

### UI tests

N/A

### Nominate for Group Code Review

- [ ] Nominate for code review 
