### PR TITLE
Refactor common attribute/field names into class to avoid typos

### DIFF
--- a/nexus_constructor/common_attrs.py
+++ b/nexus_constructor/common_attrs.py
@@ -4,8 +4,8 @@ class CommonAttrs:
     """
 
     NX_CLASS = "NX_class"
-    DEPENDEE_OF = "dependee_of"
-    UI_VALUE = "ui_value"
+    DEPENDEE_OF = "NCdependee_of"
+    UI_VALUE = "NCui_value"
     DEPENDS_ON = "depends_on"
     TRANSFORMATION_TYPE = "transformation_type"
     VECTOR = "vector"

--- a/nexus_constructor/common_attrs.py
+++ b/nexus_constructor/common_attrs.py
@@ -11,3 +11,4 @@ class CommonAttrs:
     VECTOR = "vector"
     UNITS = "units"
     VERTICES = "vertices"
+    NC_STREAM = "NCstream"

--- a/nexus_constructor/common_attrs.py
+++ b/nexus_constructor/common_attrs.py
@@ -1,0 +1,13 @@
+class CommonAttrs:
+    """
+    Commonly used attribute and field names, used to avoid typos.
+    """
+
+    NX_CLASS = "NX_class"
+    DEPENDEE_OF = "dependee_of"
+    UI_VALUE = "ui_value"
+    DEPENDS_ON = "depends_on"
+    TRANSFORMATION_TYPE = "transformation_type"
+    VECTOR = "vector"
+    UNITS = "units"
+    VERTICES = "vertices"

--- a/nexus_constructor/component/component_factory.py
+++ b/nexus_constructor/component/component_factory.py
@@ -1,3 +1,4 @@
+from nexus_constructor.common_attrs import CommonAttrs
 from nexus_constructor.component.component import Component
 from nexus_constructor.component.chopper_shape import ChopperShape
 from nexus_constructor.component.pixel_shape import PixelShape
@@ -13,14 +14,14 @@ def create_component(
     nexus_wrapper: NexusWrapper, component_group: h5py.Group
 ) -> Component:
     if (
-        nexus_wrapper.get_attribute_value(component_group, "NX_class")
+        nexus_wrapper.get_attribute_value(component_group, CommonAttrs.NX_CLASS)
         == CHOPPER_CLASS_NAME
     ):
         return Component(
             nexus_wrapper, component_group, ChopperShape(nexus_wrapper, component_group)
         )
     if (
-        nexus_wrapper.get_attribute_value(component_group, "NX_class")
+        nexus_wrapper.get_attribute_value(component_group, CommonAttrs.NX_CLASS)
         in PIXEL_COMPONENT_TYPES
         and "pixel_shape" in component_group
     ):

--- a/nexus_constructor/field_utils.py
+++ b/nexus_constructor/field_utils.py
@@ -88,7 +88,7 @@ def find_field_type(item):
             return item, update_existing_link_field
         elif (
             CommonAttrs.NX_CLASS in item.attrs.keys()
-            and item.attrs[CommonAttrs.NX_CLASS] == "NCstream"
+            and item.attrs[CommonAttrs.NX_CLASS] == CommonAttrs.NC_STREAM
         ):
             return item, update_existing_stream_field
     logging.debug(

--- a/nexus_constructor/field_utils.py
+++ b/nexus_constructor/field_utils.py
@@ -4,6 +4,7 @@ from typing import List
 import h5py
 import numpy as np
 
+from nexus_constructor.common_attrs import CommonAttrs
 from nexus_constructor.field_widget import FieldWidget
 from nexus_constructor.invalid_field_names import INVALID_FIELD_NAMES
 from nexus_constructor.nexus.nexus_wrapper import get_name_of_node
@@ -85,7 +86,10 @@ def find_field_type(item):
     elif isinstance(item, h5py.Group):
         if isinstance(item.parent.get(item.name, getlink=True), h5py.SoftLink):
             return item, update_existing_link_field
-        elif "NX_class" in item.attrs.keys() and item.attrs["NX_class"] == "NCstream":
+        elif (
+            CommonAttrs.NX_CLASS in item.attrs.keys()
+            and item.attrs[CommonAttrs.NX_CLASS] == "NCstream"
+        ):
             return item, update_existing_stream_field
     logging.debug(
         f"Object {get_name_of_node(item)} not handled as field - could be used for other parts of UI instead"

--- a/nexus_constructor/geometry/cylindrical_geometry.py
+++ b/nexus_constructor/geometry/cylindrical_geometry.py
@@ -1,5 +1,6 @@
 from PySide2.QtGui import QVector3D, QMatrix4x4
 
+from nexus_constructor.common_attrs import CommonAttrs
 from nexus_constructor.pixel_data import PixelMapping
 from nexus_constructor.pixel_data_to_nexus_utils import (
     get_detector_number_from_pixel_mapping,
@@ -80,7 +81,9 @@ class CylindricalGeometry:
             "NXcylindrical_geometry",
             (
                 ValidateDataset(
-                    "vertices", shape=(None, 3), attributes={"units": None}
+                    CommonAttrs.VERTICES,
+                    shape=(None, 3),
+                    attributes={CommonAttrs.UNITS: None},
                 ),
                 ValidateDataset("cylinders"),
             ),
@@ -98,7 +101,9 @@ class CylindricalGeometry:
 
     @property
     def units(self) -> str:
-        return self.file.get_attribute_value(self.group["vertices"], "units")
+        return self.file.get_attribute_value(
+            self.group[CommonAttrs.VERTICES], CommonAttrs.UNITS
+        )
 
     @property
     def height(self) -> float:
@@ -115,7 +120,7 @@ class CylindricalGeometry:
         # flatten cylinders in case there are multiple cylinders defined, we'll take the first three elements,
         # so effectively any cylinder after the first one is ignored
         cylinders = self.cylinders.flatten()
-        vertices = self.file.get_field_value(self.group, "vertices")
+        vertices = self.file.get_field_value(self.group, CommonAttrs.VERTICES)
         return tuple(
             numpy_array_to_qvector3d(vertices[cylinders[i], :]) for i in range(3)
         )

--- a/nexus_constructor/geometry/disk_chopper/disk_chopper_checker.py
+++ b/nexus_constructor/geometry/disk_chopper/disk_chopper_checker.py
@@ -4,6 +4,7 @@ from typing import Sequence, Dict
 import numpy as np
 from h5py import Group
 
+from nexus_constructor.common_attrs import CommonAttrs
 from nexus_constructor.geometry.disk_chopper.chopper_details import ChopperDetails
 from nexus_constructor.unit_utils import (
     units_are_recognised_by_pint,
@@ -101,7 +102,7 @@ class NexusDefinedChopperChecker:
 
         for field in UNITS_REQUIRED:
             try:
-                units = self._disk_chopper[field].attrs["units"]
+                units = self._disk_chopper[field].attrs[CommonAttrs.UNITS]
                 self.units_dict[field] = units
                 if isinstance(units, bytes):
                     self.units_dict[field] = units.decode()

--- a/nexus_constructor/geometry/off_geometry.py
+++ b/nexus_constructor/geometry/off_geometry.py
@@ -1,6 +1,8 @@
 from typing import List, Tuple
 from PySide2.QtGui import QVector3D
 from abc import ABC, abstractmethod
+
+from nexus_constructor.common_attrs import CommonAttrs
 from nexus_constructor.nexus import nexus_wrapper as nx
 import h5py
 
@@ -149,7 +151,9 @@ class OFFGeometryNexus(OFFGeometry):
             "NXoff_geometry",
             (
                 ValidateDataset(
-                    "vertices", shape=(None, 3), attributes={"units": None}
+                    CommonAttrs.VERTICES,
+                    shape=(None, 3),
+                    attributes={CommonAttrs.UNITS: None},
                 ),
                 ValidateDataset("winding_order"),
                 ValidateDataset("faces"),
@@ -185,7 +189,7 @@ class OFFGeometryNexus(OFFGeometry):
 
     @property
     def vertices(self) -> List[QVector3D]:
-        vertices_from_file = self.group["vertices"]
+        vertices_from_file = self.group[CommonAttrs.VERTICES]
         number_of_vertices = vertices_from_file.shape[0]
         return [
             numpy_array_to_qvector3d(vertices_from_file[vertex_number][:])
@@ -277,5 +281,5 @@ def record_vertices_in_file(
     :param new_vertices: The new vertices data, list of cartesian coords for each vertex
     """
     vertices = [qvector3d_to_numpy_array(vertex) for vertex in new_vertices]
