### PR TITLE
fixing mesh shape component issue

### DIFF
--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -294,6 +294,7 @@ class AddComponentDialog(Ui_AddComponentDialog, QObject):
             self.noShapeRadioButton.clicked.emit()
         else:
             if isinstance(component_shape, OFFGeometryNexus):
+                self.cad_file_name = component_shape.file_path
                 self.meshRadioButton.setChecked(True)
                 self.meshRadioButton.clicked.emit()
                 if component_shape.file_path:


### PR DESCRIPTION
### Issue

Closes #542 

### Description of work

Fills in `self.cad_file_name` in `AddComponentDialog` - previously it was not getting filled in. 

### Acceptance Criteria 

1- Create or load a file with a mesh shape 
2- Click edit component and rename it

previously this would result in an exception but not now. 

### UI tests

N/A

### Nominate for Group Code Review

- [ ] Nominate for code review 
