### PR TITLE
Duplicating shape and position when component is duplicated

### DIFF
--- a/nexus_constructor/component_tree_model.py
+++ b/nexus_constructor/component_tree_model.py
@@ -160,8 +160,11 @@ class ComponentTreeModel(QAbstractItemModel):
     def duplicate_node(self, node: QModelIndex):
         node_object = node.internalPointer()
         if isinstance(node_object, Component):
-            self.add_component(
-                node_object.duplicate(self.instrument.get_component_list())
+            new_component = node_object.duplicate(self.instrument.get_component_list())
+            self.add_component(new_component)
+            shape, positions = new_component.shape
+            self.instrument.nexus.component_added.emit(
+                new_component.name, shape, positions
             )
         elif isinstance(node_object, Transformation):
             raise NotImplementedError("Duplication of transformations not implemented")

--- a/nexus_constructor/instrument_view.py
+++ b/nexus_constructor/instrument_view.py
@@ -242,7 +242,7 @@ class InstrumentView(QWidget):
         """
         try:
             self.component_entities[name].setParent(None)
-            del self.component_entities[name]
+            self.component_entities.pop(name)
         except KeyError:
             logging.error(
                 f"Unable to delete component {name} because it doesn't exist."


### PR DESCRIPTION
### Issue

Closes #395 

### Description of work

The component shape was not being duplicated when a node was in the 3d view (even if it had no shape) so therefore when deleting it an exception was thrown due to the 3d view not finding the component's shape. 

### Acceptance Criteria 

I have duplicated the shape and position of the old shape to the new component and then called the signal to add the shape in the 3d view. 

### UI tests

None changed

### Nominate for Group Code Review

- [ ] Nominate for code review 
