### PR TITLE
148 - Mantid IDF support

### DIFF
--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -16,7 +16,7 @@ from nexus_constructor.field_widget import FieldWidget
 from nexus_constructor.invalid_field_names import INVALID_FIELD_NAMES
 from ui.add_component import Ui_AddComponentDialog
 from nexus_constructor.component.component_type import PIXEL_COMPONENT_TYPES
-from nexus_constructor.nexus.nexus_wrapper import get_name_of_node, decode_bytes_string
+from nexus_constructor.nexus.nexus_wrapper import get_name_of_node
 from nexus_constructor.validators import (
     UnitValidator,
     NameValidator,
@@ -237,9 +237,9 @@ class AddComponentDialog(Ui_AddComponentDialog, QObject):
             if update_method is not None:
                 new_ui_field = self.create_new_ui_field(field)
                 update_method(field, new_ui_field)
-                new_ui_field.units = decode_bytes_string(
-                    field.attrs[CommonAttrs.UNITS]
-                    if CommonAttrs.UNITS in field.attrs
+                new_ui_field.units = (
+                    self.instrument.nexus.get_attribute_value(field, CommonAttrs.UNITS)
+                    if not None
                     else ""
                 )
                 new_ui_field.attrs = field

--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -16,7 +16,7 @@ from nexus_constructor.field_widget import FieldWidget
 from nexus_constructor.invalid_field_names import INVALID_FIELD_NAMES
 from ui.add_component import Ui_AddComponentDialog
 from nexus_constructor.component.component_type import PIXEL_COMPONENT_TYPES
-from nexus_constructor.nexus.nexus_wrapper import get_name_of_node
+from nexus_constructor.nexus.nexus_wrapper import get_name_of_node, decode_bytes_string
 from nexus_constructor.validators import (
     UnitValidator,
     NameValidator,
@@ -237,7 +237,7 @@ class AddComponentDialog(Ui_AddComponentDialog, QObject):
             if update_method is not None:
                 new_ui_field = self.create_new_ui_field(field)
                 update_method(field, new_ui_field)
-                new_ui_field.units = (
+                new_ui_field.units = decode_bytes_string(
                     field.attrs[CommonAttrs.UNITS]
                     if CommonAttrs.UNITS in field.attrs
                     else ""

--- a/nexus_constructor/field_attrs.py
+++ b/nexus_constructor/field_attrs.py
@@ -100,7 +100,7 @@ class FieldAttrFrame(QFrame):
 
         self.type_changed("Scalar")
 
-        if name and value:
+        if name is not None and value is not None:
             self.value = (name, value)
 
     def type_changed(self, item: str):

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -5,10 +5,13 @@ from PySide2.QtWidgets import (
     QInputDialog,
     QLineEdit,
     QAction,
+    QMessageBox,
 )
 from PySide2.QtWidgets import QDialog, QLabel, QGridLayout, QComboBox, QPushButton
 import silx.gui.hdf5
 import h5py
+from nexusutils.nexusbuilder import NexusBuilder
+
 import nexus_constructor.json.forwarder_json_writer
 from nexus_constructor.add_component_window import AddComponentDialog
 from nexus_constructor.filewriter_command_widget import FilewriterCommandWidget
@@ -35,6 +38,7 @@ class MainWindow(Ui_MainWindow, QMainWindow):
         self.export_to_nexus_file_action.triggered.connect(self.save_to_nexus_file)
         self.open_nexus_file_action.triggered.connect(self.open_nexus_file)
         self.open_json_file_action.triggered.connect(self.open_json_file)
+        self.open_idf_file_action.triggered.connect(self.open_idf_file)
         self.export_to_filewriter_JSON_action.triggered.connect(
             self.save_to_filewriter_json
         )
@@ -143,6 +147,16 @@ class MainWindow(Ui_MainWindow, QMainWindow):
     def save_to_nexus_file(self):
         filename = file_dialog(True, "Save Nexus File", NEXUS_FILE_TYPES)
         self.instrument.nexus.save_file(filename)
+
+    def open_idf_file(self):
+        filename = file_dialog(False, "Open IDF file", {"IDF files": ["xml"]})
+        with open(filename) as idf_file:
+            pass
+        QMessageBox.warning(
+            self,
+            "Mantid IDF loaded",
+            "Please manually check the instrument for accuracy.",
+        )
 
     def save_to_filewriter_json(self):
         filename = file_dialog(True, "Save Filewriter JSON File", JSON_FILE_TYPES)

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -1,4 +1,3 @@
-import uuid
 from typing import Dict
 from PySide2.QtWidgets import (
     QMainWindow,

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Dict
 from PySide2.QtWidgets import (
     QMainWindow,
@@ -150,8 +151,14 @@ class MainWindow(Ui_MainWindow, QMainWindow):
 
     def open_idf_file(self):
         filename = file_dialog(False, "Open IDF file", {"IDF files": ["xml"]})
-        with open(filename) as idf_file:
-            pass
+        builder = NexusBuilder(
+            str(uuid.uuid4()), idf_file=filename, file_in_memory=True
+        )
+        builder.add_instrument_geometry_from_idf()
+        builder.add_monitors_from_idf()
+        builder.add_detectors_from_idf()
+        self.instrument.nexus.load_nexus_file(builder.target_file)
+        self._update_views()
         QMessageBox.warning(
             self,
             "Mantid IDF loaded",

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -155,7 +155,7 @@ class MainWindow(Ui_MainWindow, QMainWindow):
     def _load_idf(self, filename):
         try:
             builder = NexusBuilder(
-                str(uuid.uuid4()),
+                filename.rstrip(".xml"),
                 idf_file=filename,
                 file_in_memory=True,
                 nx_entry_name="entry",

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -152,23 +152,26 @@ class MainWindow(Ui_MainWindow, QMainWindow):
     def open_idf_file(self):
         filename = file_dialog(False, "Open IDF file", {"IDF files": ["xml"]})
         self._load_idf(filename)
-        self._update_views()
-        QMessageBox.warning(
-            self,
-            "Mantid IDF loaded",
-            "Please manually check the instrument for accuracy.",
-        )
 
     def _load_idf(self, filename):
-        builder = NexusBuilder(
-            str(uuid.uuid4()),
-            idf_file=filename,
-            file_in_memory=True,
-            compress_type="gzip",
-            compress_opts=1,
-        )
-        builder.add_instrument_geometry_from_idf()
-        self.instrument.nexus.load_nexus_file(builder.target_file)
+        try:
+            builder = NexusBuilder(
+                str(uuid.uuid4()),
+                idf_file=filename,
+                file_in_memory=True,
+                compress_type="gzip",
+                compress_opts=1,
+            )
+            builder.add_instrument_geometry_from_idf()
+            self.instrument.nexus.load_nexus_file(builder.target_file)
+            self._update_views()
+            QMessageBox.warning(
+                self,
+                "Mantid IDF loaded",
+                "Please manually check the instrument for accuracy.",
+            )
+        except Exception:
+            QMessageBox.critical(self, "IDF Error", "Error whilst loading IDF file")
 
     def save_to_filewriter_json(self):
         filename = file_dialog(True, "Save Filewriter JSON File", JSON_FILE_TYPES)

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -158,8 +158,7 @@ class MainWindow(Ui_MainWindow, QMainWindow):
                 str(uuid.uuid4()),
                 idf_file=filename,
                 file_in_memory=True,
-                compress_type="gzip",
-                compress_opts=1,
+                nx_entry_name="entry",
             )
             builder.add_instrument_geometry_from_idf()
             self.instrument.nexus.load_nexus_file(builder.target_file)

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Dict
 from PySide2.QtWidgets import (
     QMainWindow,
@@ -154,7 +155,7 @@ class MainWindow(Ui_MainWindow, QMainWindow):
     def _load_idf(self, filename):
         try:
             builder = NexusBuilder(
-                filename.rstrip(".xml"),
+                str(uuid.uuid4()),
                 idf_file=filename,
                 file_in_memory=True,
                 nx_entry_name="entry",

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -151,19 +151,24 @@ class MainWindow(Ui_MainWindow, QMainWindow):
 
     def open_idf_file(self):
         filename = file_dialog(False, "Open IDF file", {"IDF files": ["xml"]})
-        builder = NexusBuilder(
-            str(uuid.uuid4()), idf_file=filename, file_in_memory=True
-        )
-        builder.add_instrument_geometry_from_idf()
-        builder.add_monitors_from_idf()
-        builder.add_detectors_from_idf()
-        self.instrument.nexus.load_nexus_file(builder.target_file)
+        self._load_idf(filename)
         self._update_views()
         QMessageBox.warning(
             self,
             "Mantid IDF loaded",
             "Please manually check the instrument for accuracy.",
         )
+
+    def _load_idf(self, filename):
+        builder = NexusBuilder(
+            str(uuid.uuid4()),
+            idf_file=filename,
+            file_in_memory=True,
+            compress_type="gzip",
+            compress_opts=1,
+        )
+        builder.add_instrument_geometry_from_idf()
+        self.instrument.nexus.load_nexus_file(builder.target_file)
 
     def save_to_filewriter_json(self):
         filename = file_dialog(True, "Save Filewriter JSON File", JSON_FILE_TYPES)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # In general libraries should not be pinned to specific versions
 attrs
 h5py
-git+https://github.com/ess-dmsc/python-nexus-utilities@6f5d2c7f1ca66063227aad2a111a2cc567d573f6#egg=nexusutils
+git+https://github.com/ess-dmsc/python-nexus-utilities@b89304daa55b7146f57ba192fa48f3ed3d1f24ba#egg=nexusutils
 git+https://github.com/ess-dmsc/nexus-json#egg=nexusjson
 numpy-stl
 pint

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,6 @@ build_exe_options = {
         "pandas",
         "netCDF4",
         "matplotlib",
-        "tables",
-        "lxml",
         "fabio",
         "mpl_toolkits",
         "pytz",

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -38,8 +38,6 @@ class Ui_MainWindow(object):
         MainWindow.setCentralWidget(self.central_widget)
 
         self._set_up_menus(MainWindow)
-
-        self.retranslateUi(MainWindow)
         self.tab_widget.setCurrentIndex(0)
         QMetaObject.connectSlotsByName(MainWindow)
         self.splitter.setStretchFactor(0, 0)
@@ -79,8 +77,9 @@ class Ui_MainWindow(object):
         self.file_menu.addAction(self.export_to_filewriter_JSON_action)
         self.file_menu.addAction(self.export_to_forwarder_JSON_action)
         self.menu_bar.addAction(self.file_menu.menuAction())
+        self._set_up_titles(MainWindow)
 
-    def retranslateUi(self, MainWindow):
+    def _set_up_titles(self, MainWindow):
         MainWindow.setWindowTitle("NeXus Constructor")
         self.tab_widget.setTabText(
             self.tab_widget.indexOf(self.component_tree_view_tab), "Components"

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -1,5 +1,15 @@
-from PySide2 import QtCore, QtWidgets
-from PySide2.QtWidgets import QSplitter
+from PySide2.QtCore import QRect, QMetaObject, QSize
+from PySide2.QtWidgets import (
+    QSplitter,
+    QAction,
+    QStatusBar,
+    QMenuBar,
+    QMenu,
+    QWidget,
+    QTabWidget,
+    QGridLayout,
+    QLayout,
+)
 from nexus_constructor.instrument_view import InstrumentView
 from ui.treeview_tab import ComponentTreeViewTab
 
@@ -7,18 +17,18 @@ from ui.treeview_tab import ComponentTreeViewTab
 class Ui_MainWindow(object):
     def setupUi(self, MainWindow):
         MainWindow.resize(1280, 720)
-        self.central_widget = QtWidgets.QWidget(MainWindow)
+        self.central_widget = QWidget(MainWindow)
 
         self.splitter = QSplitter(self.central_widget)
         self.splitter.setChildrenCollapsible(False)
         self.splitter.setOpaqueResize(True)
 
-        self.main_grid_layout = QtWidgets.QGridLayout(self.central_widget)
+        self.main_grid_layout = QGridLayout(self.central_widget)
         self.main_grid_layout.addWidget(self.splitter)
-        self.main_grid_layout.setSizeConstraint(QtWidgets.QLayout.SetDefaultConstraint)
+        self.main_grid_layout.setSizeConstraint(QLayout.SetDefaultConstraint)
 
-        self.tab_widget = QtWidgets.QTabWidget(self.central_widget)
-        self.tab_widget.setMinimumSize(QtCore.QSize(500, 0))
+        self.tab_widget = QTabWidget(self.central_widget)
+        self.tab_widget.setMinimumSize(QSize(500, 0))
         self._set_up_component_tree_view()
         self._set_up_silx_view()
         self.splitter.addWidget(self.tab_widget)
@@ -31,18 +41,18 @@ class Ui_MainWindow(object):
 
         self.retranslateUi(MainWindow)
         self.tab_widget.setCurrentIndex(0)
-        QtCore.QMetaObject.connectSlotsByName(MainWindow)
+        QMetaObject.connectSlotsByName(MainWindow)
         self.splitter.setStretchFactor(0, 0)
         self.splitter.setStretchFactor(1, 1)
 
     def _set_up_3d_view(self):
         self.sceneWidget = InstrumentView(self.splitter)
-        self.sceneWidget.setMinimumSize(QtCore.QSize(600, 0))
+        self.sceneWidget.setMinimumSize(QSize(600, 0))
         self.splitter.addWidget(self.sceneWidget)
 
     def _set_up_silx_view(self):
-        self.silx_tab = QtWidgets.QWidget()
-        self.silx_tab_layout = QtWidgets.QGridLayout(self.silx_tab)
+        self.silx_tab = QWidget()
+        self.silx_tab_layout = QGridLayout(self.silx_tab)
         self.tab_widget.addTab(self.silx_tab, "")
 
     def _set_up_component_tree_view(self):
@@ -50,63 +60,39 @@ class Ui_MainWindow(object):
         self.tab_widget.addTab(self.component_tree_view_tab, "")
 
     def _set_up_menus(self, MainWindow):
-        self.menu_bar = QtWidgets.QMenuBar()
-        self.menu_bar.setGeometry(QtCore.QRect(0, 0, 1280, 720))
-        self.file_menu = QtWidgets.QMenu(self.menu_bar)
+        self.menu_bar = QMenuBar()
+        self.menu_bar.setGeometry(QRect(0, 0, 1280, 720))
+        self.file_menu = QMenu(self.menu_bar)
         MainWindow.setMenuBar(self.menu_bar)
-        self.status_bar = QtWidgets.QStatusBar(MainWindow)
+        self.status_bar = QStatusBar(MainWindow)
         MainWindow.setStatusBar(self.status_bar)
-        self.open_nexus_file_action = QtWidgets.QAction(MainWindow)
-        self.open_json_file_action = QtWidgets.QAction(MainWindow)
-        self.export_to_nexus_file_action = QtWidgets.QAction(MainWindow)
-        self.export_to_filewriter_JSON_action = QtWidgets.QAction(MainWindow)
-        self.export_to_forwarder_JSON_action = QtWidgets.QAction(MainWindow)
+        self.open_nexus_file_action = QAction(MainWindow)
+        self.open_json_file_action = QAction(MainWindow)
+        self.open_idf_file_action = QAction(MainWindow)
+        self.export_to_nexus_file_action = QAction(MainWindow)
+        self.export_to_filewriter_JSON_action = QAction(MainWindow)
+        self.export_to_forwarder_JSON_action = QAction(MainWindow)
         self.file_menu.addAction(self.open_nexus_file_action)
         self.file_menu.addAction(self.open_json_file_action)
+        self.file_menu.addAction(self.open_idf_file_action)
         self.file_menu.addAction(self.export_to_nexus_file_action)
         self.file_menu.addAction(self.export_to_filewriter_JSON_action)
         self.file_menu.addAction(self.export_to_forwarder_JSON_action)
         self.menu_bar.addAction(self.file_menu.menuAction())
 
     def retranslateUi(self, MainWindow):
-        MainWindow.setWindowTitle(
-            QtWidgets.QApplication.translate(
-                "MainWindow", "NeXus Constructor", None, -1
-            )
+        MainWindow.setWindowTitle("NeXus Constructor")
+        self.tab_widget.setTabText(
+            self.tab_widget.indexOf(self.component_tree_view_tab), "Components"
         )
         self.tab_widget.setTabText(
-            self.tab_widget.indexOf(self.component_tree_view_tab),
-            QtWidgets.QApplication.translate("MainWindow", "Components", None, -1),
+            self.tab_widget.indexOf(self.silx_tab), "NeXus File Layout"
         )
-        self.tab_widget.setTabText(
-            self.tab_widget.indexOf(self.silx_tab),
-            QtWidgets.QApplication.translate(
-                "MainWindow", "NeXus File Layout", None, -1
-            ),
-        )
-        self.file_menu.setTitle(
-            QtWidgets.QApplication.translate("MainWindow", "File", None, -1)
-        )
-        self.open_nexus_file_action.setText(
-            QtWidgets.QApplication.translate("MainWindow", "Open NeXus file", None, -1)
-        )
-        self.open_json_file_action.setText(
-            QtWidgets.QApplication.translate(
-                "MainWindow", "Open Filewriter JSON file", None, -1
-            )
-        )
-        self.export_to_nexus_file_action.setText(
-            QtWidgets.QApplication.translate(
-                "MainWindow", "Export to NeXus file", None, -1
-            )
-        )
-        self.export_to_filewriter_JSON_action.setText(
-            QtWidgets.QApplication.translate(
-                "MainWindow", "Export to Filewriter JSON", None, -1
-            )
-        )
-        self.export_to_forwarder_JSON_action.setText(
-            QtWidgets.QApplication.translate(
-                "MainWindow", "Export to Forwarder JSON", None, -1
-            )
-        )
+        self.file_menu.setTitle("File")
+        self.open_nexus_file_action.setText("Open NeXus file")
+        self.open_json_file_action.setText("Open Filewriter JSON file")
+
+        self.open_idf_file_action.setText("Open Mantid IDF file")
+        self.export_to_nexus_file_action.setText("Export to NeXus file")
+        self.export_to_filewriter_JSON_action.setText("Export to Filewriter JSON")
+        self.export_to_forwarder_JSON_action.setText("Export to Forwarder JSON")


### PR DESCRIPTION
### Issue

Closes #148 

### Description of work

Allows loading an IDF file into the nexus constructor. A warning message is then shown to the user saying they should check the file manually for accuracy. 

### Acceptance Criteria 

No functional changes, just minor UI additions. 
Functionality has been used from NexusBuilder in python-nexus-utilities. 

### UI tests

None added - no proper UI logic added. 

### Nominate for Group Code Review

- [ ] Nominate for code review 
