### PR TITLE
Correctly dealing with 1D arrays in columnCount of array table widget

### DIFF
--- a/nexus_constructor/array_dataset_table_widget.py
+++ b/nexus_constructor/array_dataset_table_widget.py
@@ -119,6 +119,8 @@ class ArrayDatasetTableModel(QAbstractTableModel):
         :param parent: Unused.
         :return: Number of dimensions there are in the array.
         """
+        if self.array.ndim == 1:
+            return 1
         return self.array.shape[1]
 
     def data(self, index: QModelIndex, role: int = ...) -> str:


### PR DESCRIPTION
### Issue

Closes #505 

### Description of work

Instead of trying to get shape[1], just return 1 as the number of columns that should be displayed in the widget. 

### Acceptance Criteria 

1D arrays are shown correctly when editing.

### UI tests

None

### Nominate for Group Code Review

- [ ] Nominate for code review 
