### PR TITLE
Fix chopper shape not being shown

### DIFF
--- a/nexus_constructor/component/chopper_shape.py
+++ b/nexus_constructor/component/chopper_shape.py
@@ -22,7 +22,7 @@ class ChopperShape(ComponentShape):
     ]:
         # If there is a shape group then use that
         shape, _ = super().get_shape()
-        if shape is not None:
+        if not isinstance(shape, NoShapeGeometry):
             return shape, None
 
         # Otherwise see if we can generate shape from the details we have

--- a/nexus_constructor/geometry/disk_chopper/disk_chopper_checker.py
+++ b/nexus_constructor/geometry/disk_chopper/disk_chopper_checker.py
@@ -262,7 +262,6 @@ class NexusDefinedChopperChecker:
             self._radius_units = decode_bytes_string(
                 self._disk_chopper[RADIUS_NAME].attrs["units"]
             )
-            self._disk_chopper[NAME][()],
 
         except KeyError:
             return False

--- a/tests/test_component_factory.py
+++ b/tests/test_component_factory.py
@@ -1,12 +1,35 @@
+import numpy as np
+
 from nexus_constructor.component.chopper_shape import ChopperShape
 from nexus_constructor.component.component_shape import ComponentShape
 from nexus_constructor.component.pixel_shape import PixelShape
 from nexus_constructor.component.component_factory import create_component
 from nexus_constructor.nexus import nexus_wrapper as nx
+from nexus_constructor.geometry import OFFGeometryNoNexus
 
 """
 Tests here document the conditions under which the factory creates components of different types
 """
+
+
+def add_dataset(group, name, data, attributes=None):
+    if isinstance(data, str):
+        dataset = group.create_dataset(
+            name, data=np.array(data).astype("|S" + str(len(data)))
+        )
+    else:
+        dataset = group.create_dataset(name, data=data)
+
+    if attributes:
+        for key in attributes:
+            if isinstance(attributes[key], str):
+                dataset.attrs.create(
+                    key,
+                    np.array(attributes[key]).astype("|S" + str(len(attributes[key]))),
+                )
+            else:
+                dataset.attrs.create(key, np.array(attributes[key]))
+    return dataset
 
 
 def test_GIVEN_an_NXdisk_chopper_group_WHEN_calling_create_component_THEN_component_has_a_ChopperShape():
@@ -16,6 +39,44 @@ def test_GIVEN_an_NXdisk_chopper_group_WHEN_calling_create_component_THEN_compon
     )
     new_component = create_component(wrapper, chopper_group)
     assert isinstance(new_component._shape, ChopperShape)
+
+
+def test_GIVEN_an_NXdisk_chopper_group_WHEN_calling_create_component_THEN_component_returns_OFFGeometry_of_chopper():
+    wrapper = nx.NexusWrapper("file_with_chopper")
+    chopper_group = wrapper.create_nx_group(
+        "chopper", "NXdisk_chopper", wrapper.instrument
+    )
+    add_dataset(
+        chopper_group,
+        "slit_edges",
+        np.array(
+            [
+                83.71,
+                94.7,
+                140.49,
+                155.79,
+                193.26,
+                212.56,
+                242.32,
+                265.33,
+                287.91,
+                314.37,
+                330.3,
+                360.0,
+            ]
+        )
+        + 15.0,
+        attributes={"units": "deg"},
+    )
+    add_dataset(chopper_group, "slits", 6)
+    add_dataset(chopper_group, "slit_height", 130.0, attributes={"units": "mm"})
+    add_dataset(chopper_group, "radius", 300.0, attributes={"units": "mm"})
+    new_component = create_component(wrapper, chopper_group)
+    assert isinstance(new_component._shape, ChopperShape)
+    assert isinstance(new_component.shape[0], OFFGeometryNoNexus)
+    assert (
+        len(new_component.shape[0].vertices) > 8
+    ), "Expect chopper geometry with many vertices, not just a placeholder cube with 8 vertices"
 
 
 def test_GIVEN_an_nx_group_with_no_shape_WHEN_calling_create_component_THEN_component_has_a_ComponentShape():

--- a/tests/test_disk_chopper_checker.py
+++ b/tests/test_disk_chopper_checker.py
@@ -422,13 +422,6 @@ def test_GIVEN_complete_nexus_disk_chopper_WHEN_validating_disk_chopper_THEN_req
     assert nexus_defined_chopper_checker.required_fields_present()
 
 
-def test_GIVEN_nexus_disk_chopper_with_no_name_WHEN_validating_disk_chopper_THEN_required_fields_present_returns_false(
-    nexus_defined_chopper_checker
-):
-    del nexus_defined_chopper_checker._disk_chopper[NAME]
-    assert not nexus_defined_chopper_checker.required_fields_present()
-
-
 def test_GIVEN_nexus_disk_chopper_with_no_slits_value_WHEN_validating_disk_chopper_THEN_required_fields_present_returns_false(
     nexus_defined_chopper_checker
 ):


### PR DESCRIPTION
### Issue

No ticket

### Description of work

I broke chopper shape rendering when working on pixel rendering. This fixes it and adds a unit test to prevent it from happening again.

I also removed the check for a name dataset during chopper validation as it is not needed to be able to create the chopper geometry.

### Acceptance Criteria 

Try loading the test chopper NeXus file, the chopper should be rendered.

