### PR TITLE
re #565 fix h5py deprecation warning by specifying file modes

### DIFF
--- a/nexus_constructor/component_fields.py
+++ b/nexus_constructor/component_fields.py
@@ -1,5 +1,4 @@
 import logging
-import uuid
 from functools import partial
 
 import h5py
@@ -21,6 +20,7 @@ from nexus_constructor.component.component import Component
 from nexus_constructor.array_dataset_table_widget import ArrayDatasetTableWidget
 from nexus_constructor.field_attrs import FieldAttrsDialog
 from nexus_constructor.invalid_field_names import INVALID_FIELD_NAMES
+from nexus_constructor.nexus.nexus_wrapper import create_temporary_in_memory_file
 from nexus_constructor.stream_fields_widget import StreamFieldsWidget
 from nexus_constructor.instrument import Instrument
 from nexus_constructor.ui_utils import validate_line_edit, show_warning_dialog
@@ -225,18 +225,16 @@ class FieldWidget(QFrame):
             dtype = DATASET_TYPE[self.value_type_combo.currentText()]
             val = self.value_line_edit.text()
             if dtype == h5py.special_dtype(vlen=str):
-                return_object = h5py.File(
-                    name=str(uuid.uuid4()), driver="core", backing_store=False, mode="x"
-                ).create_dataset(name=self.name, dtype=dtype, data=val)
+                return_object = create_temporary_in_memory_file().create_dataset(
+                    name=self.name, dtype=dtype, data=val
+                )
             else:
-                return_object = h5py.File(
-                    name=str(uuid.uuid4()), driver="core", backing_store=False, mode="x"
-                ).create_dataset(name=self.name, dtype=dtype, data=dtype(val))
+                return_object = create_temporary_in_memory_file().create_dataset(
+                    name=self.name, dtype=dtype, data=dtype(val)
+                )
         elif self.field_type == FieldType.array_dataset:
             # Squeeze the array so 1D arrays can exist. Should not affect dimensional arrays.
-            return_object = h5py.File(
-                name=str(uuid.uuid4()), driver="core", backing_store=False, mode="x"
-            ).create_dataset(
+            return_object = create_temporary_in_memory_file().create_dataset(
                 name=self.name, data=np.squeeze(self.table_view.model.array)
             )
         elif self.field_type == FieldType.kafka_stream:

--- a/nexus_constructor/component_fields.py
+++ b/nexus_constructor/component_fields.py
@@ -226,16 +226,16 @@ class FieldWidget(QFrame):
             val = self.value_line_edit.text()
             if dtype == h5py.special_dtype(vlen=str):
                 return_object = h5py.File(
-                    name=str(uuid.uuid4()), driver="core", backing_store=False
+                    name=str(uuid.uuid4()), driver="core", backing_store=False, mode="x"
                 ).create_dataset(name=self.name, dtype=dtype, data=val)
             else:
                 return_object = h5py.File(
-                    name=str(uuid.uuid4()), driver="core", backing_store=False
+                    name=str(uuid.uuid4()), driver="core", backing_store=False, mode="x"
                 ).create_dataset(name=self.name, dtype=dtype, data=dtype(val))
         elif self.field_type == FieldType.array_dataset:
             # Squeeze the array so 1D arrays can exist. Should not affect dimensional arrays.
             return_object = h5py.File(
-                name=str(uuid.uuid4()), driver="core", backing_store=False
+                name=str(uuid.uuid4()), driver="core", backing_store=False, mode="x"
             ).create_dataset(
                 name=self.name, data=np.squeeze(self.table_view.model.array)
             )

--- a/nexus_constructor/nexus/nexus_wrapper.py
+++ b/nexus_constructor/nexus/nexus_wrapper.py
@@ -1,4 +1,5 @@
 import logging
+import uuid
 
 import h5py
 from PySide2.QtCore import Signal, QObject
@@ -43,6 +44,14 @@ def decode_bytes_string(nexus_string):
         return str(nexus_string, encoding="utf8")
     except TypeError:
         return nexus_string
+
+
+def create_temporary_in_memory_file() -> h5py.File:
+    """
+    Create a temporary in-memory nexus file with a random name.
+    :return: The file object
+    """
+    return set_up_in_memory_nexus_file(str(uuid.uuid4()))
 
 
 def get_fields(

--- a/nexus_constructor/stream_fields_widget.py
+++ b/nexus_constructor/stream_fields_widget.py
@@ -1,4 +1,3 @@
-import uuid
 from functools import partial
 from typing import List, ItemsView
 
@@ -18,6 +17,8 @@ from PySide2.QtWidgets import (
     QFormLayout,
 )
 import numpy as np
+
+from nexus_constructor.nexus.nexus_wrapper import create_temporary_in_memory_file
 
 SCHEMAS = ["ev42", "f142", "hs00", "ns10", "TdcTime", "senv"]
 F142_TYPES = [
@@ -283,9 +284,7 @@ class StreamFieldsWidget(QDialog):
         :return: The created HDF group.
         """
 
-        temp_file = h5py.File(
-            name=str(uuid.uuid4()), driver="core", backing_store=False, mode="x"
-        )
+        temp_file = create_temporary_in_memory_file()
         group = temp_file.create_group("children")
         group.create_dataset(name="type", dtype=STRING_DTYPE, data="stream")
         stream_group = group.create_group(self.parent().parent().field_name_edit.text())

--- a/nexus_constructor/stream_fields_widget.py
+++ b/nexus_constructor/stream_fields_widget.py
@@ -284,7 +284,7 @@ class StreamFieldsWidget(QDialog):
         """
 
         temp_file = h5py.File(
-            name=str(uuid.uuid4()), driver="core", backing_store=False
+            name=str(uuid.uuid4()), driver="core", backing_store=False, mode="x"
         )
         group = temp_file.create_group("children")
         group.create_dataset(name="type", dtype=STRING_DTYPE, data="stream")

--- a/tests/ui_tests/test_ui_add_component_window.py
+++ b/tests/ui_tests/test_ui_add_component_window.py
@@ -1856,7 +1856,7 @@ def test_UI_GIVEN_component_with_basic_f142_field_WHEN_editing_component_THEN_to
 
     field_name = "stream1"
 
-    file = h5py.File("temp", driver="core", backing_store=False)
+    file = h5py.File("temp", driver="core", backing_store=False, mode="x")
     stream_group = file.create_group(name=field_name)
     stream_group.attrs["NX_class"] = "NCstream"
 


### PR DESCRIPTION
### Issue

Closes #565 

### Description of work

Fix h5py deprecation warning by specifying a file mode for all files that previously had the default mode.

### Acceptance Criteria 

Everything should still work

### UI tests

N/A

### Nominate for Group Code Review

- [ ] Nominate for code review 
