### PR TITLE
Updating cx freeze to 6.1 - windows fixes

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@
 -r requirements.txt
 
 # Packaging
-git+https://github.com/anthony-tuininga/cx_Freeze@7566412ec2f1a6bf35312439cb1eca1e8e434a82
+cx-Freeze==6.1
 
 # newer versions of jsonschema don't work with the executables built by cx_Freeze
 jsonschema==2.6.0


### PR DESCRIPTION
### Issue

None

### Description of work

Updating cx freeze to version 6.1 - there was an [issue](https://github.com/anthony-tuininga/cx_Freeze/issues/504) with cx freeze that stopped qt from working on windows so we had to pin a commit in the requirements-dev.txt file, and since then 6.1 has released that includes [this fix](https://github.com/anthony-tuininga/cx_Freeze/pull/512). We have a test in the pipeline to check the executable still works. 

### Acceptance Criteria 

None

### UI tests

N/A

### Nominate for Group Code Review

- [ ] Nominate for code review 
