### PR TITLE
576: Axis direction becomes zero when editing a cylinder with no height

### DIFF
--- a/nexus_constructor/geometry/cylindrical_geometry.py
+++ b/nexus_constructor/geometry/cylindrical_geometry.py
@@ -132,9 +132,17 @@ class CylindricalGeometry:
 
     @property
     def axis_direction(self) -> QVector3D:
-        base_centre, _, top_centre = self._get_cylinder_vertices()
-        cylinder_axis = top_centre - base_centre
-        return cylinder_axis.normalized()
+        """
+        Finds the axis direction using the base centre and top centre if the height is non-zero, otherwise it just
+        returns a default value of (0,0,1).
+        :return: The axis direction vector.
+        """
+        if self.height != 0:
+            base_centre, _, top_centre = self._get_cylinder_vertices()
+            cylinder_axis = top_centre - base_centre
+            return cylinder_axis.normalized()
+
+        return QVector3D(0, 0, 1)
 
     @property
     def off_geometry(self, steps: int = 20) -> OFFGeometry:

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -744,3 +744,18 @@ def test_GIVEN_component_with_pixel_grid_WHEN_removing_pixel_data_THEN_pixel_gri
     assert component.get_field("x_pixel_offset") is None
     assert component.get_field("y_pixel_offset") is None
     assert component.get_field("z_pixel_offset") is None
+
+
+def test_GIVEN_cylinder_with_height_of_zero_WHEN_getting_axis_direction_THEN_default_value_is_returned(
+    component, nexus_wrapper
+):
+
+    axis_x = 1.0
+    axis_y = 0.0
+    axis_z = 0.0
+    axis = QVector3D(axis_x, axis_y, axis_z)
+    height = 0
+    radius = 37.0
+
+    component.set_cylinder_shape(axis, height, radius)
+    assert component.shape[0].axis_direction == QVector3D(0, 0, 1)


### PR DESCRIPTION
### Issue

Improves #576 

### Description of work

Makes the `axis_direction` property return a default value when the `height` of a cylinder is zero. 

### Acceptance Criteria 

Check that the tests pass. Create a cylinder with zero height then edit it and check that the axis direction is (0,0,1).

### UI tests

*How you have updated the UI tests document to fit your changes*

### Nominate for Group Code Review

- [ ] Nominate for code review 
