### PR TITLE
578: Attribute validity not reevaluating when data type changes

### DIFF
--- a/nexus_constructor/field_attrs.py
+++ b/nexus_constructor/field_attrs.py
@@ -115,6 +115,9 @@ class FieldAttrFrame(QFrame):
                 tooltip_on_reject="Value is not cast-able to selected numpy type.",
             )
         )
+        self.attr_value_lineedit.validator().validate(
+            self.attr_value_lineedit.text(), 0
+        )
 
     @property
     def dtype(self):

--- a/tests/ui_tests/test_ui_field_attrs.py
+++ b/tests/ui_tests/test_ui_field_attrs.py
@@ -5,20 +5,24 @@ import numpy as np
 from tests.helpers import file  # noqa: F401
 
 
+@pytest.fixture(scope="function")
+def field_attrs_dialog(qtbot):
+
+    dialog = FieldAttrsDialog()
+    qtbot.addWidget(dialog)
+    return dialog
+
+
 @pytest.mark.parametrize("attr_val", ["test", 123, 1.1, np.ushort(12)])
 def test_GIVEN_existing_field_with_attr_WHEN_editing_component_THEN_both_field_and_attrs_are_filled_in_correctly(
-    qtbot, file, attr_val
+    qtbot, file, attr_val, field_attrs_dialog
 ):
     attr_key = "units"
 
     ds = file.create_dataset(name="test", data=123)
     ds.attrs[attr_key] = attr_val
 
-    dialog = FieldAttrsDialog()
+    field_attrs_dialog.fill_existing_attrs(ds)
 
-    qtbot.addWidget(dialog)
-
-    dialog.fill_existing_attrs(ds)
-
-    assert len(dialog.get_attrs()) == 1
-    assert dialog.get_attrs()[attr_key] == attr_val
+    assert len(field_attrs_dialog.get_attrs()) == 1
+    assert field_attrs_dialog.get_attrs()[attr_key] == attr_val

--- a/tests/ui_tests/test_ui_field_attrs.py
+++ b/tests/ui_tests/test_ui_field_attrs.py
@@ -29,9 +29,19 @@ def test_GIVEN_existing_field_with_attr_WHEN_editing_component_THEN_both_field_a
     assert field_attrs_dialog.get_attrs()[attr_key] == attr_val
 
 
