### PR TITLE
Update pyside to 5.14.0 as this fixes the icon size differences between linux and other platforms

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ numpy
 pytest-qt
 
 # PySide2 has had some issues with new versions and packaging so we will pin it
-PySide2==5.14.0
+PySide2==5.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ numpy
 pytest-qt
 
 # PySide2 has had some issues with new versions and packaging so we will pin it
-PySide2==5.13.0
+PySide2==5.14.0


### PR DESCRIPTION
### Issue

Closes #596 

### Description of work
Updating pyside to 5.14.0 seems to fix the icon size difference between Windows, Linux and MacOS. 

### Acceptance Criteria 

No functional changes. 
Check everything still works (most things should now be covered by UI tests)

### UI tests

N/A

### Nominate for Group Code Review

- [ ] Nominate for code review 
