### PR TITLE
re #621: relative path depends_on fix

### DIFF
--- a/nexus_constructor/nexus/nexus_wrapper.py
+++ b/nexus_constructor/nexus/nexus_wrapper.py
@@ -211,12 +211,18 @@ class NexusWrapper(QObject):
 
         for transform, dependee_of in transforms_dependee_of.items():
             try:
+                transform = transform.decode(
+                    "UTF-8"
+                )  # transform name is byte-string, so decode
+            except AttributeError:
+                pass  # transform name is already a string
+            try:
                 # numpy should cast to a scalar value if there is just one item.
                 # try and use an absolute path
                 set_dependee_of_attr(transform, dependee_of)
             except KeyError:
                 # try and use a relative path instead
-                path = f"{dependee_of[0]}/{transform.decode('UTF-8')}"
+                path = f"{dependee_of[0]}/{transform}"
                 set_dependee_of_attr(path, dependee_of)
 
     def duplicate_nx_group(

--- a/nexus_constructor/nexus/nexus_wrapper.py
+++ b/nexus_constructor/nexus/nexus_wrapper.py
@@ -205,10 +205,18 @@ class NexusWrapper(QObject):
             transforms_dependee_of[depends_on_transform].append(group_name)
 
         for transform, dependee_of in transforms_dependee_of.items():
-            # numpy should cast to a scalar value if there is just one item.
-            self.nexus_file[transform].attrs["dependee_of"] = np.array(
-                dependee_of, dtype=h5py.special_dtype(vlen=str)
-            )
+            try:
+                # numpy should cast to a scalar value if there is just one item.
+                # try and use an absolute path
+                self.nexus_file[transform].attrs["dependee_of"] = np.array(
+                    dependee_of, dtype=h5py.special_dtype(vlen=str)
+                )
+            except KeyError:
+                # try and use a relative path instead
+                path = f"{dependee_of[0]}/{transform.decode('UTF-8')}"
+                self.nexus_file[path].attrs["dependee_of"] = np.array(
+                    dependee_of, dtype=h5py.special_dtype(vlen=str)
+                )
 
     def duplicate_nx_group(
         self, group_to_duplicate: h5py.Group, new_group_name: str

--- a/nexus_constructor/nexus/nexus_wrapper.py
+++ b/nexus_constructor/nexus/nexus_wrapper.py
@@ -2,7 +2,7 @@ import logging
 import uuid
 import h5py
 from PySide2.QtCore import Signal, QObject
-from typing import Any, TypeVar, Optional
+from typing import Any, TypeVar, Optional, List
 import numpy as np
 
 h5Node = TypeVar("h5Node", h5py.Group, h5py.Dataset)
@@ -204,19 +204,20 @@ class NexusWrapper(QObject):
                 transforms_dependee_of[depends_on_transform] = []
             transforms_dependee_of[depends_on_transform].append(group_name)
 
+        def set_dependee_of_attr(path: str, dependee_of: List[str]):
+            self.nexus_file[path].attrs["dependee_of"] = np.array(
+                dependee_of, dtype=h5py.special_dtype(vlen=str)
+            )
+
         for transform, dependee_of in transforms_dependee_of.items():
             try:
                 # numpy should cast to a scalar value if there is just one item.
                 # try and use an absolute path
-                self.nexus_file[transform].attrs["dependee_of"] = np.array(
-                    dependee_of, dtype=h5py.special_dtype(vlen=str)
-                )
+                set_dependee_of_attr(transform, dependee_of)
             except KeyError:
                 # try and use a relative path instead
                 path = f"{dependee_of[0]}/{transform.decode('UTF-8')}"
-                self.nexus_file[path].attrs["dependee_of"] = np.array(
-                    dependee_of, dtype=h5py.special_dtype(vlen=str)
-                )
+                set_dependee_of_attr(path, dependee_of)
 
     def duplicate_nx_group(
         self, group_to_duplicate: h5py.Group, new_group_name: str

--- a/nexus_constructor/nexus/nexus_wrapper.py
+++ b/nexus_constructor/nexus/nexus_wrapper.py
@@ -200,6 +200,9 @@ class NexusWrapper(QObject):
 
         transforms_dependee_of = {}
         for group_name, depends_on_transform in component_depends_on.items():
+            if f"{group_name}/{depends_on_transform}" in self.nexus_file:
+                # depends_on is relative, change to an absolute path
+                depends_on_transform = f"{group_name}/{depends_on_transform}"
             if depends_on_transform not in transforms_dependee_of.keys():
                 transforms_dependee_of[depends_on_transform] = []
             transforms_dependee_of[depends_on_transform].append(group_name)

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -1,9 +1,8 @@
-import h5py
 from nexus_constructor.transformations import Transformation
 from nexus_constructor.instrument import _convert_name_with_spaces, Instrument
 from nexus_constructor.nexus.nexus_wrapper import NexusWrapper
 from tests.test_utils import NX_CLASS_DEFINITIONS
-from tests.helpers import file
+from tests.helpers import file  # noqa: F401
 
 
 def test_GIVEN_name_with_spaces_WHEN_converting_name_with_spaces_THEN_converts_spaces_in_name_to_underscores():
@@ -71,7 +70,7 @@ def test_GIVEN_instrument_with_component_WHEN_component_is_removed_THEN_componen
     )
 
 
-def test_dependents_list_is_created_by_instrument(file):
+def test_dependents_list_is_created_by_instrument(file):  # noqa: F811
     """
     The dependents list for transforms is stored in the "dependent_of" attribute,
     which is not part of the NeXus standard,
@@ -109,7 +108,9 @@ def test_dependents_list_is_created_by_instrument(file):
     ), "Expected transform 2 to have 2 registered dependents (transforms 3 and 4)"
 
 
-def test_dependent_is_created_by_instrument_if_depends_on_is_relative(file):
+def test_dependent_is_created_by_instrument_if_depends_on_is_relative(
+    file,  # noqa: F811
+):
     entry_group = file.create_group("entry")
     entry_group.attrs["NX_class"] = "NXentry"
     monitor_group = entry_group.create_group("monitor1")
@@ -126,7 +127,4 @@ def test_dependent_is_created_by_instrument_if_depends_on_is_relative(file):
     Instrument(nexus_wrapper, NX_CLASS_DEFINITIONS)
 
     transform_1_loaded = Transformation(nexus_wrapper, transform_1)
-    assert (
-        transform_1_loaded.dataset.attrs["dependee_of"][0]
-        == "/entry/monitor1"
-    )
+    assert transform_1_loaded.dataset.attrs["dependee_of"][0] == "/entry/monitor1"

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -3,6 +3,7 @@ from nexus_constructor.transformations import Transformation
 from nexus_constructor.instrument import _convert_name_with_spaces, Instrument
 from nexus_constructor.nexus.nexus_wrapper import NexusWrapper
 from tests.test_utils import NX_CLASS_DEFINITIONS
+from tests.helpers import file
 
 
 def test_GIVEN_name_with_spaces_WHEN_converting_name_with_spaces_THEN_converts_spaces_in_name_to_underscores():
@@ -70,7 +71,7 @@ def test_GIVEN_instrument_with_component_WHEN_component_is_removed_THEN_componen
     )
 
 
-def test_dependents_list_is_created_by_instrument():
+def test_dependents_list_is_created_by_instrument(file):
     """
     The dependents list for transforms is stored in the "dependent_of" attribute,
     which is not part of the NeXus standard,
@@ -79,10 +80,7 @@ def test_dependents_list_is_created_by_instrument():
     """
 
     # Create minimal test file with some transformations but no "dependent_of" attributes
-    in_memory_test_file = h5py.File(
-        "test_file", mode="x", driver="core", backing_store=False
-    )
-    entry_group = in_memory_test_file.create_group("entry")
+    entry_group = file.create_group("entry")
     entry_group.attrs["NX_class"] = "NXentry"
     instrument_group = entry_group.create_group("instrument")
     instrument_group.attrs["NX_class"] = "NXinstrument"
@@ -97,7 +95,7 @@ def test_dependents_list_is_created_by_instrument():
     transform_4.attrs["depends_on"] = transform_2.name
 
     nexus_wrapper = NexusWrapper("test_file_with_transforms")
-    nexus_wrapper.load_file(entry_group, in_memory_test_file)
+    nexus_wrapper.load_file(entry_group, file)
     Instrument(nexus_wrapper, NX_CLASS_DEFINITIONS)
 
     transform_1_loaded = Transformation(nexus_wrapper, transform_1)
@@ -109,3 +107,26 @@ def test_dependents_list_is_created_by_instrument():
     assert (
         len(transform_2_loaded.get_dependents()) == 2
     ), "Expected transform 2 to have 2 registered dependents (transforms 3 and 4)"
+
+
+def test_dependent_is_created_by_instrument_if_depends_on_is_relative(file):
+    entry_group = file.create_group("entry")
+    entry_group.attrs["NX_class"] = "NXentry"
+    monitor_group = entry_group.create_group("monitor1")
+    monitor_group.attrs["NX_class"] = "NXmonitor"
+
+    monitor_group.create_dataset("depends_on", data=b"transformations/translation1")
+
+    transformations_group = monitor_group.create_group("transformations")
+    transformations_group.attrs["NX_class"] = "NXtransformations"
+    transform_1 = transformations_group.create_dataset("translation1", data=1)
+
+    nexus_wrapper = NexusWrapper("test_file_with_transforms")
+    nexus_wrapper.load_file(entry_group, file)
+    Instrument(nexus_wrapper, NX_CLASS_DEFINITIONS)
+
+    transform_1_loaded = Transformation(nexus_wrapper, transform_1)
+    assert (
+        transform_1_loaded.dataset.attrs["dependee_of"][0]
+        == "/entry/monitor1"
+    )

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -130,7 +130,7 @@ def test_dependent_is_created_by_instrument_if_depends_on_is_relative(
     assert transform_1_loaded.dataset.attrs["dependee_of"][0] == "/entry/monitor1"
 
 
-def test_GIVEN_transformation_is_dependee_of_multiple_components_WHEN_one_depends_on_is_relative_and_another_is_absolute_THEN_dependee_of_contains_both_components(
+def test_dependee_of_contains_both_components_when_generating_dependee_of_chain_with_mixture_of_absolute_and_relative_paths(
     file,  # noqa: F811
 ):
     entry_group = file.create_group("entry")
@@ -142,10 +142,12 @@ def test_GIVEN_transformation_is_dependee_of_multiple_components_WHEN_one_depend
     component_a.attrs["NX_class"] = "NXaperture"
     transforms_group = component_a.create_group("Transforms1")
     transform_1 = transforms_group.create_dataset("transform1", data=1.0)
+    # Relative path to transform
     component_a.create_dataset("depends_on", data="Transforms1/transform1")
 
     component_b = instrument_group.create_group("b")
     component_b.attrs["NX_class"] = "NXaperture"
+    # Absolute path to transform
     component_b.create_dataset(
         "depends_on", data="/entry/instrument/a/Transforms1/transform1"
     )
@@ -154,5 +156,7 @@ def test_GIVEN_transformation_is_dependee_of_multiple_components_WHEN_one_depend
     nexus_wrapper.load_file(entry_group, file)
     Instrument(nexus_wrapper, NX_CLASS_DEFINITIONS)
     transform_1_loaded = Transformation(nexus_wrapper, transform_1)
+
+    # Check both relative and absolute are in dependee_of list
     assert component_a.name in transform_1_loaded.dataset.attrs["dependee_of"]
     assert component_b.name in transform_1_loaded.dataset.attrs["dependee_of"]


### PR DESCRIPTION
### Issue

Closes #621  

### Description of work

Fixes relative paths when generating dependee_of attribute for the UI to use. 
The `bigfake.nxs` file still has some issues loading but they are separate to this. This allows mostly everything to work in the UI. 

### Acceptance Criteria 

Added try/catch for relative + absolute paths in depends_on field
refactored method for setting the dependee_of attribute

### UI tests

None changed. 

### Nominate for Group Code Review

- [ ] Nominate for code review 
