### PR TITLE
477 - deleting transforms from chain when components are deleted

### DIFF
--- a/nexus_constructor/component_tree_model.py
+++ b/nexus_constructor/component_tree_model.py
@@ -124,13 +124,8 @@ class ComponentTreeModel(QAbstractItemModel):
 
     def __remove_component(self, index: QModelIndex):
         component = index.internalPointer()
-        is_depended_on = False
         transforms = component.transforms
-        if transforms:
-            if transforms[0].get_dependents():
-                is_depended_on = True
-
-        if is_depended_on:
+        if transforms and transforms[0].get_dependents():
             reply = QMessageBox.question(
                 None,
                 "Delete component?",

--- a/nexus_constructor/component_tree_model.py
+++ b/nexus_constructor/component_tree_model.py
@@ -124,8 +124,13 @@ class ComponentTreeModel(QAbstractItemModel):
 
     def __remove_component(self, index: QModelIndex):
         component = index.internalPointer()
-        # TODO: check if it's depended on
-        if component:
+        is_depended_on = False
+        transforms = component.transforms
+        if transforms:
+            if transforms[0].get_dependents():
+                is_depended_on = True
+
+        if is_depended_on:
             reply = QMessageBox.question(
                 None,
                 "Delete component?",

--- a/nexus_constructor/component_tree_model.py
+++ b/nexus_constructor/component_tree_model.py
@@ -1,6 +1,8 @@
 from PySide2.QtCore import QAbstractItemModel, QModelIndex, Qt, Signal
 import PySide2.QtGui
 from PySide2.QtGui import QVector3D
+from PySide2.QtWidgets import QMessageBox
+
 from nexus_constructor.component.component import Component
 from nexus_constructor.component.transformations_list import TransformationsList
 from nexus_constructor.component.link_transformation import LinkTransformation
@@ -121,9 +123,22 @@ class ComponentTreeModel(QAbstractItemModel):
         self.endRemoveRows()
 
     def __remove_component(self, index: QModelIndex):
+        component = index.internalPointer()
+        # TODO: check if it's depended on
+        if component:
+            reply = QMessageBox.question(
+                None,
+                "Delete component?",
+                "this component has transformations that are depended on. Are you sure you want to delete it?",
+                QMessageBox.Yes,
+                QMessageBox.No,
+            )
+            if reply == QMessageBox.Yes:
+                pass
+            elif reply == QMessageBox.No:
+                return
         remove_index = self.components.index(index.internalPointer())
         self.beginRemoveRows(QModelIndex(), remove_index, remove_index)
-        component = index.internalPointer()
         for transform in component.transforms:
             transform.remove_from_dependee_chain()
         self.instrument.remove_component(component)

--- a/nexus_constructor/component_tree_model.py
+++ b/nexus_constructor/component_tree_model.py
@@ -144,7 +144,7 @@ class ComponentTreeModel(QAbstractItemModel):
                 return
         remove_index = self.components.index(index.internalPointer())
         self.beginRemoveRows(QModelIndex(), remove_index, remove_index)
-        for transform in component.transforms:
+        for transform in transforms:
             transform.remove_from_dependee_chain()
         self.instrument.remove_component(component)
         self.components.pop(remove_index)

--- a/nexus_constructor/component_tree_model.py
+++ b/nexus_constructor/component_tree_model.py
@@ -123,7 +123,10 @@ class ComponentTreeModel(QAbstractItemModel):
     def __remove_component(self, index: QModelIndex):
         remove_index = self.components.index(index.internalPointer())
         self.beginRemoveRows(QModelIndex(), remove_index, remove_index)
-        self.instrument.remove_component(index.internalPointer())
+        component = index.internalPointer()
+        for transform in component.transforms:
+            transform.remove_from_dependee_chain()
+        self.instrument.remove_component(component)
         self.components.pop(remove_index)
         self.endRemoveRows()
 


### PR DESCRIPTION
### Issue

Closes #477 

### Description of work

Deletes the transformations before deleting a component, which in-turn should restructure the depends_on tree. 

### Acceptance Criteria 

UI looks correct 
No exceptions thrown 
depends_on is correct
transformations are deleted from nexus file

### UI tests

None yet - want to check i am on the right path first. 

### Nominate for Group Code Review

- [ ] Nominate for code review 
