### PR TITLE
Fixing bug when editing components

### DIFF
--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -165,7 +165,7 @@ class AddComponentDialog(Ui_AddComponentDialog, QObject):
         self.noShapeRadioButton.setChecked(True)
         self.show_no_geometry_fields()
 
-        component_list = self.instrument.get_component_list()
+        component_list = self.instrument.get_component_list().copy()
 
         if self.component_to_edit:
             for item in component_list:
@@ -536,17 +536,19 @@ class AddComponentDialog(Ui_AddComponentDialog, QObject):
         :param pixel_data: The component PixelData. Can be None.
         :return: The geometry object.
         """
-        self.component_to_edit.name = component_name
-        self.component_to_edit.nx_class = nx_class
-        self.component_to_edit.description = description
-        # remove the previous shape from the qt3d view
-        if not isinstance(self.component_to_edit.shape[0], NoShapeGeometry):
-            self.instrument.remove_component(self.component_to_edit)
 
         # remove previous fields
         for field_group in self.component_to_edit.group.values():
             if field_group.name.split("/")[-1] not in INVALID_FIELD_NAMES:
                 del self.instrument.nexus.nexus_file[field_group.name]
+
+        # remove the previous shape from the qt3d view
+        if not isinstance(self.component_to_edit.shape[0], NoShapeGeometry):
+            self.instrument.remove_component(self.component_to_edit)
+
+        self.component_to_edit.name = component_name
+        self.component_to_edit.nx_class = nx_class
+        self.component_to_edit.description = description
 
         add_fields_to_component(self.component_to_edit, self.fieldsListWidget)
         self.generate_geometry_model(self.component_to_edit, pixel_data)


### PR DESCRIPTION
### Issue

Closes #532 
relates to #498 

### Description of work

Fixes an order issue that meant components could not be edited. 

### Acceptance Criteria 

Edit a component and check the values entered persist. Previously hitting the ok button after editing would result in exceptions. 

### UI tests

N/A

### Nominate for Group Code Review

- [ ] Nominate for code review 
