### PR TITLE
Remove empty attributes list from json

### DIFF
--- a/nexus_constructor/json/filewriter_json_writer.py
+++ b/nexus_constructor/json/filewriter_json_writer.py
@@ -67,12 +67,14 @@ def cast_to_int(data):
 
 
 def _add_attributes(root: NexusObject, root_dict: dict):
-    root_dict["attributes"] = []
+    attrs = []
     for attr_name, attr in root.attrs.items():
         if isinstance(attr, bytes):
             attr = attr.decode("utf8")
         new_attribute = {"name": attr_name, "values": attr}
-        root_dict["attributes"].append(new_attribute)
+        attrs.append(new_attribute)
+    if attrs:
+        root_dict["attributes"] = attrs
 
 
 class NexusToDictConverter:

--- a/tests/test_json_writer.py
+++ b/tests/test_json_writer.py
@@ -177,6 +177,27 @@ def test_GIVEN_dataset_with_an_attribute_WHEN_output_to_json_THEN_attribute_is_p
     assert ds["attributes"][0]["values"] == test_input
 
 
+@pytest.mark.parametrize("test_input", [[1, 2, 3], [1.1, 2.2, 3.3]])
+def test_GIVEN_dataset_with_an_array_attribute_WHEN_output_to_json_THEN_attribute_is_present_in_json(
+    file, test_input
+):
+    dataset_name = "test_ds"
+    dataset_value = 1
+    dataset_dtype = np.int32
+
+    dataset = file.create_dataset(dataset_name, data=dataset_value, dtype=dataset_dtype)
+    test_attr_name = "test_attr"
+    dataset.attrs[test_attr_name] = test_input
+
+    converter = NexusToDictConverter()
+    root_dict = converter.convert(file, [], [])
+
+    ds = root_dict["children"][0]
+
+    assert ds["attributes"][0]["name"] == test_attr_name
+    assert ds["attributes"][0]["values"].tolist() == test_input
+
+
 def test_GIVEN_single_value_WHEN_handling_dataset_THEN_size_field_does_not_exist_in_root_dict(
     file
 ):

--- a/tests/test_json_writer.py
+++ b/tests/test_json_writer.py
@@ -156,17 +156,17 @@ def test_GIVEN_nx_class_and_attributes_are_bytes_WHEN_output_to_json_THEN_they_a
             assert attribute["values"] == test_string_attr.decode("utf8")
 
 
+@pytest.mark.parametrize("test_input", [42, 4.2, "test"])
 def test_GIVEN_dataset_with_an_attribute_WHEN_output_to_json_THEN_attribute_is_present_in_json(
-    file
+    file, test_input
 ):
     dataset_name = "test_ds"
     dataset_value = 1
     dataset_dtype = np.int32
 
     dataset = file.create_dataset(dataset_name, data=dataset_value, dtype=dataset_dtype)
-    test_attr_value = 42
     test_attr_name = "test_attr"
-    dataset.attrs[test_attr_name] = test_attr_value
+    dataset.attrs[test_attr_name] = test_input
 
     converter = NexusToDictConverter()
     root_dict = converter.convert(file, [], [])
@@ -174,7 +174,7 @@ def test_GIVEN_dataset_with_an_attribute_WHEN_output_to_json_THEN_attribute_is_p
     ds = root_dict["children"][0]
 
     assert ds["attributes"][0]["name"] == test_attr_name
