### PR TITLE
Removing component transforms in 3d view when component is deleted

### DIFF
--- a/nexus_constructor/instrument_view.py
+++ b/nexus_constructor/instrument_view.py
@@ -243,6 +243,7 @@ class InstrumentView(QWidget):
         try:
             self.component_entities[name].setParent(None)
             self.component_entities.pop(name)
+            self.transformations.pop(name)
         except KeyError:
             logging.error(
                 f"Unable to delete component {name} because it doesn't exist."


### PR DESCRIPTION
### Issue

Closes #669 

### Description of work

Fixes the `KeyError` that shows up when a component has been deleted that contains transforms. This was caused because the separate dictionary of transforms that we have to keep because of  qt3d falling over if a reference to the `QTransform` is not held.

### Acceptance Criteria 

Follow steps in issue and make sure no `KeyErrors` are thrown

### UI tests

None

### Nominate for Group Code Review

- [ ] Nominate for code review 