-    vertices_node = nexus_wrapper.set_field_value(group, "vertices", vertices)
-    nexus_wrapper.set_attribute_value(vertices_node, "units", "m")
+    vertices_node = nexus_wrapper.set_field_value(group, CommonAttrs.VERTICES, vertices)
+    nexus_wrapper.set_attribute_value(vertices_node, CommonAttrs.UNITS, "m")

--- a/nexus_constructor/instrument.py
+++ b/nexus_constructor/instrument.py
@@ -1,6 +1,8 @@
 from typing import List
 
 import h5py
+
+from nexus_constructor.common_attrs import CommonAttrs
 from nexus_constructor.nexus import nexus_wrapper as nx
 from nexus_constructor.component.component import Component
 from nexus_constructor.nexus.nexus_wrapper import get_nx_class
@@ -41,8 +43,8 @@ class Instrument:
             Refresh the depends_on attribute of each transformation, which also results in registering dependents
             """
             if isinstance(node, h5py.Group):
-                if "NX_class" in node.attrs.keys():
-                    if node.attrs["NX_class"] == "NXtransformations":
+                if CommonAttrs.NX_CLASS in node.attrs.keys():
+                    if node.attrs[CommonAttrs.NX_CLASS] == "NXtransformations":
                         for transformation_name in node:
                             transform = Transformation(
                                 self.nexus, node[transformation_name]
@@ -81,7 +83,7 @@ class Instrument:
 
         def find_components(_, node):
             if isinstance(node, h5py.Group):
-                if "NX_class" in node.attrs.keys():
+                if CommonAttrs.NX_CLASS in node.attrs.keys():
                     nx_class = get_nx_class(node)
                     if nx_class and nx_class in self.nx_component_classes:
                         component_list.append(create_component(self.nexus, node))

--- a/nexus_constructor/invalid_field_names.py
+++ b/nexus_constructor/invalid_field_names.py
@@ -2,11 +2,12 @@
 
 # These are invalid because there are separate inputs in the UI for these fields and therefore inputting them through
 # the field name line edit would cause conflicts.
+from nexus_constructor.common_attrs import CommonAttrs
 from nexus_constructor.pixel_data_to_nexus_utils import PIXEL_FIELDS
 
 INVALID_FIELD_NAMES = [
     "description",
     "shape",
-    "depends_on",
+    CommonAttrs.DEPENDS_ON,
     "pixel_shape",
 ] + PIXEL_FIELDS

--- a/nexus_constructor/json/filewriter_json_reader.py
+++ b/nexus_constructor/json/filewriter_json_reader.py
@@ -41,7 +41,7 @@ def _add_to_nexus(children: List[dict], current_group: h5py.Group):
 
 
 def _add_stream(json_object: dict, current_group: h5py.Group):
-    current_group.attrs[CommonAttrs.NX_CLASS] = "NCstream"
+    current_group.attrs[CommonAttrs.NX_CLASS] = CommonAttrs.NC_STREAM
     add_datasets(json_object["stream"], current_group)
 
 

--- a/nexus_constructor/json/filewriter_json_reader.py
+++ b/nexus_constructor/json/filewriter_json_reader.py
@@ -4,6 +4,8 @@ import numpy as np
 import uuid
 from typing import Union, List
 
+from nexus_constructor.common_attrs import CommonAttrs
+
 """
 Read the JSON and construct an in-memory NeXus file from the nexus_structure field
 """
@@ -39,7 +41,7 @@ def _add_to_nexus(children: List[dict], current_group: h5py.Group):
 
 
 def _add_stream(json_object: dict, current_group: h5py.Group):
-    current_group.attrs["NX_class"] = "NCstream"
+    current_group.attrs[CommonAttrs.NX_CLASS] = "NCstream"
     add_datasets(json_object["stream"], current_group)
 
 

--- a/nexus_constructor/json/filewriter_json_writer.py
+++ b/nexus_constructor/json/filewriter_json_writer.py
@@ -61,7 +61,7 @@ def cast_to_int(data):
 
 
 ATTR_NAME_BLACKLIST = [CommonAttrs.DEPENDEE_OF, CommonAttrs.UI_VALUE]
-NX_CLASS_BLACKLIST = ["NXgroup", "NCstream"]
+NX_CLASS_BLACKLIST = ["NXgroup", CommonAttrs.NC_STREAM]
 
 
 def _add_attributes(root: NexusObject, root_dict: dict):
@@ -156,7 +156,7 @@ class NexusToDictConverter:
         """
         root_dict = {"type": "group", "name": get_name_of_node(root), "children": []}
         # Add the entries
