### PR TITLE
Fixing qt error preventing DPI scaling

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,8 +18,8 @@ if __name__ == "__main__":
     if "help" in parser.parse_args():
         exit(0)
     logging.basicConfig(level=logging.INFO)
+    QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
     app = QApplication(sys.argv)
-    app.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
     app.setWindowIcon(QIcon(os.path.join("ui", "icon.png")))
     window = QMainWindow()
     nexus_wrapper = NexusWrapper()


### PR DESCRIPTION
### Issue

Closes #544 
Closes #530 - definitely fixes this
Closes #409 

### Description of work
had 5 minutes on a friday afternoon and this kills 3 birds with one stone. 
Setting attribute before creating instance of qapplication. apparently that is the way to do it properly in qt. 

### Acceptance Criteria 

Everything still works 

### UI tests

N/A

### Nominate for Group Code Review

- [ ] Nominate for code review 
