### PR TITLE
481-  fix stream and link writing

### DIFF
--- a/nexus_constructor/component_fields.py
+++ b/nexus_constructor/component_fields.py
@@ -73,8 +73,14 @@ class FieldWidget(QFrame):
         possible_field_names: List[str],
         parent: QListWidget = None,
         instrument: Instrument = None,
+        stream_group_name: str = None,
     ):
         super(FieldWidget, self).__init__(parent)
+
+        # We don't really care about this as it'll never end up in the JSON, but in order to save it into a nexus file it needs a name.
+        self.stream_group_name = (
+            stream_group_name if stream_group_name is not None else str(uuid.uuid4())
+        )
 
         self.edit_dialog = QDialog(parent=self)
         self.instrument = instrument
@@ -161,7 +167,11 @@ class FieldWidget(QFrame):
 
     @property
     def name(self):
-        return self.field_name_edit.text()
+        return (
+            self.field_name_edit.text()
+            if self.field_type != FieldType.kafka_stream
+            else self.stream_group_name
+        )
 
     @property
     def dtype(self):

--- a/nexus_constructor/component_fields.py
+++ b/nexus_constructor/component_fields.py
@@ -204,7 +204,7 @@ class FieldWidget(QFrame):
         elif self.field_type_combo.currentText() == FieldType.array_dataset.value:
             self.set_visibility(False, False, True, True)
         elif self.field_type_combo.currentText() == FieldType.kafka_stream.value:
-            self.set_visibility(False, False, True, False)
+            self.set_visibility(False, False, True, False, show_name_line_edit=False)
         elif self.field_type_combo.currentText() == FieldType.link.value:
             self.set_visibility(True, False, False, False)
             self._set_up_value_validator(True)
@@ -240,15 +240,17 @@ class FieldWidget(QFrame):
 
     def set_visibility(
         self,
-        show_value_line_edit,
-        show_nx_class_combo,
-        show_edit_button,
-        show_value_type_combo,
+        show_value_line_edit: bool,
+        show_nx_class_combo: bool,
+        show_edit_button: bool,
+        show_value_type_combo: bool,
+        show_name_line_edit: bool = True,
     ):
         self.value_line_edit.setVisible(show_value_line_edit)
         self.nx_class_combo.setVisible(show_nx_class_combo)
         self.edit_button.setVisible(show_edit_button)
         self.value_type_combo.setVisible(show_value_type_combo)
+        self.field_name_edit.setVisible(show_name_line_edit)
 
     def show_edit_dialog(self):
         if self.field_type_combo.currentText() == FieldType.array_dataset.value:

