### PR TITLE
Setting the default type in f142 (and all schemas) to double

### DIFF
--- a/nexus_constructor/stream_fields_widget.py
+++ b/nexus_constructor/stream_fields_widget.py
@@ -99,6 +99,7 @@ class StreamFieldsWidget(QDialog):
         self.type_label = QLabel("Type: ")
         self.type_combo = QComboBox()
         self.type_combo.addItems(F142_TYPES)
+        self.type_combo.setCurrentText("double")
 
         self.value_units_edit = QLineEdit()
         self.value_units_label = QLabel("Value Units:")


### PR DESCRIPTION
### Issue

Closes #667 

### Description of work

Sets the initial value of `type` to `double` in the stream fields widget.
The default schema is f142 anyway so i think setting it when setting up the UI for the widget is sufficient. 

### Acceptance Criteria 

No functional changes

### UI tests

None

### Nominate for Group Code Review

- [ ] Nominate for code review 
