### PR TITLE
re #568 removing misleading topic placeholder text in stream widget

### DIFF
--- a/nexus_constructor/stream_fields_widget.py
+++ b/nexus_constructor/stream_fields_widget.py
@@ -73,7 +73,7 @@ class StreamFieldsWidget(QDialog):
         self.setWindowModality(Qt.WindowModal)
         self.setModal(True)
         self.minimum_spinbox_value = 0
-        self.maximum_spinbox_value = 100000000
+        self.maximum_spinbox_value = 100_000_000
 
         self.hs00_unimplemented_label = QLabel(
             "hs00 (Event histograms) has not yet been fully implemented."
@@ -84,7 +84,6 @@ class StreamFieldsWidget(QDialog):
 
         self.topic_label = QLabel("Topic: ")
         self.topic_line_edit = QLineEdit()
-        self.topic_line_edit.setPlaceholderText("broker[:port, default=9092]/topic")
 
         self.source_label = QLabel("Source: ")
         self.source_line_edit = QLineEdit()


### PR DESCRIPTION
### Issue

Closes #568

### Description of work

Removes misleading topic text. Should not include the broker, just the topic. 

### Acceptance Criteria 

no functional changes 

### UI tests

N/A

### Nominate for Group Code Review

- [ ] Nominate for code review 