-        if get_nx_class(root) == "NCstream":
+        if get_nx_class(root) == CommonAttrs.NC_STREAM:
             self._handle_stream(root, root_dict)
             return root_dict
 

--- a/nexus_constructor/json/filewriter_json_writer.py
+++ b/nexus_constructor/json/filewriter_json_writer.py
@@ -4,6 +4,7 @@ import uuid
 import logging
 from typing import Union, Dict, Any, List, Tuple
 
+from nexus_constructor.common_attrs import CommonAttrs
 from nexus_constructor.instrument import Instrument
 from nexus_constructor.json.helpers import object_to_json_file
 from nexus_constructor.nexus.nexus_wrapper import get_nx_class, get_name_of_node
@@ -59,14 +60,14 @@ def cast_to_int(data):
         return int(data)
 
 
-ATTR_NAME_BLACKLIST = ["dependee_of", "ui_value"]
+ATTR_NAME_BLACKLIST = [CommonAttrs.DEPENDEE_OF, CommonAttrs.UI_VALUE]
 NX_CLASS_BLACKLIST = ["NXgroup", "NCstream"]
 
 
 def _add_attributes(root: NexusObject, root_dict: dict):
     attrs = []
     for attr_name, attr in root.attrs.items():
-        if attr_name == "NX_class" and attr in NX_CLASS_BLACKLIST:
+        if attr_name == CommonAttrs.NX_CLASS and attr in NX_CLASS_BLACKLIST:
             break
         if attr_name not in ATTR_NAME_BLACKLIST:
             if isinstance(attr, bytes):