-def test_GIVEN_add_attr_button_pressed_WHEN_changing_attributes_THEN_new_attribute_is_created(
+def test_GIVEN_add_attribute_button_pressed_WHEN_changing_attributes_THEN_new_attribute_is_created(
     qtbot, field_attrs_dialog
 ):
 
     qtbot.mouseClick(field_attrs_dialog.add_button, Qt.LeftButton)
     assert field_attrs_dialog.list_widget.count() == 1
+
+
+def test_GIVEN_remove_attribute_button_pressed_WHEN_changing_attributes_THEN_selected_attribute_is_removed(
+    qtbot, field_attrs_dialog
+):
+
+    qtbot.mouseClick(field_attrs_dialog.add_button, Qt.LeftButton)
+    field_attrs_dialog.list_widget.setCurrentRow(0)
+    qtbot.mouseClick(field_attrs_dialog.remove_button, Qt.LeftButton)
+    assert field_attrs_dialog.list_widget.count() == 0

--- a/tests/ui_tests/test_ui_field_attrs.py
+++ b/tests/ui_tests/test_ui_field_attrs.py
@@ -7,6 +7,7 @@ from PySide2.QtWidgets import QListWidget
 from nexus_constructor.field_attrs import FieldAttrsDialog, FieldAttrFrame
 import numpy as np
 from tests.helpers import file  # noqa: F401
+from tests.ui_tests.ui_test_utils import show_and_close_window
 
 
 @pytest.fixture(scope="function")
@@ -102,7 +103,12 @@ def test_GIVEN_attribute_is_an_array_WHEN_getting_data_THEN_array_is_returned(
     qtbot.mouseClick(widget.array_edit_button, Qt.LeftButton)
     widget.dialog.model.array = data
 
-    assert np.array_equal(widget.value[1], data)
+    attribute_name = "AttributeName"
+    qtbot.keyClicks(widget.attr_name_lineedit, attribute_name)
+
+    name, value = widget.value
+    assert name == attribute_name
+    assert np.array_equal(value, data)
 
 
 def test_GIVEN_array_and_attribute_name_set_WHEN_changing_attribute_THEN_array_attribute_set(
@@ -113,3 +119,25 @@ def test_GIVEN_array_and_attribute_name_set_WHEN_changing_attribute_THEN_array_a
     widget.value = ("AttributeName", data)
 
     assert np.array_equal(widget.array, data)
+
+
+def test_GIVEN_type_changed_to_array_WHEN_changing_attribute_THEN_edit_array_button_is_visible(
+    qtbot, field_attrs_dialog
+):
+
+    widget = add_array_attribute(field_attrs_dialog, qtbot)
+    widget.type_changed("Array")
+    show_and_close_window(qtbot, field_attrs_dialog)
+    assert widget.array_edit_button.isVisible()
+    assert not widget.attr_value_lineedit.isVisible()
+
+
+def test_GIVEN_type_changed_to_scalar_WHEN_changing_attribute_THEN_value_line_edit_is_visible(
+    qtbot, field_attrs_dialog
+):
+
+    widget = add_array_attribute(field_attrs_dialog, qtbot)
+    widget.type_changed("Scalar")
+    show_and_close_window(qtbot, field_attrs_dialog)
+    assert not widget.array_edit_button.isVisible()
+    assert widget.attr_value_lineedit.isVisible()

--- a/tests/ui_tests/test_ui_field_attrs.py
+++ b/tests/ui_tests/test_ui_field_attrs.py
@@ -1,4 +1,5 @@
 import pytest
+from PySide2.QtCore import Qt
 
 from nexus_constructor.field_attrs import FieldAttrsDialog
 import numpy as np
@@ -26,3 +27,11 @@ def test_GIVEN_existing_field_with_attr_WHEN_editing_component_THEN_both_field_a
 
     assert len(field_attrs_dialog.get_attrs()) == 1
     assert field_attrs_dialog.get_attrs()[attr_key] == attr_val
+
+
+def test_GIVEN_add_attr_button_pressed_WHEN_changing_attributes_THEN_new_attribute_is_created(
+    qtbot, field_attrs_dialog
+):
+
+    qtbot.mouseClick(field_attrs_dialog.add_button, Qt.LeftButton)
+    assert field_attrs_dialog.list_widget.count() == 1

--- a/tests/ui_tests/test_ui_field_attrs.py
+++ b/tests/ui_tests/test_ui_field_attrs.py
@@ -81,3 +81,18 @@ def test_GIVEN_edit_array_button_pressed_WHEN_attribute_is_an_array_THEN_array_w
 
     qtbot.mouseClick(widget.array_edit_button, Qt.LeftButton)
     assert widget.dialog.isVisible()
+
+
+def test_GIVEN_attribute_is_an_array_WHEN_getting_data_THEN_array_is_returned(
+    qtbot, field_attrs_dialog
+):
+
+    qtbot.mouseClick(field_attrs_dialog.add_button, Qt.LeftButton)
+    widget = get_attribute_widget(0, field_attrs_dialog.list_widget)
+    widget.array_or_scalar_combo.setCurrentText("Array")
+
+    data = np.arange(9).reshape((3, 3))
+    qtbot.mouseClick(widget.array_edit_button, Qt.LeftButton)
+    widget.dialog.model.array = data
+
+    assert np.array_equal(widget.value, data)

--- a/tests/ui_tests/test_ui_field_attrs.py
+++ b/tests/ui_tests/test_ui_field_attrs.py
@@ -69,3 +69,15 @@ def test_GIVEN_data_type_changes_WHEN_editing_component_THEN_validate_method_is_
     ) as mock_validate:
         widget.attr_dtype_combo.setCurrentIndex(2)
         mock_validate.assert_called_once()
+
+
+def test_GIVEN_edit_array_button_pressed_WHEN_attribute_is_an_array_THEN_array_widget_opens(
+    qtbot, field_attrs_dialog
+):
+
+    qtbot.mouseClick(field_attrs_dialog.add_button, Qt.LeftButton)
+    widget = get_attribute_widget(0, field_attrs_dialog.list_widget)
+    widget.array_or_scalar_combo.setCurrentText("Array")
+
+    qtbot.mouseClick(widget.array_edit_button, Qt.LeftButton)
+    assert widget.dialog.isVisible()


### PR DESCRIPTION
### Issue

Closes #578 

### Description of work

Added an extra call to `validate()` when the data type changes. That seems to fix the problem. Also added a few more fields attribute tests.

### Acceptance Criteria 

Add an attribute and enter a value that doesn't match the data type. Change the data type to one that matches the value and check that the box becomes white.

### UI tests

n/a

### Nominate for Group Code Review

- [ ] Nominate for code review 
