### PR TITLE
494 fix rendering meshes

### DIFF
--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -390,7 +390,11 @@ class AddComponentDialog(Ui_AddComponentDialog, QObject):
         component_name = self.nameLineEdit.text()
         description = self.descriptionPlainTextEdit.text()
 
-        pixel_data = self.pixel_options.generate_pixel_data()
+        pixel_data = (
+            self.pixel_options.generate_pixel_data()
+            if nx_class in PIXEL_COMPONENT_TYPES
+            else None
+        )
 
         if self.component_to_edit:
             shape, positions = self.edit_existing_component(

--- a/nexus_constructor/pixel_options.py
+++ b/nexus_constructor/pixel_options.py
@@ -299,9 +299,6 @@ class PixelOptions(Ui_PixelOptionsWidget, QObject):
         if self.entire_shape_radio_button.isChecked():
             return PixelMapping(self.get_pixel_mapping_ids())
 
-        if self.no_pixels_button.isChecked():
-            return None
-
     def update_pixel_input_validity(self):
         """
         Changes the state of the OK Validator depending on whether or not the pixel input is valid. If The No Pixel

--- a/tests/test_component_factory.py
+++ b/tests/test_component_factory.py
@@ -5,7 +5,7 @@ from nexus_constructor.component.component_shape import ComponentShape
 from nexus_constructor.component.pixel_shape import PixelShape
 from nexus_constructor.component.component_factory import create_component
 from nexus_constructor.nexus import nexus_wrapper as nx
-from nexus_constructor.geometry import OFFGeometryNoNexus
+from nexus_constructor.geometry import OFFGeometryNoNexus, OFFGeometryNexus
 
 """
 Tests here document the conditions under which the factory creates components of different types
@@ -84,6 +84,29 @@ def test_GIVEN_an_nx_group_with_no_shape_WHEN_calling_create_component_THEN_comp
     monitor_group = wrapper.create_nx_group("monitor", "NXmonitor", wrapper.instrument)
     new_component = create_component(wrapper, monitor_group)
     assert isinstance(new_component._shape, ComponentShape)
+
+
+def test_GIVEN_an_nx_group_with_shape_WHEN_calling_create_component_THEN_component_returns_OFFGeometry():
+    wrapper = nx.NexusWrapper("file_with_component_with_shape")
+    monitor_group = wrapper.create_nx_group("monitor", "NXmonitor", wrapper.instrument)
+    new_component = create_component(wrapper, monitor_group)
+
+    shape_group = wrapper.create_nx_group(
+        "shape", "NXoff_geometry", new_component.group
+    )
+    vertices_dataset = wrapper.set_field_value(
+        shape_group,
+        "vertices",
+        np.array([[0, 2, -2], [-1, -1, 1], [1, -1, 1]]),
+        dtype=np.float,
+    )
+    wrapper.set_field_value(
+        shape_group, "winding_order", np.array([0, 1, 2]), dtype=np.int32
+    )
+    wrapper.set_field_value(shape_group, "faces", np.array([0]), dtype=np.int32)
+    wrapper.set_attribute_value(vertices_dataset, "units", "m")
+
+    assert isinstance(new_component.shape[0], OFFGeometryNexus)
 
 
 def test_GIVEN_an_NXdetector_group_with_detector_shape_WHEN_calling_create_component_THEN_component_has_a_ComponentShape():


### PR DESCRIPTION
### Issue

Closes #494 

### Description of work

Fixed non-detector components with meshes rendering incorrectly in 3D view.

### Acceptance Criteria 

Create something other than an NXdetector, load a mesh as the shape and check that the mesh is rendered in the 3D view. Prior to fix it would always render the placeholder cube instead of the loaded mesh.

### Nominate for Group Code Review

- [ ] Nominate for code review 
