### PR TITLE
reverting stream group names

### DIFF
--- a/nexus_constructor/component_fields.py
+++ b/nexus_constructor/component_fields.py
@@ -83,11 +83,6 @@ class FieldWidget(QFrame):
     ):
         super(FieldWidget, self).__init__(parent)
 
-        # We don't really care about this as it'll never end up in the JSON, but in order to save it into a nexus file it needs a name.
-        self.stream_group_name = (
-            stream_group_name if stream_group_name is not None else str(uuid.uuid4())
-        )
-
         self.edit_dialog = QDialog(parent=self)
         self.attrs_dialog = FieldAttrsDialog(parent=self)
         self.instrument = instrument
@@ -187,11 +182,7 @@ class FieldWidget(QFrame):
 
     @property
     def name(self) -> str:
-        return (
-            self.field_name_edit.text()
-            if self.field_type != FieldType.kafka_stream
-            else self.stream_group_name
-        )
+        return self.field_name_edit.text()
 
     @name.setter
     def name(self, name: str):
@@ -282,7 +273,7 @@ class FieldWidget(QFrame):
         elif self.field_type_combo.currentText() == FieldType.array_dataset.value:
             self.set_visibility(False, False, True, True)
         elif self.field_type_combo.currentText() == FieldType.kafka_stream.value:
-            self.set_visibility(False, False, True, False, show_name_line_edit=False)
+            self.set_visibility(False, False, True, False, show_name_line_edit=True)
         elif self.field_type_combo.currentText() == FieldType.link.value:
             self.set_visibility(True, False, False, False)
             self._set_up_value_validator(True)

--- a/nexus_constructor/json/filewriter_json_writer.py
+++ b/nexus_constructor/json/filewriter_json_writer.py
@@ -183,7 +183,9 @@ class NexusToDictConverter:
         # Add the entries
         entries = list(root.values())
         if root.name in self._kafka_streams:
-            root_dict = {"type": "stream", "stream": self._kafka_streams[root.name]}
+            root_dict["children"].append(
+                {"type": "stream", "stream": self._kafka_streams[root.name]}
+            )
 
         elif root.name in self._links.keys():
             root_dict = self._create_link_root_dict(

--- a/nexus_constructor/stream_fields_widget.py
+++ b/nexus_constructor/stream_fields_widget.py
@@ -288,7 +288,7 @@ class StreamFieldsWidget(QDialog):
         )
         group = temp_file.create_group("children")
         group.create_dataset(name="type", dtype=STRING_DTYPE, data="stream")
-        stream_group = group.create_group(self.parent().parent().name)
+        stream_group = group.create_group(self.parent().parent().field_name_edit.text())
         stream_group.attrs["NX_class"] = "NCstream"
         stream_group.create_dataset(
             name="topic", dtype=STRING_DTYPE, data=self.topic_line_edit.text()

--- a/tests/test_json_writer.py
+++ b/tests/test_json_writer.py
@@ -247,7 +247,8 @@ def test_GIVEN_stream_in_group_children_WHEN_handling_group_THEN_stream_is_appen
         file, streams={f"/{group_name}": group_contents}, links=[]
     )
 
-    assert group_contents == root_dict["children"][0]["stream"]
+    assert group_name == root_dict["children"][0]["name"]
+    assert group_contents == root_dict["children"][0]["children"][0]["stream"]
 
 
 def test_GIVEN_link_in_group_children_WHEN_handling_group_THEN_link_is_appended_to_children(


### PR DESCRIPTION
### Issue

Closes #551 

### Description of work

Streams need to have groups in order to be processed by the filewriter. They currently do not as we changed them to be singular datasets but this will not work. I have reverted the change. 

### Acceptance Criteria 

very high priority as it stops us from using the NC at v20. It works so as long as it doesn't break any tests i will merge into master. 

### UI tests

N/A

### Nominate for Group Code Review

- [ ] Nominate for code review 
