### PR TITLE
Fix for shapes persisting after file load

### DIFF
--- a/nexus_constructor/instrument_view.py
+++ b/nexus_constructor/instrument_view.py
@@ -210,6 +210,8 @@ class InstrumentView(QWidget):
         """
         resets the entities in qt3d so all components are cleared form the 3d view.
         """
+        for component, _ in self.component_entities.items():
+            self.component_entities[component].setParent(None)
         self.component_entities = dict()
 
     def delete_component(self, name):

--- a/nexus_constructor/instrument_view.py
+++ b/nexus_constructor/instrument_view.py
@@ -210,7 +210,7 @@ class InstrumentView(QWidget):
         """
         resets the entities in qt3d so all components are cleared form the 3d view.
         """
-        for component, _ in self.component_entities.items():
+        for component in self.component_entities.keys():
             self.component_entities[component].setParent(None)
         self.component_entities = dict()
 


### PR DESCRIPTION
### Issue

Closes #526 

### Description of work

Actually deletes the shapes in the component view when all shapes are removed rather than just setting the dictionary to a new dict()

### Acceptance Criteria 

To test: 
- Add cylinder with radius 4 and height 4 
- Load a file with no shape 
- Check that cylinder does not persist in the 3d view 

### UI tests

n/a - 3d view 

### Nominate for Group Code Review

- [ ] Nominate for code review 