-    assert ds["attributes"][0]["values"] == test_attr_value
+    assert ds["attributes"][0]["values"] == test_input
 
 
 def test_GIVEN_single_value_WHEN_handling_dataset_THEN_size_field_does_not_exist_in_root_dict(

--- a/tests/test_json_writer.py
+++ b/tests/test_json_writer.py
@@ -156,9 +156,11 @@ def test_GIVEN_nx_class_and_attributes_are_bytes_WHEN_output_to_json_THEN_they_a
             assert attribute["values"] == test_string_attr.decode("utf8")
 
 
-@pytest.mark.parametrize("test_input", [42, 4.2, "test"])
+@pytest.mark.parametrize(
+    "test_input,expected_type", [(42, np.int64), (4.2, np.float64), ("test", str)]
+)
 def test_GIVEN_dataset_with_an_attribute_WHEN_output_to_json_THEN_attribute_is_present_in_json(
-    file, test_input
+    file, test_input, expected_type
 ):
     dataset_name = "test_ds"
     dataset_value = 1
@@ -175,11 +177,14 @@ def test_GIVEN_dataset_with_an_attribute_WHEN_output_to_json_THEN_attribute_is_p
 
     assert ds["attributes"][0]["name"] == test_attr_name
     assert ds["attributes"][0]["values"] == test_input
+    assert type(ds["attributes"][0]["values"]) == expected_type
 
 
-@pytest.mark.parametrize("test_input", [[1, 2, 3], [1.1, 2.2, 3.3]])
+@pytest.mark.parametrize(
+    "test_input,expected_type", [([1, 2, 3], np.int64), ([1.1, 2.2, 3.3], np.float64)]
+)
 def test_GIVEN_dataset_with_an_array_attribute_WHEN_output_to_json_THEN_attribute_is_present_in_json(
-    file, test_input
+    file, test_input, expected_type
 ):
     dataset_name = "test_ds"
     dataset_value = 1
@@ -196,6 +201,7 @@ def test_GIVEN_dataset_with_an_array_attribute_WHEN_output_to_json_THEN_attribut
 
     assert ds["attributes"][0]["name"] == test_attr_name
     assert ds["attributes"][0]["values"].tolist() == test_input
+    assert ds["attributes"][0]["values"].dtype == expected_type
 
 
 def test_GIVEN_single_value_WHEN_handling_dataset_THEN_size_field_does_not_exist_in_root_dict(

--- a/tests/test_json_writer.py
+++ b/tests/test_json_writer.py
@@ -156,11 +156,9 @@ def test_GIVEN_nx_class_and_attributes_are_bytes_WHEN_output_to_json_THEN_they_a
             assert attribute["values"] == test_string_attr.decode("utf8")
 
 
-@pytest.mark.parametrize(
-    "test_input,expected_type", [(42, np.int64), (4.2, np.float64), ("test", str)]
-)
+@pytest.mark.parametrize("test_input", [42, 4.2, "test"])
 def test_GIVEN_dataset_with_an_attribute_WHEN_output_to_json_THEN_attribute_is_present_in_json(
-    file, test_input, expected_type
+    file, test_input
 ):
     dataset_name = "test_ds"
     dataset_value = 1
@@ -177,14 +175,11 @@ def test_GIVEN_dataset_with_an_attribute_WHEN_output_to_json_THEN_attribute_is_p
 
     assert ds["attributes"][0]["name"] == test_attr_name
     assert ds["attributes"][0]["values"] == test_input
-    assert type(ds["attributes"][0]["values"]) == expected_type
 
 
-@pytest.mark.parametrize(
-    "test_input,expected_type", [([1, 2, 3], np.int64), ([1.1, 2.2, 3.3], np.float64)]
-)
+@pytest.mark.parametrize("test_input", [[1, 2, 3], [1.1, 2.2, 3.3]])
 def test_GIVEN_dataset_with_an_array_attribute_WHEN_output_to_json_THEN_attribute_is_present_in_json(
-    file, test_input, expected_type
+    file, test_input
 ):
     dataset_name = "test_ds"
     dataset_value = 1
@@ -201,7 +196,6 @@ def test_GIVEN_dataset_with_an_array_attribute_WHEN_output_to_json_THEN_attribut
 
     assert ds["attributes"][0]["name"] == test_attr_name
     assert ds["attributes"][0]["values"].tolist() == test_input
-    assert ds["attributes"][0]["values"].dtype == expected_type
 
 
 def test_GIVEN_single_value_WHEN_handling_dataset_THEN_size_field_does_not_exist_in_root_dict(

--- a/tests/test_json_writer.py
+++ b/tests/test_json_writer.py
@@ -3,6 +3,7 @@ import json
 from ast import literal_eval
 import numpy as np
 import h5py
+import pytest
 
 from nexus_constructor.instrument import Instrument
 from nexus_constructor.nexus.nexus_wrapper import NexusWrapper
@@ -18,312 +19,313 @@ from tests.helpers import InMemoryFile
 from tests.test_utils import DEFINITIONS_DIR
 
 
-def test_GIVEN_float32_WHEN_getting_data_and_dtype_THEN_function_returns_correct_fw_json_dtype():
+@pytest.fixture
+def file():
+    with InMemoryFile("test_file") as file:
+        yield file
+
+
+def test_GIVEN_float32_WHEN_getting_data_and_dtype_THEN_function_returns_correct_fw_json_dtype(
+    file
+):
     expected_dtype = "float"
     expected_size = 1
     expected_value = np.float(1.1)
 
-    with InMemoryFile("test_file") as file:
-        dataset = file.create_dataset(
-            "test_dataset", dtype="float32", data=expected_value
-        )
+    dataset = file.create_dataset("test_dataset", dtype="float32", data=expected_value)
 
-        converter = NexusToDictConverter()
+    converter = NexusToDictConverter()
 
-        data, dtype, size = converter._get_data_and_type(dataset)
+    data, dtype, size = converter._get_data_and_type(dataset)
 
-        assert size == expected_size
-        assert dtype == expected_dtype
-        assert np.isclose(data, expected_value)
+    assert size == expected_size
+    assert dtype == expected_dtype
+    assert np.isclose(data, expected_value)
 
 
-def test_GIVEN_float64_WHEN_getting_data_and_dtype_THEN_function_returns_correct_fw_json_dtype():
+def test_GIVEN_float64_WHEN_getting_data_and_dtype_THEN_function_returns_correct_fw_json_dtype(
+    file
+):
     expected_dtype = "double"
     expected_size = 1
     expected_value = np.float64(324.123_231_413_515_223_412_352_135_34)
 
-    with InMemoryFile("test_file") as file:
-        dataset = file.create_dataset(
-            "test_dataset", dtype=np.float64, data=expected_value
-        )
+    dataset = file.create_dataset("test_dataset", dtype=np.float64, data=expected_value)
 
-        converter = NexusToDictConverter()
+    converter = NexusToDictConverter()
 
-        data, dtype, size = converter._get_data_and_type(dataset)
+    data, dtype, size = converter._get_data_and_type(dataset)
 
-        assert size == expected_size
-        assert dtype == expected_dtype
-        assert data == expected_value
+    assert size == expected_size
+    assert dtype == expected_dtype
+    assert data == expected_value
 
 
-def test_GIVEN_int32_WHEN_getting_data_and_dtype_THEN_function_returns_correct_fw_json_dtype():
+def test_GIVEN_int32_WHEN_getting_data_and_dtype_THEN_function_returns_correct_fw_json_dtype(
+    file
+):
     expected_dtype = "int32"
     expected_size = 1
     expected_value = np.int32(42)
 
-    with InMemoryFile("test_file") as file:
-        dataset = file.create_dataset(
-            "test_dataset", dtype="int32", data=expected_value
-        )
+    dataset = file.create_dataset("test_dataset", dtype="int32", data=expected_value)
 
-        converter = NexusToDictConverter()
+    converter = NexusToDictConverter()
 
-        data, dtype, size = converter._get_data_and_type(dataset)
+    data, dtype, size = converter._get_data_and_type(dataset)
 
-        assert size == expected_size
-        assert dtype == expected_dtype
-        assert data == expected_value
+    assert size == expected_size
+    assert dtype == expected_dtype
+    assert data == expected_value
 
 
-def test_GIVEN_int64_WHEN_getting_data_and_dtype_THEN_function_returns_correct_fw_json_dtype():
+def test_GIVEN_int64_WHEN_getting_data_and_dtype_THEN_function_returns_correct_fw_json_dtype(
+    file
+):
     expected_dtype = "int64"
     expected_size = 1
     expected_value = np.int64(171_798_691_842)  # bigger than max 32b int
 
-    with InMemoryFile("test_file") as file:
-        dataset = file.create_dataset(
-            "test_dataset", dtype="int64", data=expected_value
-        )
+    dataset = file.create_dataset("test_dataset", dtype="int64", data=expected_value)
 
-        converter = NexusToDictConverter()
+    converter = NexusToDictConverter()
 
-        data, dtype, size = converter._get_data_and_type(dataset)
+    data, dtype, size = converter._get_data_and_type(dataset)
 
-        assert size == expected_size
-        assert dtype == expected_dtype
-        assert data == expected_value
+    assert size == expected_size
+    assert dtype == expected_dtype
+    assert data == expected_value
 
 
-def test_GIVEN_single_string_WHEN_getting_data_and_dtype_THEN_function_returns_correct_fw_json_dtype():
+def test_GIVEN_single_string_WHEN_getting_data_and_dtype_THEN_function_returns_correct_fw_json_dtype(
+    file
+):
     expected_dtype = "string"
     expected_size = 1
     expected_value = np.string_("udder")
 
-    with InMemoryFile("test_file") as file:
-        dataset = file.create_dataset("test_dataset", data=expected_value, dtype="S5")
+    dataset = file.create_dataset("test_dataset", data=expected_value, dtype="S5")
 
-        converter = NexusToDictConverter()
+    converter = NexusToDictConverter()
 
-        data, dtype, size = converter._get_data_and_type(dataset)
+    data, dtype, size = converter._get_data_and_type(dataset)
 
-        assert size == expected_size
-        assert dtype == expected_dtype
-        assert bytes(data, "ASCII") == expected_value
+    assert size == expected_size
+    assert dtype == expected_dtype
+    assert bytes(data, "ASCII") == expected_value
 
 
-def test_GIVEN_array_WHEN_getting_data_and_dtype_THEN_function_returns_correcte_fw_json_dtype_and_values():
+def test_GIVEN_array_WHEN_getting_data_and_dtype_THEN_function_returns_correcte_fw_json_dtype_and_values(
+    file
+):
     expected_dtype = "float"
     expected_values = [1.1, 1.2, 1.3]
 
-    with InMemoryFile("test_file") as file:
-        dataset = file.create_dataset(
-            "test_dataset", data=expected_values, dtype="float32"
-        )
-        converter = NexusToDictConverter()
-        data, dtype, size = converter._get_data_and_type(dataset)
+    dataset = file.create_dataset("test_dataset", data=expected_values, dtype="float32")
+    converter = NexusToDictConverter()
+    data, dtype, size = converter._get_data_and_type(dataset)
 
-        assert size == (len(expected_values),)
-        assert np.allclose(data, expected_values)
-        assert dtype == expected_dtype
+    assert size == (len(expected_values),)
+    assert np.allclose(data, expected_values)
+    assert dtype == expected_dtype
 
 
-def test_GIVEN_nx_class_and_attributes_are_bytes_WHEN_output_to_json_THEN_they_are_written_as_utf8():
-    with InMemoryFile("test_file") as file:
-        dataset_name = "test_ds"
-        dataset_value = 1
-        dataset_dtype = np.int32
+def test_GIVEN_nx_class_and_attributes_are_bytes_WHEN_output_to_json_THEN_they_are_written_as_utf8(
+    file
+):
+    dataset_name = "test_ds"
+    dataset_value = 1
+    dataset_dtype = np.int32
 
-        dataset = file.create_dataset(
-            dataset_name, data=dataset_value, dtype=dataset_dtype
-        )
-        test_nx_class = b"NXpinhole"
-        test_string_attr = b"some_string"
-        dataset.attrs["NX_class"] = test_nx_class
-        dataset.attrs["string_attr"] = test_string_attr
+    dataset = file.create_dataset(dataset_name, data=dataset_value, dtype=dataset_dtype)
+    test_nx_class = b"NXpinhole"
+    test_string_attr = b"some_string"
+    dataset.attrs["NX_class"] = test_nx_class
+    dataset.attrs["string_attr"] = test_string_attr
 
-        converter = NexusToDictConverter()
-        root_dict = converter.convert(file, [], [])
+    converter = NexusToDictConverter()
+    root_dict = converter.convert(file, [], [])
 
-        ds = root_dict["children"][0]
+    ds = root_dict["children"][0]
 
-        for attribute in ds["attributes"]:
-            assert attribute["name"] in ["NX_class", "string_attr"]
-            if attribute["name"] == "NX_class":
-                assert attribute["values"] == test_nx_class.decode("utf8")
-            elif attribute["name"] == "string_attr":
-                assert attribute["values"] == test_string_attr.decode("utf8")
-
-
-def test_GIVEN_dataset_with_an_attribute_WHEN_output_to_json_THEN_attribute_is_present_in_json():
-    with InMemoryFile("test_file") as file:
-        dataset_name = "test_ds"
-        dataset_value = 1
-        dataset_dtype = np.int32
-
-        dataset = file.create_dataset(
-            dataset_name, data=dataset_value, dtype=dataset_dtype
-        )
-        test_attr_value = 42
-        test_attr_name = "test_attr"
-        dataset.attrs[test_attr_name] = test_attr_value
-
-        converter = NexusToDictConverter()
-        root_dict = converter.convert(file, [], [])
-
-        ds = root_dict["children"][0]
-
-        assert ds["attributes"][0]["name"] == test_attr_name
-        assert ds["attributes"][0]["values"] == test_attr_value
+    for attribute in ds["attributes"]:
+        assert attribute["name"] in ["NX_class", "string_attr"]
+        if attribute["name"] == "NX_class":
+            assert attribute["values"] == test_nx_class.decode("utf8")
+        elif attribute["name"] == "string_attr":
+            assert attribute["values"] == test_string_attr.decode("utf8")
 
 
-def test_GIVEN_single_value_WHEN_handling_dataset_THEN_size_field_does_not_exist_in_root_dict():
-    with InMemoryFile("test_file") as file:
-        dataset_name = "test_ds"
-        dataset_value = 1.1
-        dataset_dtype = np.float
+def test_GIVEN_dataset_with_an_attribute_WHEN_output_to_json_THEN_attribute_is_present_in_json(
+    file
+):
+    dataset_name = "test_ds"
+    dataset_value = 1
+    dataset_dtype = np.int32
 
-        dataset = file.create_dataset(
-            dataset_name, data=dataset_value, dtype=dataset_dtype
-        )
-        dataset.attrs["NX_class"] = "NXpinhole"
+    dataset = file.create_dataset(dataset_name, data=dataset_value, dtype=dataset_dtype)
+    test_attr_value = 42
+    test_attr_name = "test_attr"
+    dataset.attrs[test_attr_name] = test_attr_value
 
-        converter = NexusToDictConverter()
-        root_dict = converter.convert(file, [], [])
+    converter = NexusToDictConverter()
+    root_dict = converter.convert(file, [], [])
 
-        ds = root_dict["children"][0]
+    ds = root_dict["children"][0]
 
-        assert ds["name"].lstrip("/") == dataset_name
-        assert ds["type"] == "dataset"
-        assert ds["values"] == dataset_value
-        assert "size" not in ds["dataset"]
-
-
-def test_GIVEN_multiple_values_WHEN_handling_dataset_THEN_size_field_does_exist_in_root_dict():
-    with InMemoryFile("test_file") as file:
-        dataset_name = "test_ds"
-        dataset_value = [1.1, 1.2, 1.3]
-        dataset_dtype = np.float
-
-        dataset = file.create_dataset(
-            dataset_name, data=dataset_value, dtype=dataset_dtype
-        )
-        dataset.attrs["NX_class"] = "NXpinhole"
-
-        converter = NexusToDictConverter()
-        root_dict = converter.convert(file, [], [])
-        ds = root_dict["children"][0]
-
-        assert ds["name"].lstrip("/") == dataset_name
-        assert ds["type"] == "dataset"
-        assert ds["values"] == dataset_value
-        assert ds["dataset"]["size"] == (len(dataset_value),)
+    assert ds["attributes"][0]["name"] == test_attr_name
+    assert ds["attributes"][0]["values"] == test_attr_value
 
 
-def test_GIVEN_stream_in_group_children_WHEN_handling_group_THEN_stream_is_appended_to_children():
-    with InMemoryFile("test_file") as file:
-        group_name = "test_group"
-        group = file.create_group(group_name)
-        group.attrs["NX_class"] = "NXgroup"
+def test_GIVEN_single_value_WHEN_handling_dataset_THEN_size_field_does_not_exist_in_root_dict(
+    file
+):
+    dataset_name = "test_ds"
+    dataset_value = 1.1
+    dataset_dtype = np.float
 
-        group_contents = ["test_contents_item"]
+    dataset = file.create_dataset(dataset_name, data=dataset_value, dtype=dataset_dtype)
+    dataset.attrs["NX_class"] = "NXpinhole"
 
-        converter = NexusToDictConverter()
-        root_dict = converter.convert(
-            file, streams={f"/{group_name}": group_contents}, links=[]
-        )
+    converter = NexusToDictConverter()
+    root_dict = converter.convert(file, [], [])
 
-        assert group_contents == root_dict["children"][0]["stream"]
+    ds = root_dict["children"][0]
 
-
-def test_GIVEN_link_in_group_children_WHEN_handling_group_THEN_link_is_appended_to_children():
-    with InMemoryFile("test_file") as file:
-        group_to_be_linked_name = "test_linked_group"
-        group_to_be_linked = file.create_group(group_to_be_linked_name)
-        group_to_be_linked.attrs["NX_class"] = "NXgroup"
-
-        group_name = "test_group_with_link"
-        file[group_name] = h5py.SoftLink(group_to_be_linked.name)
-        file[group_name].attrs["NX_class"] = "NXgroup"
-
-        converter = NexusToDictConverter()
-        root_dict = converter.convert(
-            file, streams={}, links={file[group_name].name: group_to_be_linked}
-        )
-
-        assert root_dict["children"][0]["type"] == "link"
-        assert file[group_name].name.split("/")[-1] == root_dict["children"][0]["name"]
-        assert group_to_be_linked.name == root_dict["children"][0]["target"]
+    assert ds["name"].lstrip("/") == dataset_name
+    assert ds["type"] == "dataset"
+    assert ds["values"] == dataset_value
+    assert "size" not in ds["dataset"]
 
 
-def test_GIVEN_link_in_group_children_that_is_a_dataset_WHEN_handling_group_THEN_link_is_appended_to_children():
-    with InMemoryFile("test_file") as file:
-        ds_to_be_linked_name = "test_linked_dataset"
-        dataset_to_be_linked = file.create_dataset(ds_to_be_linked_name, data=1)
-        dataset_to_be_linked.attrs["NX_class"] = "NXgroup"
+def test_GIVEN_multiple_values_WHEN_handling_dataset_THEN_size_field_does_exist_in_root_dict(
+    file
+):
+    dataset_name = "test_ds"
+    dataset_value = [1.1, 1.2, 1.3]
+    dataset_dtype = np.float
 
-        group_name = "test_group_with_link"
-        file[group_name] = h5py.SoftLink(dataset_to_be_linked.name)
-        file[group_name].attrs["NX_class"] = "NXgroup"
+    dataset = file.create_dataset(dataset_name, data=dataset_value, dtype=dataset_dtype)
+    dataset.attrs["NX_class"] = "NXpinhole"
 
-        converter = NexusToDictConverter()
-        root_dict = converter.convert(
-            file, streams={}, links={file[group_name].name: dataset_to_be_linked}
-        )
+    converter = NexusToDictConverter()
+    root_dict = converter.convert(file, [], [])
+    ds = root_dict["children"][0]
 
-        assert root_dict["children"][0]["type"] == "link"
-        assert file[group_name].name.split("/")[-1] == root_dict["children"][0]["name"]
-        assert dataset_to_be_linked.name == root_dict["children"][0]["target"]
+    assert ds["name"].lstrip("/") == dataset_name
+    assert ds["type"] == "dataset"
+    assert ds["values"] == dataset_value
+    assert ds["dataset"]["size"] == (len(dataset_value),)
 
 
-def test_GIVEN_group_with_multiple_attributes_WHEN_converting_nexus_to_dict_THEN_attributes_end_up_in_file():
-    with InMemoryFile("test_file") as file:
-        group_name = "test_group"
-        group = file.create_group(group_name)
-        group.attrs["NX_class"] = "NXgroup"
+def test_GIVEN_stream_in_group_children_WHEN_handling_group_THEN_stream_is_appended_to_children(
+    file
+):
+    group_name = "test_group"
+    group = file.create_group(group_name)
+    group.attrs["NX_class"] = "NXgroup"
 
-        field1name = "field1"
-        field1value = "field1val"
+    group_contents = ["test_contents_item"]
 
-        field2name = "field2"
-        field2value = 3
+    converter = NexusToDictConverter()
+    root_dict = converter.convert(
+        file, streams={f"/{group_name}": group_contents}, links=[]
+    )
 
-        arbitrary_field_name = "arbitrary_field"
-        arbitrary_field_value = "something"
+    assert group_contents == root_dict["children"][0]["stream"]
 
-        field1 = group.create_dataset(field1name, data=field1value)
-        field1.attrs["NX_class"] = "NXfield"
-        field1.attrs[arbitrary_field_name] = arbitrary_field_value
 
-        field2 = group.create_dataset(field2name, data=field2value)
-        field2.attrs["NX_class"] = "NXfield"
+def test_GIVEN_link_in_group_children_WHEN_handling_group_THEN_link_is_appended_to_children(
+    file
+):
+    group_to_be_linked_name = "test_linked_group"
+    group_to_be_linked = file.create_group(group_to_be_linked_name)
+    group_to_be_linked.attrs["NX_class"] = "NXgroup"
 
-        converter = NexusToDictConverter()
-        root_dict = converter.convert(file, streams=dict(), links=dict())
+    group_name = "test_group_with_link"
+    file[group_name] = h5py.SoftLink(group_to_be_linked.name)
+    file[group_name].attrs["NX_class"] = "NXgroup"
 
-        assert group.name == root_dict["children"][0]["name"]
+    converter = NexusToDictConverter()
+    root_dict = converter.convert(
+        file, streams={}, links={file[group_name].name: group_to_be_linked}
+    )
 
-        assert field1.name == root_dict["children"][0]["children"][0]["name"]
-        assert field1value == root_dict["children"][0]["children"][0]["values"]
-        assert (
-            "NX_class"
-            == root_dict["children"][0]["children"][0]["attributes"][0]["name"]
-        )
-        assert (
-            field1.attrs["NX_class"]
-            == root_dict["children"][0]["children"][0]["attributes"][0]["values"]
-        )
+    assert root_dict["children"][0]["type"] == "link"
+    assert file[group_name].name.split("/")[-1] == root_dict["children"][0]["name"]
+    assert group_to_be_linked.name == root_dict["children"][0]["target"]
 
-        assert (
-            arbitrary_field_name
-            == root_dict["children"][0]["children"][0]["attributes"][1]["name"]
-        )
-        assert (
-            field1.attrs[arbitrary_field_name]
-            == root_dict["children"][0]["children"][0]["attributes"][1]["values"]
-        )
 
-        assert field2.name == root_dict["children"][0]["children"][1]["name"]
-        assert field2value == root_dict["children"][0]["children"][1]["values"]
+def test_GIVEN_link_in_group_children_that_is_a_dataset_WHEN_handling_group_THEN_link_is_appended_to_children(
+    file
+):
+    ds_to_be_linked_name = "test_linked_dataset"
+    dataset_to_be_linked = file.create_dataset(ds_to_be_linked_name, data=1)
+    dataset_to_be_linked.attrs["NX_class"] = "NXgroup"
+
+    group_name = "test_group_with_link"
+    file[group_name] = h5py.SoftLink(dataset_to_be_linked.name)
+    file[group_name].attrs["NX_class"] = "NXgroup"
+
+    converter = NexusToDictConverter()
+    root_dict = converter.convert(
+        file, streams={}, links={file[group_name].name: dataset_to_be_linked}
+    )
+
+    assert root_dict["children"][0]["type"] == "link"
+    assert file[group_name].name.split("/")[-1] == root_dict["children"][0]["name"]
+    assert dataset_to_be_linked.name == root_dict["children"][0]["target"]
+
+
+def test_GIVEN_group_with_multiple_attributes_WHEN_converting_nexus_to_dict_THEN_attributes_end_up_in_file(
+    file
+):
+    group_name = "test_group"
+    group = file.create_group(group_name)
+    group.attrs["NX_class"] = "NXgroup"
+
+    field1name = "field1"
+    field1value = "field1val"
+
+    field2name = "field2"
+    field2value = 3
+
+    arbitrary_field_name = "arbitrary_field"
+    arbitrary_field_value = "something"
+
+    field1 = group.create_dataset(field1name, data=field1value)
+    field1.attrs["NX_class"] = "NXfield"
+    field1.attrs[arbitrary_field_name] = arbitrary_field_value
+
+    field2 = group.create_dataset(field2name, data=field2value)
+    field2.attrs["NX_class"] = "NXfield"
+
+    converter = NexusToDictConverter()
+    root_dict = converter.convert(file, streams=dict(), links=dict())
+
+    assert group.name == root_dict["children"][0]["name"]
+
+    assert field1.name == root_dict["children"][0]["children"][0]["name"]
+    assert field1value == root_dict["children"][0]["children"][0]["values"]
+    assert (
+        "NX_class" == root_dict["children"][0]["children"][0]["attributes"][0]["name"]
+    )
+    assert (
+        field1.attrs["NX_class"]
+        == root_dict["children"][0]["children"][0]["attributes"][0]["values"]
+    )
+
+    assert (
+        arbitrary_field_name
+        == root_dict["children"][0]["children"][0]["attributes"][1]["name"]
+    )
+    assert (
+        field1.attrs[arbitrary_field_name]
+        == root_dict["children"][0]["children"][0]["attributes"][1]["values"]
+    )
+
+    assert field2.name == root_dict["children"][0]["children"][1]["name"]
+    assert field2value == root_dict["children"][0]["children"][1]["values"]
 
 
 def test_GIVEN_start_time_WHEN_creating_writercommands_THEN_start_time_is_included_in_command():
@@ -408,52 +410,45 @@ def test_GIVEN_instrument_containing_component_WHEN_generating_json_THEN_file_is
     assert component["children"][0]["dataset"]["type"] == "string"
 
 
-def test_GIVEN_float64_WHEN_getting_data_and_type_THEN_returns_correct_dtype():
-    with InMemoryFile("test_file") as file:
-        dataset_name = "ds"
-        dataset_type = np.float64
-        dataset_value = np.float64(2.123)
+def test_GIVEN_float64_WHEN_getting_data_and_type_THEN_returns_correct_dtype(file):
+    dataset_name = "ds"
+    dataset_type = np.float64
+    dataset_value = np.float64(2.123)
 
-        dataset = file.create_dataset(
-            dataset_name, dtype=dataset_type, data=dataset_value
-        )
-        converter = NexusToDictConverter()
-        data, dtype, size = converter._get_data_and_type(dataset)
+    dataset = file.create_dataset(dataset_name, dtype=dataset_type, data=dataset_value)
+    converter = NexusToDictConverter()
+    data, dtype, size = converter._get_data_and_type(dataset)
 
-        assert data == dataset_value
-        assert dtype == "double"
-        assert size == 1
+    assert data == dataset_value
+    assert dtype == "double"
+    assert size == 1
 
 
-def test_GIVEN_float_WHEN_getting_data_and_type_THEN_returns_correct_dtype():
-    with InMemoryFile("test_file") as file:
-        dataset_name = "ds"
-        dataset_type = np.float32
-        dataset_value = np.float32(2.123)
+def test_GIVEN_float_WHEN_getting_data_and_type_THEN_returns_correct_dtype(file):
+    dataset_name = "ds"
+    dataset_type = np.float32
+    dataset_value = np.float32(2.123)
 
-        dataset = file.create_dataset(
-            dataset_name, dtype=dataset_type, data=dataset_value
-        )
-        converter = NexusToDictConverter()
-        data, dtype, size = converter._get_data_and_type(dataset)
+    dataset = file.create_dataset(dataset_name, dtype=dataset_type, data=dataset_value)
+    converter = NexusToDictConverter()
+    data, dtype, size = converter._get_data_and_type(dataset)
 
-        assert data == dataset_value
-        assert dtype == "float"
-        assert size == 1
+    assert data == dataset_value
+    assert dtype == "float"
+    assert size == 1
 
 
-def test_GIVEN_string_list_WHEN_getting_data_and_type_THEN_returns_correct_dtype():
-    with InMemoryFile("test_file") as file:
-        dataset_name = "ds"
-        dataset_value = np.string_(["s", "t", "r"])
+def test_GIVEN_string_list_WHEN_getting_data_and_type_THEN_returns_correct_dtype(file):
+    dataset_name = "ds"
+    dataset_value = np.string_(["s", "t", "r"])
 
-        dataset = file.create_dataset(dataset_name, data=dataset_value)
-        converter = NexusToDictConverter()
+    dataset = file.create_dataset(dataset_name, data=dataset_value)
+    converter = NexusToDictConverter()
 
-        data, dtype, size = converter._get_data_and_type(dataset)
+    data, dtype, size = converter._get_data_and_type(dataset)
 
-        assert data == [x.decode("ASCII") for x in list(dataset_value)]
-        assert size == (len(dataset_value),)
+    assert data == [x.decode("ASCII") for x in list(dataset_value)]
+    assert size == (len(dataset_value),)
 
 
 def test_GIVEN_stream_with_no_forwarder_streams_WHEN_generating_forwarder_command_THEN_output_does_not_contain_any_pvs():
@@ -612,24 +607,22 @@ def test_GIVEN_none_as_service_id_WHEN_generating_writer_commands_THEN_service_i
     assert "service_id" not in stop_cmd.keys()
 
 
-def test_GIVEN_no_attributes_WHEN_adding_attributes_THEN_root_dict_is_not_changed():
-    with InMemoryFile("test_file") as file:
-        root_dict = dict()
-        dataset = file.create_dataset("test", data=123)
-        assert not dataset.attrs.keys()
-        _add_attributes(dataset, root_dict)
-        assert not root_dict
+def test_GIVEN_no_attributes_WHEN_adding_attributes_THEN_root_dict_is_not_changed(file):
+    root_dict = dict()
+    dataset = file.create_dataset("test", data=123)
+    assert not dataset.attrs.keys()
+    _add_attributes(dataset, root_dict)
+    assert not root_dict
 
 
-def test_GIVEN_attribute_WHEN_adding_attributes_THEN_attrs_are_added_to_root_dict():
-    with InMemoryFile("test_file") as file:
-        root_dict = dict()
-        dataset_name = "test"
-        dataset = file.create_dataset(dataset_name, data=123)
-        attr_key = "something"
-        attr_value = "some_value"
-        dataset.attrs[attr_key] = attr_value
-        _add_attributes(dataset, root_dict)
-        assert root_dict["attributes"]
-        assert root_dict["attributes"][0]["name"] == attr_key
-        assert root_dict["attributes"][0]["values"] == attr_value
+def test_GIVEN_attribute_WHEN_adding_attributes_THEN_attrs_are_added_to_root_dict(file):
+    root_dict = dict()
+    dataset_name = "test"
+    dataset = file.create_dataset(dataset_name, data=123)
+    attr_key = "something"
+    attr_value = "some_value"
+    dataset.attrs[attr_key] = attr_value
+    _add_attributes(dataset, root_dict)
+    assert root_dict["attributes"]
+    assert root_dict["attributes"][0]["name"] == attr_key
+    assert root_dict["attributes"][0]["values"] == attr_value


### PR DESCRIPTION
### Issue

Closes #504 

### Description of work
Removes the `attributes` list if there are none in the JSON. 

### Acceptance Criteria 

If something in the nexus file has no attributes, the `attributes` for this should not appear in the filewriter JSON. 

### UI tests

No UI changes.

Unit tests added for functionality. 

### Nominate for Group Code Review

- [ ] Nominate for code review 