--- a/nexus_constructor/json/forwarder_json_writer.py
+++ b/nexus_constructor/json/forwarder_json_writer.py
@@ -2,6 +2,7 @@ from typing import List, TextIO
 
 import h5py
 
+from nexus_constructor.common_attrs import CommonAttrs
 from nexus_constructor.json.helpers import object_to_json_file
 from nexus_constructor.nexus.nexus_wrapper import get_nx_class
 from nexus_constructor.writer_modules import WriterModules
@@ -22,7 +23,7 @@ def find_forwarder_streams(root, provider_type: str, default_broker: str) -> Lis
         nonlocal stream_list
         if (
             isinstance(node, h5py.Group)
-            and get_nx_class(node) == "NCstream"
+            and get_nx_class(node) == CommonAttrs.NC_STREAM
             and node["writer_module"][()] in FORWARDER_SCHEMAS
         ):
             writer_module = node["writer_module"][()]

--- a/nexus_constructor/stream_fields_widget.py
+++ b/nexus_constructor/stream_fields_widget.py
@@ -294,7 +294,7 @@ class StreamFieldsWidget(QDialog):
         group = temp_file.create_group("children")
         group.create_dataset(name="type", dtype=STRING_DTYPE, data="stream")
         stream_group = group.create_group(self.parent().parent().field_name_edit.text())
-        stream_group.attrs[CommonAttrs.NX_CLASS] = "NCstream"
+        stream_group.attrs[CommonAttrs.NX_CLASS] = CommonAttrs.NC_STREAM
         stream_group.create_dataset(
             name="topic", dtype=STRING_DTYPE, data=self.topic_line_edit.text()
         )

--- a/nexus_constructor/stream_fields_widget.py
+++ b/nexus_constructor/stream_fields_widget.py
@@ -18,6 +18,7 @@ from PySide2.QtWidgets import (
 )
 import numpy as np
 
