### PR TITLE
Adding missing return statement to units property

### DIFF
--- a/nexus_constructor/transformations.py
+++ b/nexus_constructor/transformations.py
@@ -94,7 +94,7 @@ class Transformation:
 
     @property
     def units(self):
-        self.file.get_attribute_value(self._dataset, CommonAttrs.UNITS)
+        return self.file.get_attribute_value(self._dataset, CommonAttrs.UNITS)
 
     @units.setter
     def units(self, new_units):


### PR DESCRIPTION
### Issue

Closes #646 

### Description of work

This was causing the `units` field to not get filled in or saved when updated in the transformation view. 

### Acceptance Criteria 

Missing return statement was returning `None` and therefore not filling in the UI field. 

### UI tests

None

### Nominate for Group Code Review

- [ ] Nominate for code review 
