### PR TITLE
Add support for senv streams

### DIFF
--- a/nexus_constructor/stream_fields_widget.py
+++ b/nexus_constructor/stream_fields_widget.py
@@ -19,7 +19,7 @@ from PySide2.QtWidgets import (
 )
 import numpy as np
 
-SCHEMAS = ["ev42", "f142", "hs00", "ns10", "TdcTime"]
+SCHEMAS = ["ev42", "f142", "hs00", "ns10", "TdcTime",  "senv"]
 F142_TYPES = [
     "byte",
     "ubyte",
@@ -262,7 +262,7 @@ class StreamFieldsWidget(QDialog):
             self.hs00_unimplemented_label.setVisible(True)
         elif schema == "ns10":
             self._set_edits_visible(True, False, "nicos/<device>/<parameter>")
-        elif schema == "TdcTime":
+        elif schema == "TdcTime" or schema == "senv":
             self._set_edits_visible(True, False)
 
     def _set_edits_visible(self, source: bool, type: bool, source_hint=None):

--- a/nexus_constructor/stream_fields_widget.py
+++ b/nexus_constructor/stream_fields_widget.py
@@ -19,7 +19,7 @@ from PySide2.QtWidgets import (
 )
 import numpy as np
 
-SCHEMAS = ["ev42", "f142", "hs00", "ns10", "TdcTime",  "senv"]
+SCHEMAS = ["ev42", "f142", "hs00", "ns10", "TdcTime", "senv"]
 F142_TYPES = [
     "byte",
     "ubyte",

--- a/tests/ui_tests/test_ui_add_component_window.py
+++ b/tests/ui_tests/test_ui_add_component_window.py
@@ -1797,6 +1797,36 @@ def test_UI_GIVEN_field_widget_with_stream_type_and_schema_set_to_ns10_THEN_stre
     assert not streams_widget.type_combo.isVisible()
 
 
+@pytest.mark.parametrize("test_input", ["TdcTime", "senv"])
+def test_UI_GIVEN_field_widget_with_stream_type_and_schema_set_THEN_stream_dialog_shown_with_correct_options(
+    qtbot, test_input
+):
+    dialog, template = create_add_component_template(qtbot)
+
+    qtbot.mouseClick(dialog.addFieldPushButton, Qt.LeftButton)
+    field = dialog.fieldsListWidget.itemWidget(dialog.fieldsListWidget.item(0))
+
+    field.field_type_combo.setCurrentText(FieldType.kafka_stream.value)
+    field.field_type_combo.currentTextChanged.emit(field.field_type_combo.currentText())
+
+    qtbot.mouseClick(field.edit_button, Qt.LeftButton)
+
+    assert field.edit_dialog.isEnabled()
+
+    streams_widget = field.streams_widget
+    assert streams_widget.isEnabled()
+
+    streams_widget._schema_type_changed(test_input)
+
+    assert streams_widget.topic_label.isEnabled()
+    assert streams_widget.topic_line_edit.isEnabled()
+    assert streams_widget.source_label.isVisible()
+    assert streams_widget.source_line_edit.isVisible()
+
+    assert not streams_widget.type_label.isVisible()
+    assert not streams_widget.type_combo.isVisible()
+
+
 def test_UI_GIVEN_field_widget_with_stream_type_and_schema_set_to_hs00_THEN_stream_dialog_shown_with_correct_options(
     qtbot
 ):


### PR DESCRIPTION
### Issue

Closes #552 

### Description of work

Should be straightforward enough as it shares the same fields as TdcTime. 

### Acceptance Criteria 
senv streams are shown as an option in the UI 
senv streams are outputted correctly in the JSON file

### UI tests

Added for both TdcTime and senv streams. 

### Nominate for Group Code Review

- [ ] Nominate for code review 
