### PR TITLE
fix windows choppers being drawn

### DIFF
--- a/nexus_constructor/geometry/disk_chopper/disk_chopper_checker.py
+++ b/nexus_constructor/geometry/disk_chopper/disk_chopper_checker.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Sequence, Dict
 
-import h5py
 from PySide2.QtWidgets import QListWidget
 import numpy as np
 from h5py import Group

--- a/nexus_constructor/geometry/disk_chopper/disk_chopper_checker.py
+++ b/nexus_constructor/geometry/disk_chopper/disk_chopper_checker.py
@@ -39,13 +39,13 @@ def _incorrect_field_type_message(fields_dict: dict, field_name: str):
     return f"Wrong {field_name} type. Expected {EXPECTED_TYPE_ERROR_MSG[field_name]} but found {type(fields_dict[field_name])}."
 
 
-def _check_data_type(data_type: h5py.Dataset, expected_types):
+def _check_data_type(field_widget, expected_types):
     try:
-        py_data_type = data_type.dtype
-        if isinstance(data_type, np.int64):
+        dtype = field_widget.dtype
+        if isinstance(field_widget, np.int64):
             # Fix for windows - for some reason int64 is the default numpy int type on windows...
-            py_data_type = np.int32
-        return py_data_type in expected_types
+            dtype = np.int32
+        return dtype in expected_types
     except AttributeError:
         return False
 

--- a/nexus_constructor/geometry/disk_chopper/disk_chopper_checker.py
+++ b/nexus_constructor/geometry/disk_chopper/disk_chopper_checker.py
@@ -39,7 +39,7 @@ def _incorrect_field_type_message(fields_dict: dict, field_name: str):
     return f"Wrong {field_name} type. Expected {EXPECTED_TYPE_ERROR_MSG[field_name]} but found {type(fields_dict[field_name])}."
 
 
-def _check_data_type(data_type:h5py.Dataset, expected_types):
+def _check_data_type(data_type: h5py.Dataset, expected_types):
     try:
         py_data_type = data_type.dtype
         if isinstance(data_type, np.int64):


### PR DESCRIPTION
### Issue

Closes #524 

### Description of work

Windows uses np.int64s as default integers, but unix uses np.int32s. This is a quick patch so we can get it working for the demo, but shouldn't cause any issues on unix. 

### Acceptance Criteria 

Choppers are now drawn on windows correctly - have tested. 

### UI tests

*How you have updated the UI tests document to fit your changes*

### Nominate for Group Code Review

- [ ] Nominate for code review 
