### PR TITLE
Fixing exception when renaming component with cylindrical geomet…

### DIFF
--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -544,7 +544,7 @@ class AddComponentDialog(Ui_AddComponentDialog, QObject):
 
         # remove the previous shape from the qt3d view
         if not isinstance(self.component_to_edit.shape[0], NoShapeGeometry):
-            self.instrument.remove_component(self.component_to_edit)
+            self.parent().sceneWidget.delete_component(self.component_to_edit.name)
 
         self.component_to_edit.name = component_name
         self.component_to_edit.nx_class = nx_class


### PR DESCRIPTION
### Issue

Closes #538 

### Description of work
Should hopefully work now - call was deleting the node of the component rather than just its shape. 

### Acceptance Criteria 

Changed call to just delete the shape in the 3d view - not in the file. 

### UI tests

N/A

### Nominate for Group Code Review

- [ ] Nominate for code review 
