### PR TITLE
Stopping NCstream from being added to JSON stream groups NX_class

### DIFF
--- a/nexus_constructor/instrument.py
+++ b/nexus_constructor/instrument.py
@@ -1,4 +1,4 @@
-from typing import List, Dict
+from typing import List
 
 import h5py
 from nexus_constructor.component.component_type import (
@@ -93,16 +93,3 @@ class Instrument:
 
         self.nexus.entry.visititems(find_components)
         return component_list
-
-    def get_links(self) -> Dict[str, h5py.Group]:
-        links_dict = dict()
-
-        def find_links(_, node):
-            if isinstance(node, h5py.Group):
-                # visititems does not visit softlinks so we need to do this manually
-                for item in node:
-                    if isinstance(node.get(item, getlink=True), h5py.SoftLink):
-                        links_dict[node[item].name] = node[item]
-
-        self.nexus.entry.visititems(find_links)
-        return links_dict

--- a/nexus_constructor/instrument.py
+++ b/nexus_constructor/instrument.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any, Tuple, Union
+from typing import List, Dict
 
 import h5py
 from nexus_constructor.component.component_type import (
@@ -15,31 +15,6 @@ COMPONENTS_IN_ENTRY = ["NXmonitor", "NXsample"]
 
 def _convert_name_with_spaces(component_name):
     return component_name.replace(" ", "_")
-
-
-def _separate_dot_field_group_hierarchy(
-    item_dict: Dict[Any, Any],
-    dots_in_field_name: List[str],
-    item: Tuple[str, h5py.Group],
-):
-    previous_group = item_dict
-    for subgroup in dots_in_field_name:
-        # do not overwrite a group unless it doesn't yet exist
-        if subgroup not in previous_group:
-            previous_group[subgroup] = dict()
-        if subgroup == dots_in_field_name[-1]:
-            # set the value of the field to the last item in the list
-            previous_group[subgroup] = _handle_stream_dataset(item[1][...])
-        previous_group = previous_group[subgroup]
-
-
-def _handle_stream_dataset(stream_dataset: h5py.Dataset) -> Union[str, bool, int]:
-    if stream_dataset.dtype == h5py.special_dtype(vlen=str):
-        return str(stream_dataset)
-    if stream_dataset.dtype == bool:
-        return bool(stream_dataset)
-    if stream_dataset.dtype == int:
-        return int(stream_dataset)
 
 
 class Instrument:
@@ -118,33 +93,6 @@ class Instrument:
 
         self.nexus.entry.visititems(find_components)
         return component_list
-
-    def get_streams(self) -> Dict[str, Dict[str, str]]:
-        """
-        Find all streams and return them in the expected format for JSON serialisiation.
-        :return: A dictionary of stream groups, with their respective field names and values.
-        """
-        streams_dict = dict()
-
-        def find_streams(_, node):
-            if isinstance(node, h5py.Group):
-                if "NX_class" in node.attrs:
-                    if node.attrs["NX_class"] == "NCstream":
-                        item_dict = dict()
-                        for item in node.items():
-                            dots_in_field_name = item[0].split(".")
-                            if len(dots_in_field_name) > 1:
-                                _separate_dot_field_group_hierarchy(
-                                    item_dict, dots_in_field_name, item
-                                )
-                            else:
-                                item_dict[item[0]] = _handle_stream_dataset(
-                                    item[1][...]
-                                )
-                        streams_dict[node.name] = item_dict
-
-        self.nexus.entry.visititems(find_streams)
-        return streams_dict
 
     def get_links(self) -> Dict[str, h5py.Group]:
         links_dict = dict()

--- a/nexus_constructor/json/filewriter_json_writer.py
+++ b/nexus_constructor/json/filewriter_json_writer.py
@@ -2,13 +2,10 @@ import h5py
 import numpy as np
 import uuid
 import logging
-from typing import Union, Dict
+from typing import Union, Dict, Any, List, Tuple
 
 from nexus_constructor.instrument import Instrument
-from nexus_constructor.json.helpers import (
-    object_to_json_file,
-    _separate_dot_field_group_hierarchy,
-)
+from nexus_constructor.json.helpers import object_to_json_file
 from nexus_constructor.nexus.nexus_wrapper import get_nx_class, get_name_of_node
 
 NexusObject = Union[h5py.Group, h5py.Dataset, h5py.SoftLink]
@@ -273,3 +270,19 @@ def create_writer_commands(
         stop_cmd["service_id"] = service_id
 
     return write_cmd, stop_cmd
+
+
+def _separate_dot_field_group_hierarchy(
+    item_dict: Dict[Any, Any],
+    dots_in_field_name: List[str],
+    item: Tuple[str, h5py.Group],
+):
+    previous_group = item_dict
+    for subgroup in dots_in_field_name:
+        # do not overwrite a group unless it doesn't yet exist
+        if subgroup not in previous_group:
+            previous_group[subgroup] = dict()
+        if subgroup == dots_in_field_name[-1]:
+            # set the value of the field to the last item in the list
+            previous_group[subgroup] = item[...][()]
+        previous_group = previous_group[subgroup]

--- a/nexus_constructor/json/filewriter_json_writer.py
+++ b/nexus_constructor/json/filewriter_json_writer.py
@@ -4,16 +4,13 @@ import uuid
 import logging
 from typing import Union
 
-import typing
 
 from nexus_constructor.instrument import Instrument
-from nexus_constructor.json.helpers import object_to_json_file
-from nexus_constructor.nexus.nexus_wrapper import (
-    get_nx_class,
-    get_name_of_node,
+from nexus_constructor.json.helpers import (
+    object_to_json_file,
     _separate_dot_field_group_hierarchy,
-    _handle_stream_dataset,
 )
+from nexus_constructor.nexus.nexus_wrapper import get_nx_class, get_name_of_node
 
 NexusObject = Union[h5py.Group, h5py.Dataset]
 
@@ -21,7 +18,6 @@ NexusObject = Union[h5py.Group, h5py.Dataset]
 def generate_json(
     data: Instrument,
     file,
-    streams=None,
     links=None,
     nexus_file_name: str = "",
     broker: str = "",
@@ -96,7 +92,6 @@ class NexusToDictConverter:
     """
 
     def __init__(self):
-        self._kafka_streams = {}
         self._links = {}
 
     def convert(self, nexus_root: NexusObject, links: dict):
@@ -183,7 +178,7 @@ class NexusToDictConverter:
                         item_dict, dots_in_field_name, item
                     )
                 else:
-                    item_dict[name] = _handle_stream_dataset(item[...])
+                    item_dict[name] = item[...][()]
             root_dict["children"].append({"type": "stream", "stream": item_dict})
 
         elif root.name in self._links.keys():

--- a/nexus_constructor/json/filewriter_json_writer.py
+++ b/nexus_constructor/json/filewriter_json_writer.py
@@ -127,15 +127,14 @@ def get_data_and_type(root: h5py.Dataset):
 
 class NexusToDictConverter:
     """
-    Class used to convert nexus format root to python dict
+    Class used to convert NeXus format root to python dict
     """
 
     def convert(self, nexus_root: NexusObject):
         """
         Converts the given nexus_root to dict with correct replacement of
         the streams
-        :param links:
-        :param nexus_root
+        :param nexus_root: the root object to convert from NeXus to JSON
         :return: dictionary
         """
         return {
@@ -163,6 +162,7 @@ class NexusToDictConverter:
             self._handle_stream(root, root_dict)
 
         for entry in root.values():
+            # Check if there are SoftLinks in the group
             if isinstance(root.get(name=entry.name, getlink=True), h5py.SoftLink):
                 self._handle_link(entry, root, root_dict)
             root_dict["children"].append(self._root_to_dict(entry))
@@ -171,6 +171,12 @@ class NexusToDictConverter:
 
     @staticmethod
     def _handle_link(entry: NexusObject, root: h5py.Group, root_dict: Dict):
+        """
+        Create link specific fields in the JSON when a softlink is found.
+        :param entry: The entry (dataset or group) that is to be linked
+        :param root: the group containing the link object
+        :param root_dict: the output dictionary for the JSON writer
+        """
         root_dict["children"].append(
             {
                 "type": "link",
@@ -181,6 +187,11 @@ class NexusToDictConverter:
 
     @staticmethod
     def _handle_stream(root: h5py.Group, root_dict: Dict):
+        """
+        Given a stream group handle the stream-specific fields in the JSON
+        :param root: group containing stream fields
+        :param root_dict: JSON output dictionary
+        """
         item_dict = dict()
         for name, item in root.items():
             dots_in_field_name = name.split(".")

--- a/nexus_constructor/json/forwarder_json_writer.py
+++ b/nexus_constructor/json/forwarder_json_writer.py
@@ -1,46 +1,38 @@
-from typing import Dict, Any, List, Union, TextIO
+from typing import List, TextIO
+
+import h5py
 
 from nexus_constructor.json.helpers import object_to_json_file
+from nexus_constructor.nexus.nexus_wrapper import get_nx_class
+
+FORWARDER_SCHEMAS = ["f142", "TdcTime"]
 
 
-def generate_forwarder_command(
-    output_file: TextIO, streams: Dict[str, Dict[str, Any]], provider_type: str
-):
+def find_forwarder_streams(root, provider_type: str) -> List:
     """
-    Generate a forwarder command containing a list of PVs and which topics to route them to.
-    :param output_file: file object to write the JSON output to.
-    :param streams: dictionary of stream objects.
-    :param provider_type: whether to use channel access or pv access protocol
+    Find all streams and return them in the expected format for JSON serialisiation.
+    :return: A dictionary of stream groups, with their respective field names and values.
     """
-    tree_dict = dict()
-    stream_list = _extract_forwarder_stream_info(streams, provider_type)
-    tree_dict["streams"] = stream_list
-    object_to_json_file(tree_dict, output_file)
-
-
-def _extract_forwarder_stream_info(
-    streams: Dict[str, Dict[str, Any]], provider_type: str
-) -> List[Dict[str, Union[Dict, str]]]:
-    """
-    Extracts the forwarder stream information to write a forwarder JSON command.
-    :param streams: A dictionary containing all streams in the nexus file
-    :return: A list of streams containing dictionaries of PV names, topics and schemas.
-    """
+    pv_names = {}
     stream_list = []
-    pv_names = (
-        dict()
-    )  # key is pv name, value is index in stream_list where stream exists
-    for _, stream in streams.items():
-        writer_module = stream["writer_module"]
-        if writer_module == "f142" or writer_module == "TdcTime":
-            pv_name = stream["source"]
+
+    def find_streams(_, node):
+        nonlocal pv_names
+        nonlocal stream_list
+        if (
+            isinstance(node, h5py.Group)
+            and get_nx_class(node) == "NCstream"
+            and node["writer_module"][()] in FORWARDER_SCHEMAS
+        ):
+            writer_module = node["writer_module"][()]
+            pv_name = node["source"][()]
             if pv_name not in pv_names.keys():
                 stream_list.append(
                     {
                         "channel": pv_name,
                         "converter": {
                             "schema": writer_module,
-                            "topic": stream["topic"],
+                            "topic": node["topic"][()],
                         },
                         "channel_provider_type": provider_type,
                     }
@@ -50,7 +42,7 @@ def _extract_forwarder_stream_info(
                 duplicated_stream = stream_list[pv_names[pv_name] - 1]
                 new_stream_converter = {
                     "schema": writer_module,
-                    "topic": stream["topic"],
+                    "topic": node["topic"][()],
                 }
                 if isinstance(duplicated_stream["converter"], list):
                     duplicated_stream["converter"].append(new_stream_converter)
@@ -59,4 +51,19 @@ def _extract_forwarder_stream_info(
                         duplicated_stream["converter"],
                         new_stream_converter,
                     ]
+
+    root.visititems(find_streams)
     return stream_list
+
+
+def generate_forwarder_command(
+    output_file: TextIO, root: h5py.Group, provider_type: str
+):
+    """
+    Generate a forwarder command containing a list of PVs and which topics to route them to.
+    :param output_file: file object to write the JSON output to.
+    :param streams: dictionary of stream objects.
+    :param provider_type: whether to use channel access or pv access protocol
+    """
+    tree_dict = {"streams": find_forwarder_streams(root, provider_type)}
+    object_to_json_file(tree_dict, output_file)

--- a/nexus_constructor/json/helpers.py
+++ b/nexus_constructor/json/helpers.py
@@ -1,4 +1,7 @@
 import json
+from typing import Dict, Any, List, Tuple
+
+import h5py
 import numpy as np
 
 
@@ -22,3 +25,19 @@ def object_to_json_file(tree_dict, file):
     """
 
     json.dump(tree_dict, file, indent=2, sort_keys=False, default=handle_non_std_types)
+
+
+def _separate_dot_field_group_hierarchy(
+    item_dict: Dict[Any, Any],
+    dots_in_field_name: List[str],
+    item: Tuple[str, h5py.Group],
+):
+    previous_group = item_dict
+    for subgroup in dots_in_field_name:
+        # do not overwrite a group unless it doesn't yet exist
+        if subgroup not in previous_group:
+            previous_group[subgroup] = dict()
+        if subgroup == dots_in_field_name[-1]:
+            # set the value of the field to the last item in the list
+            previous_group[subgroup] = item[1][...][()]
+        previous_group = previous_group[subgroup]

--- a/nexus_constructor/json/helpers.py
+++ b/nexus_constructor/json/helpers.py
@@ -10,7 +10,7 @@ def handle_non_std_types(value):
         return bool(value)
     elif type(value) is np.ndarray:
         return list(value)
-    elif type(value) is np.int8:
+    elif type(value) is np.int8 or type(value) is np.int64:
         return int(value)
     raise (TypeError("Unknown type: {}".format(type(value))))
 
@@ -39,5 +39,5 @@ def _separate_dot_field_group_hierarchy(
             previous_group[subgroup] = dict()
         if subgroup == dots_in_field_name[-1]:
             # set the value of the field to the last item in the list
-            previous_group[subgroup] = item[1][...][()]
+            previous_group[subgroup] = item[...][()]
         previous_group = previous_group[subgroup]

--- a/nexus_constructor/json/helpers.py
+++ b/nexus_constructor/json/helpers.py
@@ -1,7 +1,5 @@
 import json
-from typing import Dict, Any, List, Tuple
 
-import h5py
 import numpy as np
 
 
@@ -25,19 +23,3 @@ def object_to_json_file(tree_dict, file):
     """
 
     json.dump(tree_dict, file, indent=2, sort_keys=False, default=handle_non_std_types)
-
-
-def _separate_dot_field_group_hierarchy(
-    item_dict: Dict[Any, Any],
-    dots_in_field_name: List[str],
-    item: Tuple[str, h5py.Group],
-):
-    previous_group = item_dict
-    for subgroup in dots_in_field_name:
-        # do not overwrite a group unless it doesn't yet exist
-        if subgroup not in previous_group:
-            previous_group[subgroup] = dict()
-        if subgroup == dots_in_field_name[-1]:
-            # set the value of the field to the last item in the list
-            previous_group[subgroup] = item[...][()]
-        previous_group = previous_group[subgroup]

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -342,7 +342,6 @@ class MainWindow(Ui_MainWindow, QMainWindow):
                     file,
                     nexus_file_name=nexus_file_name,
                     broker=broker,
-                    links=self.instrument.get_links(),
                     start_time=start_time,
                     stop_time=stop_time,
                     service_id=service_id,

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -342,7 +342,6 @@ class MainWindow(Ui_MainWindow, QMainWindow):
                     file,
                     nexus_file_name=nexus_file_name,
                     broker=broker,
-                    streams=self.instrument.get_streams(),
                     links=self.instrument.get_links(),
                     start_time=start_time,
                     stop_time=stop_time,
@@ -365,9 +364,7 @@ class MainWindow(Ui_MainWindow, QMainWindow):
             if ok_pressed:
                 with open(filename, "w") as file:
                     nexus_constructor.json.forwarder_json_writer.generate_forwarder_command(
-                        file,
-                        streams=self.instrument.get_streams(),
-                        provider_type=provider_type,
+                        file, self.instrument.nexus.entry, provider_type=provider_type
                     )
 
     def open_nexus_file(self):

--- a/nexus_constructor/nexus/nexus_wrapper.py
+++ b/nexus_constructor/nexus/nexus_wrapper.py
@@ -3,7 +3,7 @@ import uuid
 
 import h5py
 from PySide2.QtCore import Signal, QObject
-from typing import Any, TypeVar, Optional, List
+from typing import Any, TypeVar, Optional, List, Dict, Tuple, Union
 import numpy as np
 
 from nexus_constructor.invalid_field_names import INVALID_FIELD_NAMES
@@ -83,6 +83,57 @@ def get_fields(
             ):
                 stream_fields.append(item)
     return scalar_fields, array_fields, stream_fields, link_fields
+
+
+def _separate_dot_field_group_hierarchy(
+    item_dict: Dict[Any, Any],
+    dots_in_field_name: List[str],
+    item: Tuple[str, h5py.Group],
+):
+    previous_group = item_dict
+    for subgroup in dots_in_field_name:
+        # do not overwrite a group unless it doesn't yet exist
+        if subgroup not in previous_group:
+            previous_group[subgroup] = dict()
+        if subgroup == dots_in_field_name[-1]:
+            # set the value of the field to the last item in the list
+            previous_group[subgroup] = _handle_stream_dataset(item[1][...])
+        previous_group = previous_group[subgroup]
+
+
+def _handle_stream_dataset(stream_dataset: h5py.Dataset) -> Union[str, bool, int]:
+    if stream_dataset.dtype == h5py.special_dtype(vlen=str):
+        return str(stream_dataset)
+    if stream_dataset.dtype == bool:
+        return bool(stream_dataset)
+    if stream_dataset.dtype == int:
+        return int(stream_dataset)
+
+
+def get_streams(root) -> Dict[str, Dict[str, str]]:
+    """
+    Find all streams and return them in the expected format for JSON serialisiation.
+    :return: A dictionary of stream groups, with their respective field names and values.
+    """
+    streams_dict = dict()
+
+    def find_streams(_, node):
+        if isinstance(node, h5py.Group):
+            if "NX_class" in node.attrs:
+                if node.attrs["NX_class"] == "NCstream":
+                    item_dict = dict()
+                    for name, item in node.items():
+                        dots_in_field_name = name.split(".")
+                        if len(dots_in_field_name) > 1:
+                            _separate_dot_field_group_hierarchy(
+                                item_dict, dots_in_field_name, item
+                            )
+                        else:
+                            item_dict[name] = _handle_stream_dataset(item[...])
+                    streams_dict[node.name] = item_dict
+
+    root.visititems(find_streams)
+    return streams_dict
 
 
 class NexusWrapper(QObject):

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -70,41 +70,6 @@ def test_GIVEN_instrument_with_component_WHEN_component_is_removed_THEN_componen
     )
 
 
-def test_GIVEN_instrument_with_one_stream_WHEN_finding_streams_THEN_streams_dictionary_is_populated():
-    wrapper = NexusWrapper("test_streams")
-    instrument = Instrument(wrapper, DEFINITIONS_DIR)
-
-    component_type = "NCstream"
-    name = "test_crystal"
-    description = "shiny"
-    test_component = instrument.create_component(name, component_type, description)
-
-    topic_field_name = "topic"
-    topic_name = "something"
-
-    test_component.group.create_dataset(name=topic_field_name, data=topic_name)
-    streams_dict = instrument.get_streams()
-
-    assert streams_dict[test_component.absolute_path][topic_field_name] == topic_name
-
-
-def test_GIVEN_instrument_with_stream_with_incorrect_nx_class_for_stream_WHEN_finding_streams_THEN_streams_dictionary_is_empty():
-    wrapper = NexusWrapper("test_streams_none")
-    instrument = Instrument(wrapper, DEFINITIONS_DIR)
-
-    component_type = "NXcrystal"
-    name = "test_crystal"
-    description = "shiny"
-    test_component = instrument.create_component(name, component_type, description)
-
-    topic_field_name = "topic"
-    topic_name = "something"
-
-    test_component.group.create_dataset(name=topic_field_name, data=topic_name)
-    streams_dict = instrument.get_streams()
-    assert not streams_dict
-
-
 def test_dependents_list_is_created_by_instrument():
     """
     The dependents list for transforms is stored in the "dependent_of" attribute,
@@ -144,47 +109,3 @@ def test_dependents_list_is_created_by_instrument():
     assert (
         len(transform_2_loaded.get_dependents()) == 2
     ), "Expected transform 2 to have 2 registered dependents (transforms 3 and 4)"
-
-
-def test_GIVEN_dot_separated_field_name_WHEN_getting_streams_THEN_dict_is_returned_with_correct_structure():
-    wrapper = NexusWrapper("test_streams_dict")
-    inst = Instrument(wrapper, DEFINITIONS_DIR)
-
-    streams_group = wrapper.entry.create_group("streams")
-    streams_group.attrs["NX_class"] = "NCstream"
-
-    name = "nexus.indices.index_every_mb"
-    val = 1000
-
-    streams_group.create_dataset(name=name, dtype=int, data=val)
-
-    streams = inst.get_streams()
-
-    assert "nexus" in streams["/entry/streams"]
-    assert "indices" in streams["/entry/streams"]["nexus"]
-    assert streams["/entry/streams"]["nexus"]["indices"]["index_every_mb"] == val
-
-
-def test_GIVEN_several_dot_separated_field_names_with_similar_prefixes_WHEN_getting_streams_THEN_dict_is_returned_with_correct_structure():
-    wrapper = NexusWrapper("test_streams_dict_multiple")
-    inst = Instrument(wrapper, DEFINITIONS_DIR)
-
-    streams_group = wrapper.entry.create_group("streams")
-    streams_group.attrs["NX_class"] = "NCstream"
-
-    name = "nexus.indices.index_every_mb"
-    val = 1000
-
-    streams_group.create_dataset(name=name, dtype=int, data=val)
-
-    name2 = "nexus.indices.index_every_kb"
-    val2 = 2000
-
-    streams_group.create_dataset(name=name2, dtype=int, data=val2)
-
-    streams = inst.get_streams()
-
-    assert "nexus" in streams["/entry/streams"]
-    assert "indices" in streams["/entry/streams"]["nexus"]
-    assert streams["/entry/streams"]["nexus"]["indices"]["index_every_mb"] == val
-    assert streams["/entry/streams"]["nexus"]["indices"]["index_every_kb"] == val2

--- a/tests/test_json_writer.py
+++ b/tests/test_json_writer.py
@@ -477,27 +477,39 @@ def test_GIVEN_string_list_WHEN_getting_data_and_type_THEN_returns_correct_dtype
     assert size == (len(dataset_value),)
 
 
-def test_GIVEN_stream_with_no_forwarder_streams_WHEN_generating_forwarder_command_THEN_output_does_not_contain_any_pvs():
-    streams = {
-        "stream1": {"writer_module": "ev42", "source": "source1", "topic": "topic1"}
-    }
+def test_GIVEN_stream_with_no_forwarder_streams_WHEN_generating_forwarder_command_THEN_output_does_not_contain_any_pvs(
+    file
+):
+    group_name = "test_group"
+    group = file.create_group(group_name)
+    group.attrs["NX_class"] = "NCstream"
+
+    group.create_dataset("writer_module", data="ev42")
+    group.create_dataset("source", data="source1")
+    group.create_dataset("topic", data="topic1")
 
     dummy_file = io.StringIO()
-    generate_forwarder_command(dummy_file, streams, "ca")
+    generate_forwarder_command(dummy_file, file, "ca")
 
     assert not literal_eval(dummy_file.getvalue())["streams"]
 
 
-def test_GIVEN_stream_with_f142_command_WHEN_generating_forwarder_command_THEN_output_contains_pv():
+def test_GIVEN_stream_with_f142_command_WHEN_generating_forwarder_command_THEN_output_contains_pv(
+    file
+):
     pv_name = "pv1"
-    topic = "localhost:9092/someTopic"
+    topic = "someTopic"
     writer_module = "f142"
-    streams = {
-        "stream1": {"writer_module": writer_module, "source": pv_name, "topic": topic}
-    }
+    group_name = "test_group"
+    group = file.create_group(group_name)
+    group.attrs["NX_class"] = "NCstream"
+
+    group.create_dataset("writer_module", data=writer_module)
+    group.create_dataset("topic", data=topic)
+    group.create_dataset("source", data=pv_name)
 
     dummy_file = io.StringIO()
-    generate_forwarder_command(dummy_file, streams, "ca")
+    generate_forwarder_command(dummy_file, file, "ca")
 
     streams_ = literal_eval(dummy_file.getvalue())["streams"]
     assert len(streams_) == 1

--- a/tests/test_json_writer.py
+++ b/tests/test_json_writer.py
@@ -574,7 +574,9 @@ def test_GIVEN_stream_with_tdc_command_WHEN_generating_forwarder_command_THEN_ou
     assert streams_[0]["converter"]["schema"] == writer_module
 
 
-def test_GIVEN_stream_with_one_pv_with_two_topics_WHEN_generating_forwarder_command_THEN_contains_one_converter_with_list():
+def test_GIVEN_stream_with_one_pv_with_two_topics_WHEN_generating_forwarder_command_THEN_contains_one_converter_with_list(
+    file
+):
     pv_name = "testPV"
 
     topic1 = "topic1"
@@ -582,13 +584,20 @@ def test_GIVEN_stream_with_one_pv_with_two_topics_WHEN_generating_forwarder_comm
 
     writer_module = "f142"
 
-    streams = {
-        "stream1": {"writer_module": writer_module, "source": pv_name, "topic": topic1},
-        "stream2": {"writer_module": writer_module, "source": pv_name, "topic": topic2},
-    }
+    group = file.create_group("test_group")
+    group.attrs["NX_class"] = "NCstream"
+    group.create_dataset("writer_module", data=writer_module)
+    group.create_dataset("source", data=pv_name)
+    group.create_dataset("topic", data=topic1)
+
+    group2 = file.create_group("test_group2")
+    group2.attrs["NX_class"] = "NCstream"
+    group2.create_dataset("writer_module", data=writer_module)
+    group2.create_dataset("topic", data=topic2)
+    group2.create_dataset("source", data=pv_name)
 
     dummy_file = io.StringIO()
-    generate_forwarder_command(dummy_file, streams, "ca")
+    generate_forwarder_command(dummy_file, file, "ca")
 
     streams_ = literal_eval(dummy_file.getvalue())["streams"]
 
@@ -600,7 +609,9 @@ def test_GIVEN_stream_with_one_pv_with_two_topics_WHEN_generating_forwarder_comm
     assert streams_[0]["converter"][1]["topic"] == topic2
 
 
-def test_GIVEN_stream_with_pv_forwarding_to_three_topics_WHEN_generating_forwarder_command_THEN_stream_is_added_to_converters():
+def test_GIVEN_stream_with_pv_forwarding_to_three_topics_WHEN_generating_forwarder_command_THEN_stream_is_added_to_converters(
+    file
+):
     pv_name = "testPV"
 
     topic1 = "topic1"
@@ -609,14 +620,26 @@ def test_GIVEN_stream_with_pv_forwarding_to_three_topics_WHEN_generating_forward
 
     writer_module = "f142"
 
-    streams = {
-        "stream1": {"writer_module": writer_module, "source": pv_name, "topic": topic1},
-        "stream2": {"writer_module": writer_module, "source": pv_name, "topic": topic2},
-        "stream3": {"writer_module": writer_module, "source": pv_name, "topic": topic3},
-    }
+    group = file.create_group("test_group")
+    group.attrs["NX_class"] = "NCstream"
+    group.create_dataset("writer_module", data=writer_module)
+    group.create_dataset("source", data=pv_name)
+    group.create_dataset("topic", data=topic1)
+
+    group2 = file.create_group("test_group2")
+    group2.attrs["NX_class"] = "NCstream"
+    group2.create_dataset("writer_module", data=writer_module)
+    group2.create_dataset("topic", data=topic2)
+    group2.create_dataset("source", data=pv_name)
+
+    group3 = file.create_group("test_group3")
+    group3.attrs["NX_class"] = "NCstream"
+    group3.create_dataset("writer_module", data=writer_module)
+    group3.create_dataset("topic", data=topic3)
+    group3.create_dataset("source", data=pv_name)
 
     dummy_file = io.StringIO()
-    generate_forwarder_command(dummy_file, streams, "pva")
+    generate_forwarder_command(dummy_file, file, "pva")
 
     streams_ = literal_eval(dummy_file.getvalue())["streams"]
 

--- a/tests/test_json_writer.py
+++ b/tests/test_json_writer.py
@@ -12,7 +12,7 @@ from nexus_constructor.json.filewriter_json_writer import (
     create_writer_commands,
     generate_json,
     _add_attributes,
-    ATTR_BLACKLIST,
+    ATTR_NAME_BLACKLIST,
 )
 from nexus_constructor.json.helpers import object_to_json_file
 from nexus_constructor.json.forwarder_json_writer import generate_forwarder_command
@@ -250,17 +250,15 @@ def test_GIVEN_stream_in_group_children_WHEN_handling_group_THEN_stream_is_appen
         "array_size": 32,
     }
 
+    for name, value in group_contents.items():
+        group.create_dataset(name, data=value)
+
     converter = NexusToDictConverter()
     root_dict = converter.convert(file, {})
 
     assert group_name == root_dict["children"][0]["name"]
     assert group_contents == root_dict["children"][0]["children"][0]["stream"]
-    assert "NX_class" not in [
-        item["name"] for item in root_dict["children"][0]["attributes"]
-    ]
-    assert "NCstream" not in [
-        item["values"] for item in root_dict["children"][0]["attributes"]
-    ]
+    assert "attributes" not in root_dict["children"][0]
 
 
 def test_GIVEN_link_in_group_children_WHEN_handling_group_THEN_link_is_appended_to_children(
@@ -660,7 +658,7 @@ def test_GIVEN_attribute_in_blacklist_WHEN_adding_attributes_THEN_attrs_is_blank
     root_dict = dict()
     dataset_name = "test"
     dataset = file.create_dataset(dataset_name, data=123)
-    attr_key = ATTR_BLACKLIST[0]
+    attr_key = ATTR_NAME_BLACKLIST[0]
     attr_value = "some_value"
     dataset.attrs[attr_key] = attr_value
     _add_attributes(dataset, root_dict)

--- a/tests/test_json_writer.py
+++ b/tests/test_json_writer.py
@@ -518,17 +518,29 @@ def test_GIVEN_stream_with_f142_command_WHEN_generating_forwarder_command_THEN_o
     assert streams_[0]["converter"]["schema"] == writer_module
 
 
-def test_GIVEN_stream_with_f142_command_and_non_forwarder_modules_THEN_only_f142_is_contained():
+def test_GIVEN_stream_with_f142_command_and_non_forwarder_modules_THEN_only_f142_is_contained(
+    file
+):
+
+    group = file.create_group("test_group")
+    group.attrs["NX_class"] = "NCstream"
+
+    group.create_dataset("writer_module", data="ev42")
+    group.create_dataset("source", data="source1")
+    group.create_dataset("topic", data="topic1")
+
+    group2 = file.create_group("test_group2")
+    group2.attrs["NX_class"] = "NCstream"
+
     pv_name = "pv1"
     topic = "localhost:9092/someTopic"
     writer_module = "f142"
-    streams = {
-        "stream1": {"writer_module": writer_module, "source": pv_name, "topic": topic},
-        "stream2": {"writer_module": "ev42", "source": "source1", "topic": "topic1"},
-    }
+    group2.create_dataset("writer_module", data=writer_module)
+    group2.create_dataset("topic", data=topic)
+    group2.create_dataset("source", data=pv_name)
 
     dummy_file = io.StringIO()
-    generate_forwarder_command(dummy_file, streams, "ca")
+    generate_forwarder_command(dummy_file, file, "ca")
 
     streams_ = literal_eval(dummy_file.getvalue())["streams"]
     assert len(streams_) == 1
@@ -537,16 +549,23 @@ def test_GIVEN_stream_with_f142_command_and_non_forwarder_modules_THEN_only_f142
     assert streams_[0]["converter"]["schema"] == writer_module
 
 
-def test_GIVEN_stream_with_tdc_command_WHEN_generating_forwarder_command_THEN_output_contains_pv():
+def test_GIVEN_stream_with_tdc_command_WHEN_generating_forwarder_command_THEN_output_contains_pv(
+    file
+):
     pv_name = "tdcpv1"
     topic = "localhost:9092/someOtherTopic"
     writer_module = "TdcTime"
-    streams = {
-        "stream1": {"writer_module": writer_module, "source": pv_name, "topic": topic}
-    }
+
+    group_name = "test_group"
+    group = file.create_group(group_name)
+    group.attrs["NX_class"] = "NCstream"
+
+    group.create_dataset("writer_module", data=writer_module)
+    group.create_dataset("topic", data=topic)
+    group.create_dataset("source", data=pv_name)
 
     dummy_file = io.StringIO()
-    generate_forwarder_command(dummy_file, streams, "pva")
+    generate_forwarder_command(dummy_file, file, "pva")
 
     streams_ = literal_eval(dummy_file.getvalue())["streams"]
     assert len(streams_) == 1

--- a/tests/test_json_writer.py
+++ b/tests/test_json_writer.py
@@ -13,6 +13,7 @@ from nexus_constructor.json.filewriter_json_writer import (
     generate_json,
     _add_attributes,
     ATTR_NAME_BLACKLIST,
+    get_data_and_type,
 )
 from nexus_constructor.json.helpers import object_to_json_file
 from nexus_constructor.json.forwarder_json_writer import generate_forwarder_command
@@ -29,9 +30,7 @@ def test_GIVEN_float32_WHEN_getting_data_and_dtype_THEN_function_returns_correct
 
     dataset = file.create_dataset("test_dataset", dtype="float32", data=expected_value)
 
-    converter = NexusToDictConverter()
-
-    data, dtype, size = converter._get_data_and_type(dataset)
+    data, dtype, size = get_data_and_type(dataset)
 
     assert size == expected_size
     assert dtype == expected_dtype
@@ -47,9 +46,7 @@ def test_GIVEN_float64_WHEN_getting_data_and_dtype_THEN_function_returns_correct
 
     dataset = file.create_dataset("test_dataset", dtype=np.float64, data=expected_value)
 
-    converter = NexusToDictConverter()
-
-    data, dtype, size = converter._get_data_and_type(dataset)
+    data, dtype, size = get_data_and_type(dataset)
 
     assert size == expected_size
     assert dtype == expected_dtype
@@ -65,9 +62,7 @@ def test_GIVEN_int32_WHEN_getting_data_and_dtype_THEN_function_returns_correct_f
 
     dataset = file.create_dataset("test_dataset", dtype="int32", data=expected_value)
 
-    converter = NexusToDictConverter()
-
-    data, dtype, size = converter._get_data_and_type(dataset)
+    data, dtype, size = get_data_and_type(dataset)
 
     assert size == expected_size
     assert dtype == expected_dtype
@@ -83,9 +78,7 @@ def test_GIVEN_int64_WHEN_getting_data_and_dtype_THEN_function_returns_correct_f
 
     dataset = file.create_dataset("test_dataset", dtype="int64", data=expected_value)
 
-    converter = NexusToDictConverter()
-
-    data, dtype, size = converter._get_data_and_type(dataset)
+    data, dtype, size = get_data_and_type(dataset)
 
     assert size == expected_size
     assert dtype == expected_dtype
@@ -101,9 +94,7 @@ def test_GIVEN_single_string_WHEN_getting_data_and_dtype_THEN_function_returns_c
 
     dataset = file.create_dataset("test_dataset", data=expected_value, dtype="S5")
 
-    converter = NexusToDictConverter()
-
-    data, dtype, size = converter._get_data_and_type(dataset)
+    data, dtype, size = get_data_and_type(dataset)
 
     assert size == expected_size
     assert dtype == expected_dtype
@@ -117,8 +108,7 @@ def test_GIVEN_array_WHEN_getting_data_and_dtype_THEN_function_returns_correcte_
     expected_values = [1.1, 1.2, 1.3]
 
     dataset = file.create_dataset("test_dataset", data=expected_values, dtype="float32")
-    converter = NexusToDictConverter()
-    data, dtype, size = converter._get_data_and_type(dataset)
+    data, dtype, size = get_data_and_type(dataset)
 
     assert size == (len(expected_values),)
     assert np.allclose(data, expected_values)
@@ -139,7 +129,7 @@ def test_GIVEN_nx_class_and_attributes_are_bytes_WHEN_output_to_json_THEN_they_a
     dataset.attrs["string_attr"] = test_string_attr
 
     converter = NexusToDictConverter()
-    root_dict = converter.convert(file, {})
+    root_dict = converter.convert(file)
 
     ds = root_dict["children"][0]
 
@@ -164,7 +154,7 @@ def test_GIVEN_dataset_with_an_attribute_WHEN_output_to_json_THEN_attribute_is_p
     dataset.attrs[test_attr_name] = test_input
 
     converter = NexusToDictConverter()
-    root_dict = converter.convert(file, {})
+    root_dict = converter.convert(file)
 
     ds = root_dict["children"][0]
 
@@ -185,7 +175,7 @@ def test_GIVEN_dataset_with_an_array_attribute_WHEN_output_to_json_THEN_attribut
     dataset.attrs[test_attr_name] = test_input
 
     converter = NexusToDictConverter()
-    root_dict = converter.convert(file, {})
+    root_dict = converter.convert(file)
 
     ds = root_dict["children"][0]
 
@@ -204,7 +194,7 @@ def test_GIVEN_single_value_WHEN_handling_dataset_THEN_size_field_does_not_exist
     dataset.attrs["NX_class"] = "NXpinhole"
 
     converter = NexusToDictConverter()
-    root_dict = converter.convert(file, {})
+    root_dict = converter.convert(file)
 
     ds = root_dict["children"][0]
 
@@ -225,7 +215,7 @@ def test_GIVEN_multiple_values_WHEN_handling_dataset_THEN_size_field_does_exist_
     dataset.attrs["NX_class"] = "NXpinhole"
 
     converter = NexusToDictConverter()
-    root_dict = converter.convert(file, {})
+    root_dict = converter.convert(file)
     ds = root_dict["children"][0]
 
     assert ds["name"].lstrip("/") == dataset_name
@@ -254,7 +244,7 @@ def test_GIVEN_stream_in_group_children_WHEN_handling_group_THEN_stream_is_appen
         group.create_dataset(name, data=value)
 
     converter = NexusToDictConverter()
-    root_dict = converter.convert(file, {})
+    root_dict = converter.convert(file)
 
     assert group_name == root_dict["children"][0]["name"]
     assert group_contents == root_dict["children"][0]["children"][0]["stream"]
@@ -264,43 +254,50 @@ def test_GIVEN_stream_in_group_children_WHEN_handling_group_THEN_stream_is_appen
 def test_GIVEN_link_in_group_children_WHEN_handling_group_THEN_link_is_appended_to_children(
     file
 ):
+    root_group = file.create_group("root")
+
     group_to_be_linked_name = "test_linked_group"
-    group_to_be_linked = file.create_group(group_to_be_linked_name)
+    group_to_be_linked = root_group.create_group(group_to_be_linked_name)
     group_to_be_linked.attrs["NX_class"] = "NXgroup"
 
     group_name = "test_group_with_link"
-    file[group_name] = h5py.SoftLink(group_to_be_linked.name)
-    file[group_name].attrs["NX_class"] = "NXgroup"
+    root_group[group_name] = h5py.SoftLink(group_to_be_linked.name)
+    root_group[group_name].attrs["NX_class"] = "NXgroup"
 
     converter = NexusToDictConverter()
-    root_dict = converter.convert(
-        file, links={file[group_name].name: group_to_be_linked}
-    )
+    root_dict = converter.convert(file)
 
-    assert root_dict["children"][0]["type"] == "link"
-    assert file[group_name].name.split("/")[-1] == root_dict["children"][0]["name"]
-    assert group_to_be_linked.name == root_dict["children"][0]["target"]
+    assert root_dict["children"][0]["children"][0]["type"] == "link"
+    assert (
+        root_group[group_name].name.split("/")[-1]
+        == root_dict["children"][0]["children"][0]["name"]
+    )
+    assert group_to_be_linked.name == root_dict["children"][0]["children"][0]["target"]
 
 
 def test_GIVEN_link_in_group_children_that_is_a_dataset_WHEN_handling_group_THEN_link_is_appended_to_children(
     file
 ):
+    root_group = file.create_group("root")
     ds_to_be_linked_name = "test_linked_dataset"
-    dataset_to_be_linked = file.create_dataset(ds_to_be_linked_name, data=1)
+    dataset_to_be_linked = root_group.create_dataset(ds_to_be_linked_name, data=1)
     dataset_to_be_linked.attrs["NX_class"] = "NXgroup"
 
     group_name = "test_group_with_link"
-    file[group_name] = h5py.SoftLink(dataset_to_be_linked.name)
-    file[group_name].attrs["NX_class"] = "NXgroup"
+    root_group[group_name] = h5py.SoftLink(dataset_to_be_linked.name)
+    root_group[group_name].attrs["NX_class"] = "NXgroup"
 
     converter = NexusToDictConverter()
-    root_dict = converter.convert(
-        file, links={file[group_name].name: dataset_to_be_linked}
-    )
+    root_dict = converter.convert(file)
 
-    assert root_dict["children"][0]["type"] == "link"
-    assert file[group_name].name.split("/")[-1] == root_dict["children"][0]["name"]
-    assert dataset_to_be_linked.name == root_dict["children"][0]["target"]
+    assert root_dict["children"][0]["children"][0]["type"] == "link"
+    assert (
+        root_group[group_name].name.split("/")[-1]
+        == root_dict["children"][0]["children"][0]["name"]
+    )
+    assert (
+        dataset_to_be_linked.name == root_dict["children"][0]["children"][0]["target"]
+    )
 
 
 def test_GIVEN_group_with_multiple_attributes_WHEN_converting_nexus_to_dict_THEN_attributes_end_up_in_file(
@@ -327,7 +324,7 @@ def test_GIVEN_group_with_multiple_attributes_WHEN_converting_nexus_to_dict_THEN
     field2.attrs["NX_class"] = "NXfield"
 
     converter = NexusToDictConverter()
-    root_dict = converter.convert(file, links={})
+    root_dict = converter.convert(file)
 
     assert group.name.split("/")[-1] == root_dict["children"][0]["name"]
 
@@ -442,8 +439,7 @@ def test_GIVEN_float64_WHEN_getting_data_and_type_THEN_returns_correct_dtype(fil
     dataset_value = np.float64(2.123)
 
     dataset = file.create_dataset(dataset_name, dtype=dataset_type, data=dataset_value)
-    converter = NexusToDictConverter()
-    data, dtype, size = converter._get_data_and_type(dataset)
+    data, dtype, size = get_data_and_type(dataset)
 
     assert data == dataset_value
     assert dtype == "double"
@@ -456,8 +452,7 @@ def test_GIVEN_float_WHEN_getting_data_and_type_THEN_returns_correct_dtype(file)
     dataset_value = np.float32(2.123)
 
     dataset = file.create_dataset(dataset_name, dtype=dataset_type, data=dataset_value)
-    converter = NexusToDictConverter()
-    data, dtype, size = converter._get_data_and_type(dataset)
+    data, dtype, size = get_data_and_type(dataset)
 
     assert data == dataset_value
     assert dtype == "float"
@@ -469,9 +464,8 @@ def test_GIVEN_string_list_WHEN_getting_data_and_type_THEN_returns_correct_dtype
     dataset_value = np.string_(["s", "t", "r"])
 
     dataset = file.create_dataset(dataset_name, data=dataset_value)
-    converter = NexusToDictConverter()
 
-    data, dtype, size = converter._get_data_and_type(dataset)
+    data, dtype, size = get_data_and_type(dataset)
 
     assert data == [x.decode("ASCII") for x in list(dataset_value)]
     assert size == (len(dataset_value),)


### PR DESCRIPTION
### Issue

Closes #604 

### Description of work
Refactored out some of the stuff that finds streams as there was some duplication going on and I think it should be more streamlined. Previously, you had to pass two dictionaries containing links and streams to the JSON writer. This was duplication, as these could be found from the root object passed to that method anyway. I have removed this and made it flow a bit nicer, and it should make the interface nicer to use. 

I have added a test that makes sure NCstream is not added to the nx_class attributes so this can be overwritten by the writer module. 

### Acceptance Criteria 

- Refactored `_handle_stream()` and `_handle_links()` in json writer 
- Removed `get_streams()` and `get_links()` from `instrument.py`
- Refactored finding forwarder streams into the forwarder JSON writer and hopefully making the code that does this a bit more readable 
- Hopefully made the code more easy to understand? 

### UI tests

None modified as no UI changes. 

### Nominate for Group Code Review

- [ ] Nominate for code review 
