### PR TITLE
Stopping dependee_of being added to the filewriter JSON

### DIFF
--- a/nexus_constructor/json/filewriter_json_writer.py
+++ b/nexus_constructor/json/filewriter_json_writer.py
@@ -66,13 +66,17 @@ def cast_to_int(data):
         return int(data)
 
 
+ATTR_BLACKLIST = ["dependee_of"]
+
+
 def _add_attributes(root: NexusObject, root_dict: dict):
     attrs = []
     for attr_name, attr in root.attrs.items():
-        if isinstance(attr, bytes):
-            attr = attr.decode("utf8")
-        new_attribute = {"name": attr_name, "values": attr}
-        attrs.append(new_attribute)
+        if attr_name not in ATTR_BLACKLIST:
+            if isinstance(attr, bytes):
+                attr = attr.decode("utf8")
+            new_attribute = {"name": attr_name, "values": attr}
+            attrs.append(new_attribute)
     if attrs:
         root_dict["attributes"] = attrs
 

--- a/tests/test_json_writer.py
+++ b/tests/test_json_writer.py
@@ -12,6 +12,7 @@ from nexus_constructor.json.filewriter_json_writer import (
     create_writer_commands,
     generate_json,
     _add_attributes,
+    ATTR_BLACKLIST,
 )
 from nexus_constructor.json.helpers import object_to_json_file
 from nexus_constructor.json.forwarder_json_writer import generate_forwarder_command
@@ -647,3 +648,14 @@ def test_GIVEN_attribute_WHEN_adding_attributes_THEN_attrs_are_added_to_root_dic
     assert root_dict["attributes"]
     assert root_dict["attributes"][0]["name"] == attr_key
     assert root_dict["attributes"][0]["values"] == attr_value
+
+
+def test_GIVEN_attribute_in_blacklist_WHEN_adding_attributes_THEN_attrs_is_blank(file):
+    root_dict = dict()
+    dataset_name = "test"
+    dataset = file.create_dataset(dataset_name, data=123)
+    attr_key = ATTR_BLACKLIST[0]
+    attr_value = "some_value"
+    dataset.attrs[attr_key] = attr_value
+    _add_attributes(dataset, root_dict)
+    assert not root_dict


### PR DESCRIPTION
### Issue

Closes #520 

### Description of work

Stops dependee_of attribute being added to the filewriter JSON. 

### Acceptance Criteria 

For an easy way of testing this, load a json file with components that depend on a transform and then output back to json, then check the diff. Neither file should have any attributes that contain "dependee_of"

If you don't have a file I can send you one.  

### UI tests

No UI changes. 

### Nominate for Group Code Review

- [ ] Nominate for code review 