+from nexus_constructor.common_attrs import CommonAttrs
 from nexus_constructor.nexus.nexus_wrapper import create_temporary_in_memory_file
 from nexus_constructor.writer_modules import WriterModules
 
@@ -293,7 +294,7 @@ class StreamFieldsWidget(QDialog):
         group = temp_file.create_group("children")
         group.create_dataset(name="type", dtype=STRING_DTYPE, data="stream")
         stream_group = group.create_group(self.parent().parent().field_name_edit.text())
-        stream_group.attrs["NX_class"] = "NCstream"
+        stream_group.attrs[CommonAttrs.NX_CLASS] = "NCstream"
         stream_group.create_dataset(
             name="topic", dtype=STRING_DTYPE, data=self.topic_line_edit.text()
         )

--- a/nexus_constructor/transformations.py
+++ b/nexus_constructor/transformations.py
@@ -4,6 +4,8 @@ import numpy as np
 from PySide2.QtGui import QVector3D, QMatrix4x4
 from PySide2.Qt3DCore import Qt3DCore
 import h5py
+
+from nexus_constructor.common_attrs import CommonAttrs
 from nexus_constructor.nexus import nexus_wrapper as nx
 from typing import TypeVar
 
@@ -70,7 +72,7 @@ class Transformation:
         Get transformation type, should be "Translation" or "Rotation"
         """
         return self.file.get_attribute_value(
-            self._dataset, "transformation_type"
+            self._dataset, CommonAttrs.TRANSFORMATION_TYPE
         ).capitalize()
 
     @type.setter
@@ -79,7 +81,7 @@ class Transformation:
         Set transformation type, should be "Translation" or "Rotation"
         """
         self.file.set_attribute_value(
-            self._dataset, "transformation_type", new_type.capitalize()
+            self._dataset, CommonAttrs.TRANSFORMATION_TYPE, new_type.capitalize()
         )
 
     @property
@@ -87,7 +89,9 @@ class Transformation:
         """
         Returns rotation axis or translation direction as a QVector3D
         """
-        vector_as_np_array = self.file.get_attribute_value(self._dataset, "vector")
+        vector_as_np_array = self.file.get_attribute_value(
+            self._dataset, CommonAttrs.VECTOR
+        )
         return QVector3D(
             vector_as_np_array[0], vector_as_np_array[1], vector_as_np_array[2]
         )
@@ -95,7 +99,9 @@ class Transformation:
     @vector.setter
     def vector(self, new_vector: QVector3D):
         vector_as_np_array = np.array([new_vector.x(), new_vector.y(), new_vector.z()])
-        self.file.set_attribute_value(self._dataset, "vector", vector_as_np_array)
+        self.file.set_attribute_value(
+            self._dataset, CommonAttrs.VECTOR, vector_as_np_array
+        )
 
     @property
     def dataset(self) -> h5Node:
@@ -126,8 +132,8 @@ class Transformation:
         for k, v in old_attrs.items():
             self._dataset.attrs[k] = v
 
-        if "ui_value" not in self._dataset.attrs:
-            self._dataset.attrs["ui_value"] = 0
+        if CommonAttrs.UI_VALUE not in self._dataset.attrs:
+            self._dataset.attrs[CommonAttrs.UI_VALUE] = 0
 
     @property
     def ui_value(self) -> float:
@@ -143,7 +149,7 @@ class Transformation:
                 logging.debug(
                     "transformation value is not cast-able to int, using UI placeholder value instead."
                 )
-        return self.file.get_attribute_value(self._dataset, "ui_value")[()]
+        return self.file.get_attribute_value(self._dataset, CommonAttrs.UI_VALUE)[()]
 
     @ui_value.setter
     def ui_value(self, new_value: float):
