### PR TITLE
Fixing layout issues with edit dialog when field type is changed

### DIFF
--- a/nexus_constructor/field_utils.py
+++ b/nexus_constructor/field_utils.py
@@ -27,8 +27,8 @@ def update_existing_array_field(field: h5py.Dataset, new_ui_field: FieldWidget):
     :param value: The array dataset's value to copy to the UI fields list model
     :param new_ui_field: The new UI field to fill in with existing data
     """
-    new_ui_field.dtype = field.dtype
     new_ui_field.field_type = FieldType.array_dataset.value
+    new_ui_field.dtype = field.dtype
     new_ui_field.value = field[()]
 
 
@@ -38,6 +38,7 @@ def update_existing_scalar_field(field: h5py.Dataset, new_ui_field: FieldWidget)
     :param field: The dataset to copy into the value line edit
     :param new_ui_field: The new UI field to fill in with existing data
     """
+    new_ui_field.field_type = FieldType.scalar_dataset.value
     dtype = field.dtype
     if "S" in str(dtype):
         dtype = h5py.special_dtype(vlen=str)
@@ -45,7 +46,6 @@ def update_existing_scalar_field(field: h5py.Dataset, new_ui_field: FieldWidget)
     else:
         new_ui_field.value = field[()]
     new_ui_field.dtype = dtype
-    new_ui_field.field_type = FieldType.scalar_dataset.value
 
 
 def update_existing_stream_field(field: h5py.Dataset, new_ui_field: FieldWidget):

--- a/nexus_constructor/field_widget.py
+++ b/nexus_constructor/field_widget.py
@@ -88,7 +88,6 @@ class FieldWidget(QFrame):
         self.attrs_dialog = FieldAttrsDialog(parent=self)
         self.instrument = instrument
 
-        self.table_view = ArrayDatasetTableWidget()
         self.field_name_edit = FieldNameLineEdit(possible_field_names)
         self.hide_name_field = hide_name_field
         if hide_name_field:
@@ -102,8 +101,6 @@ class FieldWidget(QFrame):
             partial(validate_line_edit, self.units_line_edit)
         )
         self.units_line_edit.setPlaceholderText(CommonAttrs.UNITS)
-
-        self.streams_widget = StreamFieldsWidget(self.edit_dialog)
 
         self.field_type_combo = QComboBox()
         self.field_type_combo.addItems([item.value for item in FieldType])
@@ -294,13 +291,17 @@ class FieldWidget(QFrame):
             return False
 
     def field_type_changed(self):
+        self.edit_dialog = QDialog()
         self._set_up_value_validator(False)
         if self.field_type_combo.currentText() == FieldType.scalar_dataset.value:
             self.set_visibility(True, False, False, True)
         elif self.field_type_combo.currentText() == FieldType.array_dataset.value:
             self.set_visibility(False, False, True, True)
+            self.table_view = ArrayDatasetTableWidget()
+
         elif self.field_type_combo.currentText() == FieldType.kafka_stream.value:
             self.set_visibility(False, False, True, False, show_name_line_edit=True)
+            self.streams_widget = StreamFieldsWidget(self.edit_dialog)
         elif self.field_type_combo.currentText() == FieldType.link.value:
             self.set_visibility(True, False, False, False)
             self._set_up_value_validator(True)

--- a/nexus_constructor/field_widget.py
+++ b/nexus_constructor/field_widget.py
@@ -356,7 +356,7 @@ class FieldWidget(QFrame):
         )
 
     def show_edit_dialog(self):
