### PR TITLE
Test and fix for reading vlen string datasets with NexusWrapper

### DIFF
--- a/nexus_constructor/nexus/nexus_wrapper.py
+++ b/nexus_constructor/nexus/nexus_wrapper.py
@@ -185,6 +185,8 @@ class NexusWrapper(QObject):
         value = group[name][...]
         if value.dtype.type is np.string_:
             value = str(value, "utf8")
+        elif "vlen" in group[name].dtype.metadata.keys():
+            value = str(value.astype(np.string_), "utf8")
         return value
 
     @staticmethod

--- a/nexus_constructor/nexus/nexus_wrapper.py
+++ b/nexus_constructor/nexus/nexus_wrapper.py
@@ -188,6 +188,7 @@ class NexusWrapper(QObject):
         elif (
             group[name].dtype.metadata is not None
             and "vlen" in group[name].dtype.metadata.keys()
+            and group[name].dtype.metadata["vlen"] == str
         ):
             value = str(value.astype(np.string_), "utf8")
         return value

--- a/nexus_constructor/nexus/nexus_wrapper.py
+++ b/nexus_constructor/nexus/nexus_wrapper.py
@@ -185,7 +185,10 @@ class NexusWrapper(QObject):
         value = group[name][...]
         if value.dtype.type is np.string_:
             value = str(value, "utf8")
-        elif "vlen" in group[name].dtype.metadata.keys():
+        elif (
+            group[name].dtype.metadata is not None
+            and "vlen" in group[name].dtype.metadata.keys()
+        ):
             value = str(value.astype(np.string_), "utf8")
         return value
 

--- a/tests/test_nexus_wrapper.py
+++ b/tests/test_nexus_wrapper.py
@@ -153,7 +153,7 @@ def test_GIVEN_variable_length_string_type_dataset_WHEN_getting_value_THEN_retur
     dataset_name = "vlen_str_dataset"
     string_data = b"This is a string"
     wrapper.nexus_file.create_dataset(
-        dataset_name, dtype=h5py.string_dtype(), data=string_data
+        dataset_name, dtype=h5py.special_dtype(vlen=str), data=string_data
     )
 
     assert wrapper.get_field_value(

--- a/tests/test_nexus_wrapper.py
+++ b/tests/test_nexus_wrapper.py
@@ -1,3 +1,4 @@
+import h5py
 from mock import Mock
 
 from nexus_constructor.nexus.nexus_wrapper import (
@@ -145,3 +146,17 @@ def test_GIVEN_group_with_bytes_attribute_WHEN_getting_attribute_value_THEN_retu
     attr_value_as_str = attr_value.decode("utf-8")
 
     assert wrapper.get_attribute_value(test_group, attr_name) == attr_value_as_str
+
+
+def test_GIVEN_variable_length_string_type_dataset_WHEN_getting_value_THEN_returned_as_str():
+    wrapper = NexusWrapper(filename="test_read_vlen_str_dataset")
+    dataset_name = "vlen_str_dataset"
+    string_data = b"This is a string"
+    wrapper.nexus_file.create_dataset(
+        dataset_name, dtype=h5py.string_dtype(), data=string_data
+    )
+
+    assert wrapper.get_field_value(
+        wrapper.nexus_file, dataset_name
+    ) == string_data.decode("utf8")
+    assert isinstance(wrapper.get_field_value(wrapper.nexus_file, dataset_name), str)


### PR DESCRIPTION
Towards #498

### Description of work

Noticed a bug with loading vlen string datasets via the `NexusWrapper` when trying loading different JSON files.

### Acceptance Criteria 

Check unit test makes sense.

### Nominate for Group Code Review

- [ ] Nominate for code review 