@@ -151,11 +157,13 @@ class Transformation:
         Used for setting the magnitude of the transformation in the 3d view
         :param new_value: the placeholder magnitude for the 3d view
         """
-        self.file.set_attribute_value(self._dataset, "ui_value", new_value)
+        self.file.set_attribute_value(self._dataset, CommonAttrs.UI_VALUE, new_value)
 
     @property
     def depends_on(self) -> "Transformation":
-        depends_on_path = self.file.get_attribute_value(self._dataset, "depends_on")
+        depends_on_path = self.file.get_attribute_value(
+            self._dataset, CommonAttrs.DEPENDS_ON
+        )
         if depends_on_path is not None:
             return Transformation(self.file, self.file.nexus_file[depends_on_path])
 
@@ -165,17 +173,19 @@ class Transformation:
         Note, until Python 4.0 (or 3.7 with from __future__ import annotations) have
         to use string for depends_on type here, because the current class is not defined yet
         """
-        existing_depends_on = self.file.get_attribute_value(self._dataset, "depends_on")
+        existing_depends_on = self.file.get_attribute_value(
+            self._dataset, CommonAttrs.DEPENDS_ON
+        )
         if existing_depends_on is not None:
             Transformation(
                 self.file, self.file.nexus_file[existing_depends_on]
             ).deregister_dependent(self)
 
         if depends_on is None:
-            self.file.set_attribute_value(self._dataset, "depends_on", ".")
+            self.file.set_attribute_value(self._dataset, CommonAttrs.DEPENDS_ON, ".")
         else:
             self.file.set_attribute_value(
-                self._dataset, "depends_on", depends_on.absolute_path
+                self._dataset, CommonAttrs.DEPENDS_ON, depends_on.absolute_path
             )
             depends_on.register_dependent(self)
 
@@ -186,13 +196,13 @@ class Transformation:
         :param dependent: transform or component that depends on this one
         """
 
-        if "dependee_of" not in self._dataset.attrs.keys():
+        if CommonAttrs.DEPENDEE_OF not in self._dataset.attrs.keys():
             self.file.set_attribute_value(
-                self._dataset, "dependee_of", dependent.absolute_path
+                self._dataset, CommonAttrs.DEPENDEE_OF, dependent.absolute_path
             )
         else:
             dependee_of_list = self.file.get_attribute_value(
-                self._dataset, "dependee_of"
+                self._dataset, CommonAttrs.DEPENDEE_OF
             )
             if not isinstance(dependee_of_list, np.ndarray):
                 dependee_of_list = np.array([dependee_of_list])
@@ -202,7 +212,7 @@ class Transformation:
                     dependee_of_list, np.array([dependent.absolute_path])
                 )
                 self.file.set_attribute_value(
-                    self._dataset, "dependee_of", dependee_of_list
+                    self._dataset, CommonAttrs.DEPENDEE_OF, dependee_of_list
                 )
 
     def deregister_dependent(self, former_dependent: TransformationOrComponent):
@@ -211,22 +221,22 @@ class Transformation:
         Note, "dependee_of" attribute is not part of the NeXus format
         :param former_dependent: transform or component that used to depend on this one
         """
-        if "dependee_of" in self._dataset.attrs.keys():
+        if CommonAttrs.DEPENDEE_OF in self._dataset.attrs.keys():
             dependee_of_list = self.file.get_attribute_value(
-                self._dataset, "dependee_of"
+                self._dataset, CommonAttrs.DEPENDEE_OF
             )
             if (
                 not isinstance(dependee_of_list, np.ndarray)
                 and dependee_of_list == former_dependent.absolute_path
             ):
                 # Must be a single string rather than a list, so simply delete it
