### PR TITLE
Adding optional expected type to unit validator so all units can be validated against

### DIFF
--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -14,6 +14,7 @@ from nexus_constructor.geometry import (
 )
 from nexus_constructor.field_widget import FieldWidget
 from nexus_constructor.invalid_field_names import INVALID_FIELD_NAMES
+from nexus_constructor.unit_utils import METRES
 from ui.add_component import Ui_AddComponentDialog
 from nexus_constructor.component.component_type import PIXEL_COMPONENT_TYPES
 from nexus_constructor.nexus.nexus_wrapper import get_name_of_node
@@ -120,7 +121,7 @@ class AddComponentDialog(Ui_AddComponentDialog, QObject):
 
         validate_line_edit(self.fileLineEdit, False)
 
-        self.unitsLineEdit.setValidator(UnitValidator())
+        self.unitsLineEdit.setValidator(UnitValidator(expected_type=METRES))
         self.unitsLineEdit.validator().is_valid.connect(
             partial(
                 validate_line_edit,

--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -121,7 +121,7 @@ class AddComponentDialog(Ui_AddComponentDialog, QObject):
 
         validate_line_edit(self.fileLineEdit, False)
 
-        self.unitsLineEdit.setValidator(UnitValidator(expected_type=METRES))
+        self.unitsLineEdit.setValidator(UnitValidator(expected_dimensionality=METRES))
         self.unitsLineEdit.validator().is_valid.connect(
             partial(
                 validate_line_edit,

--- a/nexus_constructor/geometry/disk_chopper/disk_chopper_checker.py
+++ b/nexus_constructor/geometry/disk_chopper/disk_chopper_checker.py
@@ -8,7 +8,7 @@ from nexus_constructor.common_attrs import CommonAttrs
 from nexus_constructor.geometry.disk_chopper.chopper_details import ChopperDetails
 from nexus_constructor.unit_utils import (
     units_are_recognised_by_pint,
-    units_are_expected_type,
+    units_are_expected_dimensionality,
     units_have_magnitude_of_one,
 )
 from nexus_constructor.validators import DATASET_TYPE
@@ -223,7 +223,7 @@ class NexusDefinedChopperChecker:
                 )
                 good_units = False
                 continue
-            if not units_are_expected_type(
+            if not units_are_expected_dimensionality(
                 unit_input, EXPECTED_UNIT_TYPE[field], False
             ):
                 logging.info(

--- a/nexus_constructor/transformation_view.py
+++ b/nexus_constructor/transformation_view.py
@@ -1,5 +1,6 @@
 from nexus_constructor.field_utils import find_field_type
 from nexus_constructor.transformation_types import TransformationType
+from nexus_constructor.unit_utils import METRES, RADIANS
 from ui.transformation import Ui_Transformation
 from ui.link import Ui_Link
 from PySide2.QtWidgets import QGroupBox, QFrame, QWidget, QLabel
@@ -74,6 +75,9 @@ class EditTranslation(EditTransformation):
         self, parent: QWidget, transformation: Transformation, instrument: Instrument
     ):
         super().__init__(parent, transformation, instrument)
+        self.transformation_frame.magnitude_widget.unit_validator.expected_dimensionality = (
+            METRES
+        )
         self.transformation_frame.vector_label.setText("Direction")
         self.transformation_frame.value_label.setText("Distance (m)")
         self.setTitle(TransformationType.TRANSLATION)
@@ -84,6 +88,9 @@ class EditRotation(EditTransformation):
         self, parent: QWidget, transformation: Transformation, instrument: Instrument
     ):
         super().__init__(parent, transformation, instrument)
+        self.transformation_frame.magnitude_widget.unit_validator.expected_dimensionality = (
+            RADIANS
+        )
         self.transformation_frame.vector_label.setText("Rotation Axis")
         self.transformation_frame.value_label.setText("Angle (°)")
         self.setTitle(TransformationType.ROTATION)

--- a/nexus_constructor/unit_utils.py
+++ b/nexus_constructor/unit_utils.py
@@ -31,11 +31,11 @@ def units_are_recognised_by_pint(input: str, emit_logging_msg: bool = True) -> b
     return True
 
 
-def units_are_expected_type(
+def units_are_expected_dimensionality(
     input: str, expected_unit_type: str, emit_logging_msg=True
 ) -> bool:
     """
-    Checks if a unit is the expected type by trying to convert it.
+    Checks if a unit is the expected dimensionality by trying to convert it.
     :param input: The units string.
     :return: True if the conversion was successful, False otherwise.
     """

--- a/nexus_constructor/validators.py
+++ b/nexus_constructor/validators.py
@@ -15,7 +15,7 @@ from stl import mesh
 
 from nexus_constructor.unit_utils import (
     units_are_recognised_by_pint,
-    units_are_expected_type,
+    units_are_expected_dimensionality,
     units_have_magnitude_of_one,
 )
 
@@ -46,16 +46,22 @@ class UnitValidator(QValidator):
     Validator to ensure the the text entered is a valid unit of length.
     """
 
-    def __init__(self, expected_type=None):
+    def __init__(self, expected_dimensionality=None):
         super().__init__()
         self.ureg = pint.UnitRegistry()
-        self.expected_type = expected_type
+        self.expected_dimensionality = expected_dimensionality
 
     def validate(self, input: str, pos: int):
 
         if not (
             units_are_recognised_by_pint(input)
-            and self._is_expected_type(input)
+            and (
+                True
+                if self.expected_dimensionality is None
+                else units_are_expected_dimensionality(
+                    input, self.expected_dimensionality
+                )
+            )
             and units_have_magnitude_of_one(input)
         ):
             self.is_valid.emit(False)
@@ -63,11 +69,6 @@ class UnitValidator(QValidator):
 
         self.is_valid.emit(True)
         return QValidator.Acceptable
-
-    def _is_expected_type(self, input: str):
-        if self.expected_type is not None:
-            return units_are_expected_type(input, self.expected_type)
-        return True
 
     is_valid = Signal(bool)
 

--- a/nexus_constructor/validators.py
+++ b/nexus_constructor/validators.py
@@ -17,7 +17,6 @@ from nexus_constructor.unit_utils import (
     units_are_recognised_by_pint,
     units_are_expected_type,
     units_have_magnitude_of_one,
-    METRES,
 )
 
 HDF_FILE_EXTENSIONS = ("nxs", "hdf", "hdf5")
@@ -47,15 +46,16 @@ class UnitValidator(QValidator):
     Validator to ensure the the text entered is a valid unit of length.
     """
 
-    def __init__(self):
+    def __init__(self, expected_type=None):
         super().__init__()
         self.ureg = pint.UnitRegistry()
+        self.expected_type = expected_type
 
     def validate(self, input: str, pos: int):
 
         if not (
             units_are_recognised_by_pint(input)
-            and units_are_expected_type(input, METRES)
+            and self._is_expected_type(input)
             and units_have_magnitude_of_one(input)
         ):
             self.is_valid.emit(False)
@@ -63,6 +63,11 @@ class UnitValidator(QValidator):
 
         self.is_valid.emit(True)
         return QValidator.Acceptable
+
+    def _is_expected_type(self, input: str):
+        if self.expected_type is not None:
+            return units_are_expected_type(input, self.expected_type)
+        return True
 
     is_valid = Signal(bool)
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -99,7 +99,7 @@ def test_name_validator_set_to_duplicate_name():
     )
 
 
-def test_unit_validator_with_metres_set_as_expected_type():
+def test_unit_validator_with_metres_set_as_expected_dimensionality():
     validator = UnitValidator(expected_dimensionality=METRES)
 
     lengths = ["mile", "cm", "centimetre", "yard", "km"]

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -127,7 +127,7 @@ def test_unit_validator_with_metres_set_as_expected_type():
         assert validator.validate(unit, 0) == QValidator.Intermediate
 
 
-def test_unit_validator_with_no_expected_type():
+def test_unit_validator_with_no_expected_dimensionality():
     validator = UnitValidator()
 
     valid_units = ["deg", "m", "cm", "dm", "rad"]

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -100,7 +100,7 @@ def test_name_validator_set_to_duplicate_name():
 
 
 def test_unit_validator_with_metres_set_as_expected_type():
-    validator = UnitValidator(expected_type=METRES)
+    validator = UnitValidator(expected_dimensionality=METRES)
 
     lengths = ["mile", "cm", "centimetre", "yard", "km"]
     not_lengths = [

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -4,6 +4,7 @@ from typing import List
 
 import pytest
 
+from nexus_constructor.unit_utils import METRES
 from nexus_constructor.validators import (
     NameValidator,
     UnitValidator,
@@ -98,8 +99,8 @@ def test_name_validator_set_to_duplicate_name():
     )
 
 
-def test_unit_validator():
-    validator = UnitValidator()
+def test_unit_validator_with_metres_set_as_expected_type():
+    validator = UnitValidator(expected_type=METRES)
 
     lengths = ["mile", "cm", "centimetre", "yard", "km"]
     not_lengths = [
@@ -123,6 +124,20 @@ def test_unit_validator():
         assert validator.validate(unit, 0) == QValidator.Acceptable
 
     for unit in not_lengths:
+        assert validator.validate(unit, 0) == QValidator.Intermediate
+
+
+def test_unit_validator_with_no_expected_type():
+    validator = UnitValidator()
+
+    valid_units = ["deg", "m", "cm", "dm", "rad"]
+
+    invalid_units = ["asdfghj", "degre", "2 degrees"]
+
+    for unit in valid_units:
+        assert validator.validate(unit, 0) == QValidator.Acceptable
+
+    for unit in invalid_units:
         assert validator.validate(unit, 0) == QValidator.Intermediate
 
 


### PR DESCRIPTION
### Issue

Closes #663 

### Description of work

Adds an optional parameter when setting up a unit validator so an expected type can be specified. 
In the case of the add component window and for the OFF file units line edit, this is set to units of length (cm, m etc.)
Everywhere else this is now unset so stuff like `deg` will work. 

### Acceptance Criteria 

Added test for degrees etc without specifying an expected type. 

### UI tests

No ui tests added as problem was in logic anyway

### Nominate for Group Code Review

- [ ] Nominate for code review 
