### PR TITLE
579: Load bytestring attributes from a NeXus file

### DIFF
--- a/nexus_constructor/field_attrs.py
+++ b/nexus_constructor/field_attrs.py
@@ -147,9 +147,7 @@ class FieldAttrFrame(QFrame):
 
         # Decode the attribute value if it's in byte form
         if isinstance(new_value, bytes):
-            decoded = new_value.decode("utf-8")
-            if isinstance(decoded, str):
-                new_value = decoded
+            new_value = new_value.decode("utf-8")
 
         self.attr_name_lineedit.setText(new_name)
         self.attr_dtype_combo.setCurrentText(

--- a/nexus_constructor/field_attrs.py
+++ b/nexus_constructor/field_attrs.py
@@ -96,7 +96,7 @@ class FieldAttrFrame(QFrame):
 
         self.type_changed("Scalar")
 
-        if name is not None and value is not None:
+        if name and value:
             self.value = (name, value)
 
     def type_changed(self, item: str):
@@ -145,6 +145,7 @@ class FieldAttrFrame(QFrame):
         new_name = name_and_value[0]
         new_value = name_and_value[1]
 
+        # Decode the attribute value if it's in byte form
         if isinstance(new_value, bytes):
             decoded = new_value.decode("utf-8")
             if isinstance(decoded, str):

--- a/nexus_constructor/field_attrs.py
+++ b/nexus_constructor/field_attrs.py
@@ -96,7 +96,7 @@ class FieldAttrFrame(QFrame):
 
         self.type_changed("Scalar")
 
-        if name and value:
+        if name is not None and value is not None:
             self.value = (name, value)
 
     def type_changed(self, item: str):
@@ -144,6 +144,12 @@ class FieldAttrFrame(QFrame):
     def value(self, name_and_value: Tuple[str, Union[np.generic, np.ndarray]]):
         new_name = name_and_value[0]
         new_value = name_and_value[1]
+
+        if isinstance(new_value, bytes):
+            decoded = new_value.decode("utf-8")
+            if isinstance(decoded, str):
+                new_value = decoded
+
         self.attr_name_lineedit.setText(new_name)
         self.attr_dtype_combo.setCurrentText(
             "String"

--- a/nexus_constructor/pixel_options.py
+++ b/nexus_constructor/pixel_options.py
@@ -101,25 +101,12 @@ class PixelOptions(Ui_PixelOptionsWidget, QObject):
         """
         self.reset_pixel_mapping_list()
 
-        x_pixel_offset = component_to_edit.get_field("x_pixel_offset")
-        y_pixel_offset = component_to_edit.get_field("y_pixel_offset")
-        detector_numbers = component_to_edit.get_field("detector_number")
-
-        if x_pixel_offset is not None:
+        if component_to_edit.get_field("x_pixel_offset") is not None:
             self.single_pixel_radio_button.setChecked(True)
             self.update_pixel_layout_visibility(True, False)
-            if (
-                isinstance(x_pixel_offset, np.ndarray)
-                and len(x_pixel_offset.shape) != 2
-            ):
-                x_pixel_offset, y_pixel_offset, detector_numbers = self._reshape_pixel_data(
-                    x_pixel_offset, y_pixel_offset, detector_numbers
-                )
-            self._fill_single_pixel_fields(
-                x_pixel_offset, y_pixel_offset, detector_numbers
-            )
+            self._fill_single_pixel_fields(component_to_edit)
 
-        elif detector_numbers is not None:
+        elif component_to_edit.get_field("detector_number") is not None:
             self.entire_shape_radio_button.setChecked(True)
             self.update_pixel_layout_visibility(False, True)
             self._fill_entire_shape_fields(component_to_edit)
@@ -128,32 +115,16 @@ class PixelOptions(Ui_PixelOptionsWidget, QObject):
             self.no_pixels_button.setChecked(True)
             self.pixel_options_stack.setVisible(False)
 
-    def _reshape_pixel_data(
-        self,
-        x_pixel_offset: np.ndarray,
-        y_pixel_offset: np.ndarray,
-        detector_numbers: np.ndarray,
-    ):
-        first = y_pixel_offset[0]
-        row_size = np.where(y_pixel_offset != first)[0][0]
-        col_size = y_pixel_offset.size // row_size
-
-        return (
-            x_pixel_offset.reshape((col_size, row_size)),
-            y_pixel_offset.reshape((col_size, row_size)),
-            detector_numbers.reshape((col_size, row_size)),
-        )
-
-    def _fill_single_pixel_fields(
-        self,
-        x_pixel_offset: np.ndarray,
-        y_pixel_offset: np.ndarray,
-        detector_numbers: np.ndarray,
-    ):
+    def _fill_single_pixel_fields(self, component_to_edit: Component):
         """
         Fill the "single pixel" fields of a component that's being edited and contains pixel information.
         :param component_to_edit: The component that's being edited.
         """
+        # Retrieve the pixel offsets and detector number from the component
+        x_pixel_offset = component_to_edit.get_field("x_pixel_offset")
+        y_pixel_offset = component_to_edit.get_field("y_pixel_offset")
+        detector_numbers = component_to_edit.get_field("detector_number")
+
         # Check that x offset is more than one value
         if check_data_is_an_array(x_pixel_offset):
 

--- a/nexus_constructor/pixel_options.py
+++ b/nexus_constructor/pixel_options.py
@@ -101,12 +101,25 @@ class PixelOptions(Ui_PixelOptionsWidget, QObject):
         """
         self.reset_pixel_mapping_list()
 
-        if component_to_edit.get_field("x_pixel_offset") is not None:
+        x_pixel_offset = component_to_edit.get_field("x_pixel_offset")
+        y_pixel_offset = component_to_edit.get_field("y_pixel_offset")
+        detector_numbers = component_to_edit.get_field("detector_number")
+
+        if x_pixel_offset is not None:
             self.single_pixel_radio_button.setChecked(True)
             self.update_pixel_layout_visibility(True, False)
-            self._fill_single_pixel_fields(component_to_edit)
+            if (
+                isinstance(x_pixel_offset, np.ndarray)
+                and len(x_pixel_offset.shape) != 2
+            ):
+                x_pixel_offset, y_pixel_offset, detector_numbers = self._reshape_pixel_data(
+                    x_pixel_offset, y_pixel_offset, detector_numbers
+                )
+            self._fill_single_pixel_fields(
+                x_pixel_offset, y_pixel_offset, detector_numbers
+            )
 
-        elif component_to_edit.get_field("detector_number") is not None:
+        elif detector_numbers is not None:
             self.entire_shape_radio_button.setChecked(True)
             self.update_pixel_layout_visibility(False, True)
             self._fill_entire_shape_fields(component_to_edit)
@@ -115,16 +128,32 @@ class PixelOptions(Ui_PixelOptionsWidget, QObject):
             self.no_pixels_button.setChecked(True)
             self.pixel_options_stack.setVisible(False)
 
-    def _fill_single_pixel_fields(self, component_to_edit: Component):
+    def _reshape_pixel_data(
+        self,
+        x_pixel_offset: np.ndarray,
+        y_pixel_offset: np.ndarray,
+        detector_numbers: np.ndarray,
+    ):
+        first = y_pixel_offset[0]
+        row_size = np.where(y_pixel_offset != first)[0][0]
+        col_size = y_pixel_offset.size // row_size
+
+        return (
+            x_pixel_offset.reshape((col_size, row_size)),
+            y_pixel_offset.reshape((col_size, row_size)),
+            detector_numbers.reshape((col_size, row_size)),
+        )
+
+    def _fill_single_pixel_fields(
+        self,
+        x_pixel_offset: np.ndarray,
+        y_pixel_offset: np.ndarray,
+        detector_numbers: np.ndarray,
+    ):
         """
         Fill the "single pixel" fields of a component that's being edited and contains pixel information.
         :param component_to_edit: The component that's being edited.
         """
-        # Retrieve the pixel offsets and detector number from the component
-        x_pixel_offset = component_to_edit.get_field("x_pixel_offset")
-        y_pixel_offset = component_to_edit.get_field("y_pixel_offset")
-        detector_numbers = component_to_edit.get_field("detector_number")
-
         # Check that x offset is more than one value
         if check_data_is_an_array(x_pixel_offset):
 

--- a/tests/ui_tests/test_ui_field_attrs.py
+++ b/tests/ui_tests/test_ui_field_attrs.py
@@ -1,24 +1,51 @@
 import pytest
+from PySide2.QtWidgets import QDialog
 
 from nexus_constructor.field_attrs import FieldAttrsDialog
 import numpy as np
 from tests.helpers import file  # noqa: F401
 
 
+@pytest.fixture(scope="function")
+def template(qtbot):
+    return QDialog()
+
+
+@pytest.fixture(scope="function")
+def field_attributes_dialog(qtbot, template):
+    field_attributes_dialog = FieldAttrsDialog(template)
+    qtbot.addWidget(field_attributes_dialog)
+    return field_attributes_dialog
+
+
 @pytest.mark.parametrize("attr_val", ["test", 123, 1.1, np.ushort(12)])
 def test_GIVEN_existing_field_with_attr_WHEN_editing_component_THEN_both_field_and_attrs_are_filled_in_correctly(
-    qtbot, file, attr_val
+    qtbot, file, attr_val, field_attributes_dialog
 ):
     attr_key = "units"
 
     ds = file.create_dataset(name="test", data=123)
     ds.attrs[attr_key] = attr_val
 
-    dialog = FieldAttrsDialog()
+    field_attributes_dialog.fill_existing_attrs(ds)
 
-    qtbot.addWidget(dialog)
+    assert len(field_attributes_dialog.get_attrs()) == 1
+    assert field_attributes_dialog.get_attrs()[attr_key] == attr_val
 
-    dialog.fill_existing_attrs(ds)
 
-    assert len(dialog.get_attrs()) == 1
-    assert dialog.get_attrs()[attr_key] == attr_val
+def test_GIVEN_attribute_value_is_byte_string_WHEN_filling_existing_values_THEN_string_is_decoded_in_lineedit(
+    qtbot, field_attributes_dialog, file
+):
+
+    attribute_value_string = "yards"
+
+    ds = file.create_dataset(name="test", data=123)
+    ds.attrs["units"] = attribute_value_string.encode("utf-8")
+
+    field_attributes_dialog.fill_existing_attrs(ds)
+    assert (
+        field_attributes_dialog.list_widget.itemWidget(
+            field_attributes_dialog.list_widget.item(0)
+        ).attr_value_lineedit.text()
+        == attribute_value_string
+    )


### PR DESCRIPTION
### Issue

Closes #579 

### Description of work

Allows a user to view attributes that are contained in byte strings without it causing an exception. 

### Acceptance Criteria 

Open the `example_nx_disk_chopper.nxs` file and check that it doesn't throw an exception when you open the Edit Component window.

### UI tests

n/a

### Nominate for Group Code Review

- [ ] Nominate for code review 