--- a/nexus_constructor/json/filewriter_json_writer.py
+++ b/nexus_constructor/json/filewriter_json_writer.py
@@ -171,7 +171,7 @@ class NexusToDictConverter:
             root_dict["children"].append(
                 {
                     "type": "link",
-                    "name": root.name,
+                    "name": root.name.split("/")[-1],
                     "target": self._links[root.name]
                     .file.get(root.name, getlink=True)
                     .path,

--- a/nexus_constructor/json/filewriter_json_writer.py
+++ b/nexus_constructor/json/filewriter_json_writer.py
@@ -164,19 +164,14 @@ class NexusToDictConverter:
         # Add the entries
         entries = list(root.values())
         if root.name in self._kafka_streams:
-            root_dict["children"].append(
-                {"type": "stream", "stream": self._kafka_streams[root.name]}
-            )
+            root_dict = {"type": "stream", "stream": self._kafka_streams[root.name]}
+
         elif root.name in self._links.keys():
-            root_dict["children"].append(
-                {
-                    "type": "link",
-                    "name": root.name.split("/")[-1],
-                    "target": self._links[root.name]
-                    .file.get(root.name, getlink=True)
-                    .path,
-                }
-            )
+            root_dict = {
+                "type": "link",
+                "name": root.name.split("/")[-1],
+                "target": self._links[root.name].file.get(root.name, getlink=True).path,
+            }
         elif entries:
             for entry in entries:
                 child_dict = self._root_to_dict(entry)

--- a/nexus_constructor/json/filewriter_json_writer.py
+++ b/nexus_constructor/json/filewriter_json_writer.py
@@ -81,8 +81,8 @@ class NexusToDictConverter:
     """
 
     def __init__(self):
-        self._kafka_streams = dict()
-        self._links = dict()
+        self._kafka_streams = {}
+        self._links = {}
 
     def convert(self, nexus_root: NexusObject, streams: dict, links: dict):
         """
@@ -184,11 +184,9 @@ class NexusToDictConverter:
             root_dict = {"type": "stream", "stream": self._kafka_streams[root.name]}
 
         elif root.name in self._links.keys():
-            root_dict = {
-                "type": "link",
-                "name": root.name.split("/")[-1],
-                "target": self._links[root.name].file.get(root.name, getlink=True).path,
-            }
+            root_dict = self._create_link_root_dict(
+                root, self._links[root.name].file.get(root.name, getlink=True).path
+            )
         elif entries:
             for entry in entries:
                 child_dict = self._root_to_dict(entry)
@@ -196,23 +194,33 @@ class NexusToDictConverter:
 
         return root_dict
 
-    def _handle_dataset(self, root: h5py.Dataset):
+    def _handle_dataset(self, root: Union[h5py.Dataset, h5py.SoftLink]):
         """
         Generate JSON dict for a h5py dataset.
         :param root: h5py dataset to generate dict from.
         :return: generated dictionary of dataset values and attrs.
         """
         data, dataset_type, size = self._get_data_and_type(root)
-        root_dict = {
-            "type": "dataset",
-            "name": root.name,
-            "dataset": {"type": dataset_type},
-            "values": data,
-        }
-        if size != 1:
-            root_dict["dataset"]["size"] = size
+
+        if self._links and root.name in self._links.keys():
+            root_dict = self._create_link_root_dict(
+                root, root.file.get(root.name, getlink=True).path
+            )
+        else:
+            root_dict = {
+                "type": "dataset",
+                "name": root.name,
+                "dataset": {"type": dataset_type},
+                "values": data,
+            }
+            if size != 1:
+                root_dict["dataset"]["size"] = size
 
         return root_dict
+
+    @staticmethod
+    def _create_link_root_dict(root, target):
+        return {"type": "link", "name": root.name.split("/")[-1], "target": target}
 
 
 def create_writer_commands(

--- a/tests/test_json_writer.py
+++ b/tests/test_json_writer.py
@@ -248,8 +248,29 @@ def test_GIVEN_link_in_group_children_WHEN_handling_group_THEN_link_is_appended_
             file, streams={}, links={file[group_name].name: group_to_be_linked}
         )
 
+        assert root_dict["children"][0]["type"] == "link"
         assert file[group_name].name.split("/")[-1] == root_dict["children"][0]["name"]
         assert group_to_be_linked.name == root_dict["children"][0]["target"]
+
+
+def test_GIVEN_link_in_group_children_that_is_a_dataset_WHEN_handling_group_THEN_link_is_appended_to_children():
+    with InMemoryFile("test_file") as file:
+        ds_to_be_linked_name = "test_linked_dataset"
+        dataset_to_be_linked = file.create_dataset(ds_to_be_linked_name, data=1)
+        dataset_to_be_linked.attrs["NX_class"] = "NXgroup"
+
+        group_name = "test_group_with_link"
+        file[group_name] = h5py.SoftLink(dataset_to_be_linked.name)
+        file[group_name].attrs["NX_class"] = "NXgroup"
+
+        converter = NexusToDictConverter()
+        root_dict = converter.convert(
+            file, streams={}, links={file[group_name].name: dataset_to_be_linked}
+        )
+
+        assert root_dict["children"][0]["type"] == "link"
+        assert file[group_name].name.split("/")[-1] == root_dict["children"][0]["name"]
+        assert dataset_to_be_linked.name == root_dict["children"][0]["target"]
 
 
 def test_GIVEN_group_with_multiple_attributes_WHEN_converting_nexus_to_dict_THEN_attributes_end_up_in_file():

--- a/tests/test_json_writer.py
+++ b/tests/test_json_writer.py
@@ -230,8 +230,7 @@ def test_GIVEN_stream_in_group_children_WHEN_handling_group_THEN_stream_is_appen
             file, streams={f"/{group_name}": group_contents}, links=[]
         )
 
-        assert group.name == root_dict["children"][0]["name"]
-        assert group_contents == root_dict["children"][0]["children"][0]["stream"]
+        assert group_contents == root_dict["children"][0]["stream"]
 
 
 def test_GIVEN_link_in_group_children_WHEN_handling_group_THEN_link_is_appended_to_children():
@@ -249,11 +248,8 @@ def test_GIVEN_link_in_group_children_WHEN_handling_group_THEN_link_is_appended_
             file, streams={}, links={file[group_name].name: group_to_be_linked}
         )
 
-        assert file[group_name].name == root_dict["children"][0]["name"]
-        assert file[group_name].name == root_dict["children"][0]["children"][0]["name"]
-        assert (
-            group_to_be_linked.name == root_dict["children"][0]["children"][0]["target"]
-        )
+        assert file[group_name].name.split("/")[-1] == root_dict["children"][0]["name"]
+        assert group_to_be_linked.name == root_dict["children"][0]["target"]
 
 
 def test_GIVEN_group_with_multiple_attributes_WHEN_converting_nexus_to_dict_THEN_attributes_end_up_in_file():

--- a/tests/ui_tests/test_ui_add_component_window.py
+++ b/tests/ui_tests/test_ui_add_component_window.py
@@ -1716,8 +1716,6 @@ def test_UI_GIVEN_field_widget_with_stream_type_and_schema_set_to_f142_THEN_stre
 
     group = streams_widget.get_stream_group()
 
-    assert name in group.name
-
     assert "array_size" in group
 
     assert group["array_size"][()] == array_size


### PR DESCRIPTION
### Issue

Closes #481 

### Description of work

Fixes the links and streams being put in an extra group that should not be there. This is now not the case and it just puts in the stream object. 

### Acceptance Criteria 

When "kafka stream" is selected as field type, the name field should not be visible. 

Streams and links should now be outputted properly 

### UI tests

N/A - no UI changes besides the kafka stream field disappearing. 

### Nominate for Group Code Review

- [ ] Nominate for code review 
