### PR TITLE
Make chopper component return NoShapeGeometry if cannot create m…

### DIFF
--- a/nexus_constructor/component/chopper_shape.py
+++ b/nexus_constructor/component/chopper_shape.py
@@ -36,4 +36,4 @@ class ChopperShape(ComponentShape):
             )
         else:
             logging.warning("Validation failed. Unable to create disk chopper mesh.")
-        return None, None
+        return NoShapeGeometry(), None

--- a/tests/test_component_factory.py
+++ b/tests/test_component_factory.py
@@ -5,7 +5,11 @@ from nexus_constructor.component.component_shape import ComponentShape
 from nexus_constructor.component.pixel_shape import PixelShape
 from nexus_constructor.component.component_factory import create_component
 from nexus_constructor.nexus import nexus_wrapper as nx
-from nexus_constructor.geometry import OFFGeometryNoNexus, NoShapeGeometry, OFFGeometryNexus
+from nexus_constructor.geometry import (
+    OFFGeometryNoNexus,
+    NoShapeGeometry,
+    OFFGeometryNexus,
+)
 
 """
 Tests here document the conditions under which the factory creates components of different types

--- a/tests/test_component_factory.py
+++ b/tests/test_component_factory.py
@@ -5,7 +5,7 @@ from nexus_constructor.component.component_shape import ComponentShape
 from nexus_constructor.component.pixel_shape import PixelShape
 from nexus_constructor.component.component_factory import create_component
 from nexus_constructor.nexus import nexus_wrapper as nx
-from nexus_constructor.geometry import OFFGeometryNoNexus
+from nexus_constructor.geometry import OFFGeometryNoNexus, NoShapeGeometry
 
 """
 Tests here document the conditions under which the factory creates components of different types
@@ -39,6 +39,9 @@ def test_GIVEN_an_NXdisk_chopper_group_WHEN_calling_create_component_THEN_compon
     )
     new_component = create_component(wrapper, chopper_group)
     assert isinstance(new_component._shape, ChopperShape)
+    assert isinstance(
+        new_component.shape[0], NoShapeGeometry
+    ), "Expect chopper component to return NoShapeGeometry as it has insufficient details to create a mesh of the disk shape"
 
 
 def test_GIVEN_an_NXdisk_chopper_group_WHEN_calling_create_component_THEN_component_returns_OFFGeometry_of_chopper():


### PR DESCRIPTION
All components should return `NoShapeGeometry` unless they can return something better.

### Issue
Closes #502

### Description of work
Make chopper component return `NoShapeGeometry` if the validation fails for creating a mesh of the disk because it has insufficient information about the disk geometry in its fields.

### Acceptance Criteria 

Check test makes sense.

### Nominate for Group Code Review

- [ ] Nominate for code review 