-                self.file.delete_attribute(self._dataset, "dependee_of")
+                self.file.delete_attribute(self._dataset, CommonAttrs.DEPENDEE_OF)
             elif isinstance(dependee_of_list, np.ndarray):
                 dependee_of_list = dependee_of_list[
                     dependee_of_list != former_dependent.absolute_path
                 ]
                 self.file.set_attribute_value(
-                    self._dataset, "dependee_of", dependee_of_list
+                    self._dataset, CommonAttrs.DEPENDEE_OF, dependee_of_list
                 )
             else:
                 logging.warning(
@@ -236,9 +246,11 @@ class Transformation:
     def get_dependents(self):
         import nexus_constructor.component.component as comp
 
-        if "dependee_of" in self._dataset.attrs.keys():
+        if CommonAttrs.DEPENDEE_OF in self._dataset.attrs.keys():
             return_dependents = []
-            dependents = self.file.get_attribute_value(self._dataset, "dependee_of")
+            dependents = self.file.get_attribute_value(
+                self._dataset, CommonAttrs.DEPENDEE_OF
+            )
             if not isinstance(dependents, np.ndarray):
                 dependents = [dependents]
             for path in dependents:

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from nexus_constructor.common_attrs import CommonAttrs
 from nexus_constructor.transformations import Transformation, QVector3D
 from nexus_constructor.nexus.nexus_wrapper import NexusWrapper
 from typing import Any
@@ -21,8 +22,8 @@ def _add_transform_to_file(
     transform_type: str,
 ):
     transform_dataset = nexus_wrapper.nexus_file.create_dataset(name, data=value)
-    transform_dataset.attrs["vector"] = qvector3d_to_numpy_array(vector)
-    transform_dataset.attrs["transformation_type"] = transform_type
+    transform_dataset.attrs[CommonAttrs.VECTOR] = qvector3d_to_numpy_array(vector)
+    transform_dataset.attrs[CommonAttrs.TRANSFORMATION_TYPE] = transform_type
     return transform_dataset
 
 

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -401,16 +401,20 @@ def test_GIVEN_nexus_file_with_linked_transformation_but_without_dependee_of_att
     component2 = add_component_to_file(nexus_wrapper, component_name=component2_name)
     component1.depends_on = transform
     component2.depends_on = transform
-    dependee_of = "dependee_of"
-    del transform._dataset.attrs[dependee_of]
+
+    del transform._dataset.attrs[CommonAttrs.DEPENDEE_OF]
 
     nexus_wrapper.load_nexus_file(nexus_wrapper.nexus_file)
     new_transform_group = nexus_wrapper.nexus_file[transform_name]
 
-    assert dependee_of in new_transform_group.attrs
-    assert len(new_transform_group.attrs[dependee_of]) == 2
-    assert new_transform_group.attrs[dependee_of][0] == "/" + component1_name
-    assert new_transform_group.attrs[dependee_of][1] == "/" + component2_name
+    assert CommonAttrs.DEPENDEE_OF in new_transform_group.attrs
+    assert len(new_transform_group.attrs[CommonAttrs.DEPENDEE_OF]) == 2
+    assert (
+        new_transform_group.attrs[CommonAttrs.DEPENDEE_OF][0] == "/" + component1_name
+    )
+    assert (
+        new_transform_group.attrs[CommonAttrs.DEPENDEE_OF][1] == "/" + component2_name
+    )
 
 
 def test_GIVEN_nexus_file_with_linked_transformation_but_without_dependee_of_attr_WHEN_opening_nexus_file_THEN_component_linked_contains_dependee_of_attribute():
@@ -422,14 +426,13 @@ def test_GIVEN_nexus_file_with_linked_transformation_but_without_dependee_of_att
 
     component1 = add_component_to_file(nexus_wrapper, component_name=component1_name)
     component1.depends_on = transform
-    dependee_of = "dependee_of"
-    del transform._dataset.attrs[dependee_of]
+    del transform._dataset.attrs[CommonAttrs.DEPENDEE_OF]
 
     nexus_wrapper.load_nexus_file(nexus_wrapper.nexus_file)
     new_transform_group = nexus_wrapper.nexus_file[transform_name]
 
-    assert dependee_of in new_transform_group.attrs
-    assert new_transform_group.attrs[dependee_of] == "/" + component1_name
+    assert CommonAttrs.DEPENDEE_OF in new_transform_group.attrs
+    assert new_transform_group.attrs[CommonAttrs.DEPENDEE_OF] == "/" + component1_name
 
 
 def test_GIVEN_transformation_with_scalar_value_that_is_not_castable_to_int_WHEN_getting_ui_value_THEN_ui_placeholder_value_is_returned_instead(


### PR DESCRIPTION
### Issue

Closes #618 

### Description of work

Refactors out into const vars commonly used attribute and field names to avoid typos.
Also renames dependee_of and ui_value to include NC prefix as they are specific to the nexus constructor. 

### Acceptance Criteria 

No functional changes

### UI tests

None modified. 

### Nominate for Group Code Review

- [ ] Nominate for code review 
