### PR TITLE
Fixing JSON group and dataset name issue

### DIFF
--- a/nexus_constructor/json/filewriter_json_writer.py
+++ b/nexus_constructor/json/filewriter_json_writer.py
@@ -179,7 +179,7 @@ class NexusToDictConverter:
         :param root: h5py group to generate dict from.
         :return: generated dict of group and children.
         """
-        root_dict = {"type": "group", "name": root.name, "children": []}
+        root_dict = {"type": "group", "name": root.name.split("/")[-1], "children": []}
         # Add the entries
         entries = list(root.values())
         if root.name in self._kafka_streams:
@@ -211,7 +211,7 @@ class NexusToDictConverter:
         else:
             root_dict = {
                 "type": "dataset",
-                "name": root.name,
+                "name": root.name.split("/")[-1],
                 "dataset": {"type": dataset_type},
                 "values": data,
             }

--- a/tests/test_json_writer.py
+++ b/tests/test_json_writer.py
@@ -324,9 +324,9 @@ def test_GIVEN_group_with_multiple_attributes_WHEN_converting_nexus_to_dict_THEN
     converter = NexusToDictConverter()
     root_dict = converter.convert(file, streams=dict(), links=dict())
 
-    assert group.name == root_dict["children"][0]["name"]
+    assert group.name.split("/")[-1] == root_dict["children"][0]["name"]
 
-    assert field1.name == root_dict["children"][0]["children"][0]["name"]
+    assert field1.name.split("/")[-1] == root_dict["children"][0]["children"][0]["name"]
     assert field1value == root_dict["children"][0]["children"][0]["values"]
     assert (
         "NX_class" == root_dict["children"][0]["children"][0]["attributes"][0]["name"]
@@ -345,7 +345,7 @@ def test_GIVEN_group_with_multiple_attributes_WHEN_converting_nexus_to_dict_THEN
         == root_dict["children"][0]["children"][0]["attributes"][1]["values"]
     )
 
-    assert field2.name == root_dict["children"][0]["children"][1]["name"]
+    assert field2.name.split("/")[-1] == root_dict["children"][0]["children"][1]["name"]
     assert field2value == root_dict["children"][0]["children"][1]["values"]
 
 


### PR DESCRIPTION
### Issue

Closes #517 
Relates to #498 
### Description of work

I had only just realised but components in the filewriter command should only contain their name and not full path in the "name" field of the command. 

### Acceptance Criteria 

full paths in commands are emitted and just the name of the group/dataset are specified in the "name" field. 

### UI tests

N/A

### Nominate for Group Code Review

- [ ] Nominate for code review 
