### PR TITLE
537: "Edit Component" button is greyed-out when editing a compon…

### DIFF
--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -243,7 +243,6 @@ class AddComponentDialog(Ui_AddComponentDialog, QObject):
         self.unitsLineEdit.validator().validate(self.unitsLineEdit.text(), 0)
         self.nameLineEdit.validator().validate(self.nameLineEdit.text(), 0)
         self.fileLineEdit.validator().validate(self.fileLineEdit.text(), 0)
-
         self.addFieldPushButton.clicked.connect(self.add_field)
         self.removeFieldPushButton.clicked.connect(self.remove_field)
 

--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -242,6 +242,8 @@ class AddComponentDialog(Ui_AddComponentDialog, QObject):
         # Validate the default values set by the UI
         self.unitsLineEdit.validator().validate(self.unitsLineEdit.text(), 0)
         self.nameLineEdit.validator().validate(self.nameLineEdit.text(), 0)
+        self.fileLineEdit.validator().validate(self.fileLineEdit.text(), 0)
+
         self.addFieldPushButton.clicked.connect(self.add_field)
         self.removeFieldPushButton.clicked.connect(self.remove_field)
 


### PR DESCRIPTION
### Issue

Closes #537

### Description of work

Only the units and name fields were being validated in the AddComponentWindow `setupUi` method. Filename wasn't being validated, so as a result the `valid_file_name` member variable in OKValidator would get stuck as False and remain that way unless you selected a different, valid mesh file. This should be fixed now that the filename is also being validated in `setupUi`.

### Acceptance Criteria 

Create a component with a mesh and attempt to edit it. Check that the "Edit Component" button starts off as enabled, and becomes disabled only when you give bad input.

### UI tests

n/a

### Nominate for Group Code Review

- [ ] Nominate for code review 
