### PR TITLE
649 Fixing recursive transforms with relative paths and allowing nxlogs as transforms 

### DIFF
--- a/nexus_constructor/component/component.py
+++ b/nexus_constructor/component/component.py
@@ -316,7 +316,7 @@ class Component:
             self.file.delete_node(transform._dataset)
 
     @property
-    def depends_on(self):
+    def depends_on(self) -> Optional[Transformation]:
         depends_on_path = self.file.get_field_value(self.group, CommonAttrs.DEPENDS_ON)
         if depends_on_path is None:
             return None

--- a/nexus_constructor/component/component.py
+++ b/nexus_constructor/component/component.py
@@ -167,7 +167,26 @@ class Component:
         :param local_only: If True then only add transformations which are stored within this component
         """
         if depends_on is not None and depends_on != ".":
-            transform_dataset = self.file.nexus_file[depends_on]
+            if (
+                len(transforms) >= 1
+                and depends_on
+                == str(
+                    transforms[-1].dataset.attrs[CommonAttrs.DEPENDS_ON],
+                    encoding="utf-8",
+                )
+                and depends_on
+                in [x.split("/")[-1] for x in transforms[-1].dataset.parent.keys()]
+            ):
+                # depends_on is recursive, ie one transformation in this group depends on another transformation in the group, and it is also relative
+                transform_dataset = self.file.nexus_file[
+                    f"{transforms[-1].dataset.parent.name}/{depends_on}"
+                ]
+            elif f"{self.group.name}/{depends_on}" in self.file.nexus_file:
+                transform_dataset = self.file.nexus_file[
+                    f"{self.group.name}/{depends_on}"
+                ]
+            else:
+                transform_dataset = self.file.nexus_file[depends_on]
             if (
                 local_only
                 and transform_dataset.parent.parent.name != self.absolute_path

--- a/nexus_constructor/component/component.py
+++ b/nexus_constructor/component/component.py
@@ -20,7 +20,7 @@ from nexus_constructor.pixel_data_to_nexus_utils import (
     PIXEL_FIELDS,
 )
 from nexus_constructor.transformation_types import TransformationType
-from nexus_constructor.transformations import Transformation
+from nexus_constructor.transformations import Transformation, create_transformation
 from nexus_constructor.ui_utils import (
     qvector3d_to_numpy_array,
     generate_unique_name,
@@ -192,7 +192,7 @@ class Component:
             ):
                 # We're done, the next transformation is not stored in this component
                 return
-            new_transform = Transformation(self.file, transform_dataset)
+            new_transform = create_transformation(self.file, transform_dataset)
             new_transform.parent = transforms
             transforms.append(new_transform)
             if CommonAttrs.DEPENDS_ON in transform_dataset.attrs.keys():

--- a/nexus_constructor/component/component.py
+++ b/nexus_constructor/component/component.py
@@ -8,7 +8,7 @@ from nexus_constructor.common_attrs import CommonAttrs
 from nexus_constructor.component.pixel_shape import PixelShape
 from nexus_constructor.component.transformations_list import TransformationsList
 from nexus_constructor.nexus import nexus_wrapper as nx
-from nexus_constructor.nexus.nexus_wrapper import get_nx_class
+from nexus_constructor.nexus.nexus_wrapper import get_nx_class, decode_bytes_string
 from nexus_constructor.field_utils import get_fields_with_update_functions
 from nexus_constructor.pixel_data import PixelMapping, PixelGrid, PixelData
 from nexus_constructor.pixel_data_to_nexus_utils import (
@@ -168,11 +168,10 @@ class Component:
         """
         if depends_on is not None and depends_on != ".":
             if (
-                len(transforms) >= 1
+                transforms
                 and depends_on
-                == str(
-                    transforms[-1].dataset.attrs[CommonAttrs.DEPENDS_ON],
-                    encoding="utf-8",
+                == decode_bytes_string(
+                    transforms[-1].dataset.attrs[CommonAttrs.DEPENDS_ON]
                 )
                 and depends_on
                 in [x.split("/")[-1] for x in transforms[-1].dataset.parent.keys()]

--- a/nexus_constructor/component/component.py
+++ b/nexus_constructor/component/component.py
@@ -254,7 +254,7 @@ class Component:
             field, CommonAttrs.TRANSFORMATION_TYPE, TransformationType.TRANSLATION
         )
 
-        translation_transform = Transformation(self.file, field)
+        translation_transform = create_transformation(self.file, field)
         translation_transform.ui_value = magnitude
         translation_transform.depends_on = depends_on
         return translation_transform
@@ -288,7 +288,7 @@ class Component:
         self.file.set_attribute_value(
             field, CommonAttrs.TRANSFORMATION_TYPE, TransformationType.ROTATION
         )
-        rotation_transform = Transformation(self.file, field)
+        rotation_transform = create_transformation(self.file, field)
         rotation_transform.depends_on = depends_on
         rotation_transform.ui_value = angle
         return rotation_transform
@@ -320,7 +320,7 @@ class Component:
         depends_on_path = self.file.get_field_value(self.group, CommonAttrs.DEPENDS_ON)
         if depends_on_path is None:
             return None
-        return Transformation(self.file, self.file.nexus_file[depends_on_path])
+        return create_transformation(self.file, self.file.nexus_file[depends_on_path])
 
     @depends_on.setter
     def depends_on(self, transformation: Transformation):
@@ -328,7 +328,7 @@ class Component:
             self.group, CommonAttrs.DEPENDS_ON
         )
         if existing_depends_on is not None:
-            Transformation(
+            create_transformation(
                 self.file, self.file[existing_depends_on]
             ).deregister_dependent(self)
 

--- a/nexus_constructor/component/link_transformation.py
+++ b/nexus_constructor/component/link_transformation.py
@@ -1,5 +1,6 @@
 from nexus_constructor.component.component import Component
 from nexus_constructor.component.transformations_list import TransformationsList
+from typing import Optional
 
 TRANSFORM_STR = "/transformations/"
 
@@ -14,7 +15,7 @@ class LinkTransformation:
         super().__init__()
         self.parent = parent
 
-    def _find_linked_component(self) -> Component:
+    def _find_linked_component(self) -> Optional[Component]:
         for transformation in self.parent:
             if self.parent._transform_has_external_link(transformation):
                 component_path = transformation.depends_on.absolute_path[
@@ -30,7 +31,7 @@ class LinkTransformation:
         return self.parent._has_direct_link()
 
     @property
-    def linked_component(self) -> Component:
+    def linked_component(self) -> Optional[Component]:
         if not self.parent.has_link:
             return None
         if self._has_direct_component_link():
@@ -54,7 +55,8 @@ class LinkTransformation:
         else:
             for c_transform in parent_component.transforms:
                 if (
-                    parent_component.absolute_path + TRANSFORM_STR
+                    c_transform.depends_on is None
+                    or parent_component.absolute_path + TRANSFORM_STR
                     not in c_transform.depends_on.absolute_path
                 ):
                     target = c_transform

--- a/nexus_constructor/component/transformations_list.py
+++ b/nexus_constructor/component/transformations_list.py
@@ -26,6 +26,8 @@ class TransformationsList(list):
         )
 
     def _transform_has_external_link(self, transformation: Transformation) -> bool:
+        if transformation.depends_on is None:
+            return False
         return (
             TRANSFORM_STR in transformation.depends_on.absolute_path
             and (self.parent_component.absolute_path + TRANSFORM_STR)

--- a/nexus_constructor/instrument.py
+++ b/nexus_constructor/instrument.py
@@ -46,11 +46,7 @@ class Instrument:
                 if CommonAttrs.NX_CLASS in node.attrs.keys():
                     if node.attrs[CommonAttrs.NX_CLASS] == "NXtransformations":
                         for transformation_name, transformation_node in node.items():
-                            if (
-                                CommonAttrs.NX_CLASS in transformation_node.attrs
-                                and transformation_node.attrs[CommonAttrs.NX_CLASS]
-                                == "NXlog"
-                            ):
+                            if get_nx_class(transformation_node) == "NXlog":
                                 transform = NXLogTransformation(
                                     self.nexus, node[transformation_name]
                                 )

--- a/nexus_constructor/instrument.py
+++ b/nexus_constructor/instrument.py
@@ -6,7 +6,7 @@ from nexus_constructor.common_attrs import CommonAttrs
 from nexus_constructor.nexus import nexus_wrapper as nx
 from nexus_constructor.component.component import Component
 from nexus_constructor.nexus.nexus_wrapper import get_nx_class
-from nexus_constructor.transformations import NXLogTransformation, create_transformation
+from nexus_constructor.transformations import create_transformation
 from nexus_constructor.component.component_factory import create_component
 
 COMPONENTS_IN_ENTRY = ["NXmonitor", "NXsample"]
@@ -46,14 +46,9 @@ class Instrument:
                 if CommonAttrs.NX_CLASS in node.attrs.keys():
                     if node.attrs[CommonAttrs.NX_CLASS] == "NXtransformations":
                         for transformation_name, transformation_node in node.items():
-                            if get_nx_class(transformation_node) == "NXlog":
-                                transform = NXLogTransformation(
-                                    self.nexus, node[transformation_name]
-                                )
-                            else:
-                                transform = create_transformation(
-                                    self.nexus, node[transformation_name]
-                                )
+                            transform = create_transformation(
+                                self.nexus, node[transformation_name]
+                            )
                             transform.depends_on = transform.depends_on
 
         self.nexus.nexus_file.visititems(refresh_depends_on)

--- a/nexus_constructor/instrument.py
+++ b/nexus_constructor/instrument.py
@@ -6,7 +6,7 @@ from nexus_constructor.common_attrs import CommonAttrs
 from nexus_constructor.nexus import nexus_wrapper as nx
 from nexus_constructor.component.component import Component
 from nexus_constructor.nexus.nexus_wrapper import get_nx_class
-from nexus_constructor.transformations import Transformation, NXLogTransformation
+from nexus_constructor.transformations import NXLogTransformation, create_transformation
 from nexus_constructor.component.component_factory import create_component
 
 COMPONENTS_IN_ENTRY = ["NXmonitor", "NXsample"]
@@ -51,7 +51,7 @@ class Instrument:
                                     self.nexus, node[transformation_name]
                                 )
                             else:
-                                transform = Transformation(
+                                transform = create_transformation(
                                     self.nexus, node[transformation_name]
                                 )
                             transform.depends_on = transform.depends_on

--- a/nexus_constructor/instrument.py
+++ b/nexus_constructor/instrument.py
@@ -6,7 +6,7 @@ from nexus_constructor.common_attrs import CommonAttrs
 from nexus_constructor.nexus import nexus_wrapper as nx
 from nexus_constructor.component.component import Component
 from nexus_constructor.nexus.nexus_wrapper import get_nx_class
-from nexus_constructor.transformations import Transformation
+from nexus_constructor.transformations import Transformation, NXLogTransformation
 from nexus_constructor.component.component_factory import create_component
 
 COMPONENTS_IN_ENTRY = ["NXmonitor", "NXsample"]
@@ -45,10 +45,19 @@ class Instrument:
             if isinstance(node, h5py.Group):
                 if CommonAttrs.NX_CLASS in node.attrs.keys():
                     if node.attrs[CommonAttrs.NX_CLASS] == "NXtransformations":
-                        for transformation_name in node:
-                            transform = Transformation(
-                                self.nexus, node[transformation_name]
-                            )
+                        for transformation_name, transformation_node in node.items():
+                            if (
+                                CommonAttrs.NX_CLASS in transformation_node.attrs
+                                and transformation_node.attrs[CommonAttrs.NX_CLASS]
+                                == "NXlog"
+                            ):
+                                transform = NXLogTransformation(
+                                    self.nexus, node[transformation_name]
+                                )
+                            else:
+                                transform = Transformation(
+                                    self.nexus, node[transformation_name]
+                                )
                             transform.depends_on = transform.depends_on
 
         self.nexus.nexus_file.visititems(refresh_depends_on)

--- a/nexus_constructor/transformation_view.py
+++ b/nexus_constructor/transformation_view.py
@@ -36,7 +36,7 @@ class EditTransformation(QGroupBox):
         if isinstance(self.transformation, NXLogTransformation):
             self.transformation_frame.main_layout.addWidget(
                 QLabel(
-                    "Transformation is an NXlog - currently these are supported but not editable. "
+                    "Transformation is an NXlog - currently these are not editable. "
                 )
             )
             self.transformation_frame.magnitude_widget.setVisible(False)

--- a/nexus_constructor/transformation_view.py
+++ b/nexus_constructor/transformation_view.py
@@ -2,7 +2,7 @@ from nexus_constructor.field_utils import find_field_type
 from nexus_constructor.transformation_types import TransformationType
 from ui.transformation import Ui_Transformation
 from ui.link import Ui_Link
-from PySide2.QtWidgets import QGroupBox, QFrame, QWidget
+from PySide2.QtWidgets import QGroupBox, QFrame, QWidget, QLabel
 from PySide2.QtGui import QVector3D
 from nexus_constructor.transformations import Transformation, NXLogTransformation
 from nexus_constructor.instrument import Instrument
@@ -28,11 +28,18 @@ class EditTransformation(QGroupBox):
         self.transformation_frame.x_spinbox.setValue(current_vector.x())
         self.transformation_frame.y_spinbox.setValue(current_vector.y())
         self.transformation_frame.z_spinbox.setValue(current_vector.z())
-        if not isinstance(self.transformation, NXLogTransformation):
-            update_function = find_field_type(self.transformation.dataset)
+        update_function = find_field_type(self.transformation.dataset)
+        if update_function is not None:
             update_function(
                 self.transformation.dataset, self.transformation_frame.magnitude_widget
             )
+        if isinstance(self.transformation, NXLogTransformation):
+            self.transformation_frame.main_layout.addWidget(
+                QLabel(
+                    "Transformation is an NXlog - currently these are supported but not editable. "
+                )
+            )
+            self.transformation_frame.magnitude_widget.setVisible(False)
         self.transformation_frame.magnitude_widget.units = self.transformation.units
         self.transformation_frame.value_spinbox.setValue(self.transformation.ui_value)
 

--- a/nexus_constructor/transformation_view.py
+++ b/nexus_constructor/transformation_view.py
@@ -4,7 +4,7 @@ from ui.transformation import Ui_Transformation
 from ui.link import Ui_Link
 from PySide2.QtWidgets import QGroupBox, QFrame, QWidget
 from PySide2.QtGui import QVector3D
-from nexus_constructor.transformations import Transformation
+from nexus_constructor.transformations import Transformation, NXLogTransformation
 from nexus_constructor.instrument import Instrument
 from nexus_constructor.component_tree_model import LinkTransformation
 from nexus_constructor.component.component import Component
@@ -28,8 +28,9 @@ class EditTransformation(QGroupBox):
         self.transformation_frame.x_spinbox.setValue(current_vector.x())
         self.transformation_frame.y_spinbox.setValue(current_vector.y())
         self.transformation_frame.z_spinbox.setValue(current_vector.z())
-        item, update_function = find_field_type(self.transformation.dataset)
-        update_function(item, self.transformation_frame.magnitude_widget)
+        if not isinstance(self.transformation, NXLogTransformation):
+            item, update_function = find_field_type(self.transformation.dataset)
+            update_function(item, self.transformation_frame.magnitude_widget)
         self.transformation_frame.magnitude_widget.units = self.transformation.units
         self.transformation_frame.value_spinbox.setValue(self.transformation.ui_value)
 

--- a/nexus_constructor/transformation_view.py
+++ b/nexus_constructor/transformation_view.py
@@ -29,8 +29,10 @@ class EditTransformation(QGroupBox):
         self.transformation_frame.y_spinbox.setValue(current_vector.y())
         self.transformation_frame.z_spinbox.setValue(current_vector.z())
         if not isinstance(self.transformation, NXLogTransformation):
-            item, update_function = find_field_type(self.transformation.dataset)
-            update_function(item, self.transformation_frame.magnitude_widget)
+            update_function = find_field_type(self.transformation.dataset)
+            update_function(
+                self.transformation.dataset, self.transformation_frame.magnitude_widget
+            )
         self.transformation_frame.magnitude_widget.units = self.transformation.units
         self.transformation_frame.value_spinbox.setValue(self.transformation.ui_value)
 

--- a/nexus_constructor/transformations.py
+++ b/nexus_constructor/transformations.py
@@ -300,3 +300,23 @@ class Transformation:
             dependee.depends_on = new_depends_on
             self.deregister_dependent(dependee)
         self.depends_on = None
+
+
+class NXLogTransformation(Transformation):
+    @property
+    def ui_value(self) -> float:
+        if "value" not in self._dataset.keys():
+            return 0
+        value_group = self._dataset["value"]
+        if np.isscalar(value_group):
+            return value_group[()]
+        else:
+            return float(value_group[0][()])
+
+    @property
+    def units(self) -> str:
+        self.file.get_attribute_value(self._dataset["value"], "units")
+
+    @units.setter
+    def units(self, new_units: str):
+        self.file.set_attribute_value(self._dataset["value"], "units", new_units)

--- a/nexus_constructor/transformations.py
+++ b/nexus_constructor/transformations.py
@@ -343,3 +343,16 @@ class NXLogTransformation(Transformation):
     @units.setter
     def units(self, new_units: str):
         self.file.set_attribute_value(self._dataset["value"], "units", new_units)
+
+
+def create_transformation(wrapper: nx.NexusWrapper, node: h5Node):
+    """
+    Factory for creating different types of transform.
+    If it is an NXlog group then the magnitude and units fields will be different to a normal transformation dataset.
+    """
+    if (
+        CommonAttrs.NX_CLASS in node.attrs
+        and str(node.attrs[CommonAttrs.NX_CLASS], encoding="utf-8") == "NXlog"
+    ):
+        return NXLogTransformation(wrapper, node)
+    return Transformation(wrapper, node)

--- a/nexus_constructor/transformations.py
+++ b/nexus_constructor/transformations.py
@@ -335,12 +335,18 @@ class NXLogTransformation(Transformation):
     @property
     def ui_value(self) -> float:
         if "value" not in self._dataset.keys():
-            return 0
+            if CommonAttrs.UI_VALUE not in self._dataset.attrs:
+                self.ui_value = 0
+            return self.file.get_attribute_value(self._dataset, CommonAttrs.UI_VALUE)
         value_group = self._dataset["value"]
         if np.isscalar(value_group):
             return value_group[()]
         else:
             return float(value_group[0][()])
+
+    @ui_value.setter
+    def ui_value(self, new_value):
+        self.file.set_attribute_value(self._dataset, CommonAttrs.UI_VALUE, new_value)
 
     @property
     def units(self) -> str:

--- a/nexus_constructor/transformations.py
+++ b/nexus_constructor/transformations.py
@@ -196,11 +196,8 @@ class Transformation:
         depends_on_path = self.file.get_attribute_value(
             self._dataset, CommonAttrs.DEPENDS_ON
         )
-        if depends_on_path is not None:
-            if (
-                f"{self._dataset.parent.name}/{depends_on_path}" in self.file.nexus_file
-                and depends_on_path != "."
-            ):
+        if depends_on_path not in (None, "."):
+            if f"{self._dataset.parent.name}/{depends_on_path}" in self.file.nexus_file:
                 # depends_on is relative
                 return create_transformation(
                     self.file,
@@ -319,7 +316,7 @@ class Transformation:
     def remove_from_dependee_chain(self):
         all_dependees = self.get_dependents()
         new_depends_on = self.depends_on
-        if self.depends_on.absolute_path == "/":
+        if self.depends_on is not None and self.depends_on.absolute_path == "/":
             new_depends_on = None
         else:
             for dependee in all_dependees:
@@ -365,7 +362,7 @@ class NXLogTransformation(Transformation):
         pass
 
 
-def create_transformation(wrapper: nx.NexusWrapper, node: h5Node):
+def create_transformation(wrapper: nx.NexusWrapper, node: h5Node) -> Transformation:
     """
     Factory for creating different types of transform.
     If it is an NXlog group then the magnitude and units fields will be different to a normal transformation dataset.

--- a/nexus_constructor/transformations.py
+++ b/nexus_constructor/transformations.py
@@ -7,7 +7,7 @@ import h5py
 
 from nexus_constructor.common_attrs import CommonAttrs
 from nexus_constructor.nexus import nexus_wrapper as nx
-from typing import TypeVar, Union, List
+from typing import TypeVar, Union, List, Optional
 
 from nexus_constructor.nexus.nexus_wrapper import h5Node, decode_bytes_string
 from nexus_constructor.transformation_types import TransformationType
@@ -192,7 +192,7 @@ class Transformation:
         self.file.set_attribute_value(self._dataset, CommonAttrs.UI_VALUE, new_value)
 
     @property
-    def depends_on(self) -> "Transformation":
+    def depends_on(self) -> Optional["Transformation"]:
         depends_on_path = self.file.get_attribute_value(
             self._dataset, CommonAttrs.DEPENDS_ON
         )

--- a/nexus_constructor/transformations.py
+++ b/nexus_constructor/transformations.py
@@ -196,6 +196,14 @@ class Transformation:
             self._dataset, CommonAttrs.DEPENDS_ON
         )
         if depends_on_path is not None:
+            if f"{self._dataset.parent.name}/{depends_on_path}" in self.file.nexus_file:
+                # depends_on is relative
+                return Transformation(
+                    self.file,
+                    self.file.nexus_file[
+                        f"{self._dataset.parent.name}/{depends_on_path}"
+                    ],
+                )
             return Transformation(self.file, self.file.nexus_file[depends_on_path])
 
     @depends_on.setter

--- a/nexus_constructor/transformations.py
+++ b/nexus_constructor/transformations.py
@@ -197,7 +197,10 @@ class Transformation:
             self._dataset, CommonAttrs.DEPENDS_ON
         )
         if depends_on_path is not None:
-            if f"{self._dataset.parent.name}/{depends_on_path}" in self.file.nexus_file:
+            if (
+                f"{self._dataset.parent.name}/{depends_on_path}" in self.file.nexus_file
+                and depends_on_path != "."
+            ):
                 # depends_on is relative
                 return create_transformation(
                     self.file,

--- a/nexus_constructor/transformations.py
+++ b/nexus_constructor/transformations.py
@@ -356,6 +356,14 @@ class NXLogTransformation(Transformation):
     def units(self, new_units: str):
         self.file.set_attribute_value(self._dataset["value"], "units", new_units)
 
+    @property
+    def dataset(self) -> h5Node:
+        return self._dataset
+
+    @dataset.setter
+    def dataset(self, new_dataset):
+        pass
+
 
 def create_transformation(wrapper: nx.NexusWrapper, node: h5Node):
     """

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -558,9 +558,7 @@ def test_multiple_relative_transform_paths_are_converted_to_absolute_path_in_dep
     )
 
 
-def test_transforms_with_no_dependees_are_not_treated_as_having_relative_dependees(
-    file,  # noqa: F811
-):
+def test_transforms_with_no_dependees_return_None_for_depends_on(file,):  # noqa: F811
     nexus_wrapper = NexusWrapper(str(uuid1()))
     component_name = "component_1"
 
@@ -580,7 +578,6 @@ def test_transforms_with_no_dependees_are_not_treated_as_having_relative_depende
     ] = TransformationType.TRANSLATION
 
     transform1_dataset.attrs["depends_on"] = "."
-
     transformation = Transformation(nexus_wrapper, transform1_dataset)
 
-    assert not transformation.depends_on.name
+    assert not transformation.depends_on

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -559,7 +559,7 @@ def test_multiple_relative_transform_paths_are_converted_to_absolute_path_in_dep
 
 
 def test_transforms_with_no_dependees_are_not_treated_as_having_relative_dependees(
-    file,
+    file,  # noqa: F811
 ):
     nexus_wrapper = NexusWrapper(str(uuid1()))
     component_name = "component_1"

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -515,3 +515,44 @@ def test_GIVEN_transformation_with_scalar_value_that_is_not_castable_to_int_WHEN
 
     assert transform.ui_value != str_value
     assert transform.ui_value == 0
+
+
+def test_multiple_relative_transform_paths_are_converted_to_absolute_path_in_dependee_of_field(
+    file,  # noqa: F811
+):
+    nexus_wrapper = NexusWrapper(str(uuid1()))
+    component_name = "component_1"
+
+    component1 = add_component_to_file(nexus_wrapper, component_name=component_name)
+    # make depends_on point to relative transformations group
+    component1.group["depends_on"] = "transformations/transform1"
+
+    transformations_group = component1.group.create_group("transformations")
+
+    transform1_name = "transform1"
+    transform1_dataset = transformations_group.create_dataset(transform1_name, data=1)
+    transform1_dataset.attrs[CommonAttrs.VECTOR] = qvector3d_to_numpy_array(
+        QVector3D(1, 0, 0)
+    )
+    transform1_dataset.attrs[
+        CommonAttrs.TRANSFORMATION_TYPE
+    ] = TransformationType.TRANSLATION
+
+    transform2_name = "transform2"
+
+    # make transform1 depends_on point to relative transform in same directory
+    transform1_dataset.attrs["depends_on"] = transform2_name
+
+    transform2_dataset = transformations_group.create_dataset(transform2_name, data=2)
+    transform2_dataset.attrs[CommonAttrs.VECTOR] = qvector3d_to_numpy_array(
+        QVector3D(1, 1, 0)
+    )
+    transform2_dataset.attrs[
+        CommonAttrs.TRANSFORMATION_TYPE
+    ] = TransformationType.TRANSLATION
+
+    # make sure the depends_on points to the absolute path of the transform it depends on in the file
+    assert (
+        Transformation(nexus_wrapper, transform1_dataset).depends_on.dataset.name
+        == transform2_dataset.name
+    )

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -556,3 +556,31 @@ def test_multiple_relative_transform_paths_are_converted_to_absolute_path_in_dep
         Transformation(nexus_wrapper, transform1_dataset).depends_on.dataset.name
         == transform2_dataset.name
     )