-        if self.field_type_combo.currentText() == FieldType.array_dataset.value:
+        if self.field_type == FieldType.array_dataset:
             self.edit_dialog.setLayout(QGridLayout())
             self.table_view.model.update_array_dtype(
                 DATASET_TYPE[self.value_type_combo.currentText()]
@@ -365,10 +365,10 @@ class FieldWidget(QFrame):
             self.edit_dialog.setWindowTitle(
                 f"Edit {self.value_type_combo.currentText()} Array field"
             )
-        elif self.field_type_combo.currentText() == FieldType.kafka_stream.value:
+        elif self.field_type == FieldType.kafka_stream:
             self.edit_dialog.setLayout(QFormLayout())
             self.edit_dialog.layout().addWidget(self.streams_widget)
-        elif self.field_type_combo.currentText() == FieldType.nx_class.value:
+        elif self.field_type.currentText() == FieldType.nx_class:
             # TODO: show nx class panels
             pass
         self.edit_dialog.show()

--- a/nexus_constructor/field_widget.py
+++ b/nexus_constructor/field_widget.py
@@ -291,21 +291,20 @@ class FieldWidget(QFrame):
             return False
 
     def field_type_changed(self):
-        self.edit_dialog = QDialog()
+        self.edit_dialog = QDialog(parent=self)
         self._set_up_value_validator(False)
-        if self.field_type_combo.currentText() == FieldType.scalar_dataset.value:
+        if self.field_type == FieldType.scalar_dataset:
             self.set_visibility(True, False, False, True)
-        elif self.field_type_combo.currentText() == FieldType.array_dataset.value:
+        elif self.field_type == FieldType.array_dataset:
             self.set_visibility(False, False, True, True)
             self.table_view = ArrayDatasetTableWidget()
-
-        elif self.field_type_combo.currentText() == FieldType.kafka_stream.value:
+        elif self.field_type == FieldType.kafka_stream:
             self.set_visibility(False, False, True, False, show_name_line_edit=True)
             self.streams_widget = StreamFieldsWidget(self.edit_dialog)
-        elif self.field_type_combo.currentText() == FieldType.link.value:
+        elif self.field_type == FieldType.link:
             self.set_visibility(True, False, False, False)
             self._set_up_value_validator(True)
-        elif self.field_type_combo.currentText() == FieldType.nx_class.value:
+        elif self.field_type == FieldType.nx_class:
             self.set_visibility(False, True, False, False)
 
     def _set_up_value_validator(self, is_link: bool):

--- a/tests/ui_tests/test_ui_add_component_window.py
+++ b/tests/ui_tests/test_ui_add_component_window.py
@@ -1363,7 +1363,7 @@ def test_UI_GIVEN_array_field_selected_and_edit_button_pressed_THEN_edit_dialog_
     field = add_component_dialog.fieldsListWidget.itemWidget(
         add_component_dialog.fieldsListWidget.item(0)
     )
-    field.field_type_combo.setCurrentIndex(2)
+    field.field_type_combo.setCurrentIndex(1)
     qtbot.addWidget(field)
     qtbot.mouseClick(field.edit_button, Qt.LeftButton)
     assert field.edit_dialog.isEnabled()
@@ -1376,10 +1376,40 @@ def test_UI_GIVEN_array_field_selected_and_edit_button_pressed_THEN_edit_dialog_
     field = add_component_dialog.fieldsListWidget.itemWidget(
         add_component_dialog.fieldsListWidget.item(0)
     )
-    field.field_type_combo.setCurrentIndex(2)
+    field.field_type_combo.setCurrentIndex(1)
+    field.field_type_changed()
+
     qtbot.addWidget(field)
     qtbot.mouseClick(field.edit_button, Qt.LeftButton)
     assert field.table_view.isEnabled()
+
+
+def test_UI_GIVEN_stream_field_selected_and_edit_button_pressed_THEN_edit_dialog_is_shown(
+    qtbot, template, add_component_dialog
+):
+    qtbot.mouseClick(add_component_dialog.addFieldPushButton, Qt.LeftButton)
+    field = add_component_dialog.fieldsListWidget.itemWidget(
+        add_component_dialog.fieldsListWidget.item(0)
+    )
+    field.field_type_combo.setCurrentIndex(2)
+    qtbot.addWidget(field)
+    qtbot.mouseClick(field.edit_button, Qt.LeftButton)
+    assert field.edit_dialog.isEnabled()
+
+
+def test_UI_GIVEN_stream_field_selected_and_edit_button_pressed_THEN_edit_dialog_stream_widget_is_shown(
+    qtbot, template, add_component_dialog
+):
+    qtbot.mouseClick(add_component_dialog.addFieldPushButton, Qt.LeftButton)
+    field = add_component_dialog.fieldsListWidget.itemWidget(
+        add_component_dialog.fieldsListWidget.item(0)
+    )
+    field.field_type_combo.setCurrentIndex(2)
+    field.field_type_changed()
+
+    qtbot.addWidget(field)
+    qtbot.mouseClick(field.edit_button, Qt.LeftButton)
+    assert field.streams_widget.isEnabled()
 
 
 def test_UI_GIVEN_user_provides_valid_pixel_configuration_WHEN_entering_pixel_data_THEN_add_component_button_is_enabled(


### PR DESCRIPTION
### Issue
Closes #608 

### Description of work

Sets the dialog layout when the field type is changed instead of just applying a new layout, as these were conflicting with each other. 

There wasn't really a workaround for this either which meant it could prevent a user from saving fields in a component. 

### Acceptance Criteria 

Create field specific objects when the field type is changed, and when the dialog is shown then set the layout. 

### UI tests

None modified 

### Nominate for Group Code Review

- [ ] Nominate for code review 
