### PR TITLE
sorting the nx_classes by name in the add component window

### DIFF
--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from enum import Enum
 
 from PySide2.QtGui import QVector3D
@@ -69,6 +70,10 @@ class AddComponentDialog(Ui_AddComponentDialog, QObject):
         _, self.nx_component_classes = make_dictionary_of_class_definitions(
             os.path.abspath(os.path.join(os.curdir, "definitions"))
         )
+        self.nx_component_classes = OrderedDict(
+            sorted(self.nx_component_classes.items())
+        )
+
         self.cad_file_name = None
         self.possible_fields = []
         self.component_to_edit = component_to_edit


### PR DESCRIPTION
### Issue

Closes #390 

### Description of work

Was getting really annoyed by not being able to find certain nx classes instantly so made this change, might as well make a PR of it rather than just stashing the changes. 

I know this does not drop the `NX_` prefix but as a simple fix to make the add component window easier to use I have sorted the nx_classes in alphabetical order using an ordered dict. 

### Acceptance Criteria 

Add component window still works as normal
NX_classes are in alphabetical order 

### UI tests

N/A

### Nominate for Group Code Review

- [ ] Nominate for code review 