+
+
+def test_transforms_with_no_dependees_are_not_treated_as_having_relative_dependees(
+    file,
+):
+    nexus_wrapper = NexusWrapper(str(uuid1()))
+    component_name = "component_1"
+
+    component1 = add_component_to_file(nexus_wrapper, component_name=component_name)
+    # make depends_on point to relative transformations group
+    component1.group["depends_on"] = "transformations/transform1"
+
+    transformations_group = component1.group.create_group("transformations")
+
+    transform1_name = "transform1"
+    transform1_dataset = transformations_group.create_dataset(transform1_name, data=1)
+    transform1_dataset.attrs[CommonAttrs.VECTOR] = qvector3d_to_numpy_array(
+        QVector3D(1, 0, 0)
+    )
+    transform1_dataset.attrs[
+        CommonAttrs.TRANSFORMATION_TYPE
+    ] = TransformationType.TRANSLATION
+
+    transform1_dataset.attrs["depends_on"] = "."
+
+    transformation = Transformation(nexus_wrapper, transform1_dataset)
+
+    assert not transformation.depends_on.name


### PR DESCRIPTION
### Issue

Closes #649 

### Description of work

Fixing recursive transforms, in the case of the `bigfake.nxs` these are in this form: 

```
- comp1:
  - depends_on = "transformations/transform1"
  - transforms:
    - transform1:
      - depends_on = "transform2"
    - transform2:
```
### Acceptance Criteria 

Have added a test to cover this situation. 

### UI tests

No UI changes

### Nominate for Group Code Review

- [ ] Nominate for code review 
