### PR TITLE
Maximise main window by default

### DIFF
--- a/main.py
+++ b/main.py
@@ -32,5 +32,5 @@ if __name__ == "__main__":
     instrument = Instrument(nexus_wrapper, nx_component_classes)
     ui = MainWindow(instrument, nx_component_classes)
     ui.setupUi(window)
-    window.show()
+    window.showMaximized()
     sys.exit(app.exec_())


### PR DESCRIPTION
### Issue

Closes #636 

### Description of work

Makes the main window of the nexus constructor maximised by default. 

### Acceptance Criteria 

Changed `show()` to `showMaximised()`

### UI tests

None

### Nominate for Group Code Review

- [ ] Nominate for code review 
