### PR TITLE
473 - disallowing invalid field names from being used and adding tests

### DIFF
--- a/nexus_constructor/component_fields.py
+++ b/nexus_constructor/component_fields.py
@@ -31,10 +31,15 @@ from nexus_constructor.validators import (
 )
 import numpy as np
 
+invalid_field_names = ["description", "shape", "depends_on"]
+
 
 class FieldNameLineEdit(QLineEdit):
     def __init__(self, possible_field_names: List[str]):
         super().__init__()
+        possible_field_names = [
+            x for x in possible_field_names if x not in invalid_field_names
+        ]
         self.update_possible_fields(possible_field_names)
         self.setPlaceholderText("Name of new field")
         self.setMinimumWidth(160)
@@ -146,7 +151,10 @@ class FieldWidget(QFrame):
         field_widgets = []
         for i in range(parent.count()):
             field_widgets.append(parent.itemWidget(parent.item(i)))
-        self.field_name_edit.setValidator(NameValidator(field_widgets))
+
+        self.field_name_edit.setValidator(
+            NameValidator(field_widgets, invalid_names=invalid_field_names)
+        )
         self.field_name_edit.validator().is_valid.connect(
             partial(
                 validate_line_edit,

--- a/nexus_constructor/component_fields.py
+++ b/nexus_constructor/component_fields.py
@@ -31,14 +31,16 @@ from nexus_constructor.validators import (
 )
 import numpy as np
 
-invalid_field_names = ["description", "shape", "depends_on"]
+# These are invalid because there are separate inputs in the UI for these fields and therefore inputting them through
+# the field name line edit would cause conflicts.
+INVALID_FIELD_NAMES = ["description", "shape", "depends_on"]
 
 
 class FieldNameLineEdit(QLineEdit):
     def __init__(self, possible_field_names: List[str]):
         super().__init__()
         possible_field_names = [
-            x for x in possible_field_names if x not in invalid_field_names
+            x for x in possible_field_names if x not in INVALID_FIELD_NAMES
         ]
         self.update_possible_fields(possible_field_names)
         self.setPlaceholderText("Name of new field")
@@ -153,7 +155,7 @@ class FieldWidget(QFrame):
             field_widgets.append(parent.itemWidget(parent.item(i)))
 
         self.field_name_edit.setValidator(
-            NameValidator(field_widgets, invalid_names=invalid_field_names)
+            NameValidator(field_widgets, invalid_names=INVALID_FIELD_NAMES)
         )
         self.field_name_edit.validator().is_valid.connect(
             partial(

--- a/nexus_constructor/validators.py
+++ b/nexus_constructor/validators.py
@@ -78,12 +78,15 @@ class NameValidator(QValidator):
     The validationFailed signal is emitted if an entered name is not unique.
     """
 
-    def __init__(self, list_model: List):
+    def __init__(self, list_model: List, invalid_names=None):
         super().__init__()
+        if invalid_names is None:
+            invalid_names = []
         self.list_model = list_model
+        self.invalid_names = invalid_names
 
     def validate(self, input: str, pos: int):
-        if not input:
+        if not input or input in self.invalid_names:
             self.is_valid.emit(False)
             return QValidator.Intermediate
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -27,7 +27,7 @@ class ObjectWithName:
 
 
 def assess_names(
-    names: List[ObjectWithName], new_name, expected_validity, invalid=None
+    names: List[ObjectWithName], new_name, expected_validity, invalid_names=None
 ):
     """
     Tests the validity of a given name at a given index in a TransformationModel and InstrumentModel with an existing
@@ -37,14 +37,17 @@ def assess_names(
     :param new_name: The name to check the validity of a change/insert into the model
     :param expected_validity: Whether the name change/insert is expected to be valid
     """
-    validator = NameValidator(names, invalid)
+    validator = NameValidator(names, invalid_names)
     assert (
         validator.validate(new_name, 0) == QValidator.Acceptable
     ) == expected_validity
 
 
 def test_name_validator_name_in_invalid_names():
-    assess_names([], "test", expected_validity=False, invalid=["test"])
+    invalid_names = ["test"]
+    assess_names(
+        [], invalid_names[0], expected_validity=False, invalid_names=invalid_names
+    )
 
 
 def test_name_validator_new_unique_name():

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -26,7 +26,9 @@ class ObjectWithName:
     name = attr.ib(str)
 
 
-def assess_names(names: List[ObjectWithName], new_name, expected_validity):
+def assess_names(
+    names: List[ObjectWithName], new_name, expected_validity, invalid=None
+):
     """
     Tests the validity of a given name at a given index in a TransformationModel and InstrumentModel with an existing
     list of named transforms
@@ -35,10 +37,14 @@ def assess_names(names: List[ObjectWithName], new_name, expected_validity):
     :param new_name: The name to check the validity of a change/insert into the model
     :param expected_validity: Whether the name change/insert is expected to be valid
     """
-    validator = NameValidator(names)
+    validator = NameValidator(names, invalid)
     assert (
         validator.validate(new_name, 0) == QValidator.Acceptable
     ) == expected_validity
+
+
+def test_name_validator_name_in_invalid_names():
+    assess_names([], "test", expected_validity=False, invalid=["test"])
 
 
 def test_name_validator_new_unique_name():


### PR DESCRIPTION
### Issue

Closes #473 

### Description of work

Validates against invalid names such as depends_on, shape and description. 
Also removes the invalid names from the field name suggestion so the user is not encouraged to put the invalid field name in. 

### Acceptance Criteria 

Test putting in depends_on into a field name, it should be highlighted red. 
It should also not auto-complete to depends_on or any other invalid field name. 

### UI tests

Unit tests added for validator 

### Nominate for Group Code Review

- [ ] Nominate for code review 
