### PR TITLE
Fixing byte strings not being displayed correctly in field widget value edit

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,7 +6,4 @@ select = B,C,E,F,W,T4,B9
 exclude = ui/,build*,definitions
 per-file-ignores =
     nexus_constructor/geometry/__init__.py:F401
-    tests/test_json_writer.py:F811
-    tests/ui_tests/test_stream_fields_widget.py:F811
-    tests/ui_tests/test_ui_field_attrs.py:F811
     tests/ui_tests/test_ui_fields.py:F811,F401

--- a/nexus_constructor/component/component.py
+++ b/nexus_constructor/component/component.py
@@ -8,7 +8,7 @@ from nexus_constructor.common_attrs import CommonAttrs
 from nexus_constructor.component.pixel_shape import PixelShape
 from nexus_constructor.component.transformations_list import TransformationsList
 from nexus_constructor.nexus import nexus_wrapper as nx
-from nexus_constructor.nexus.nexus_wrapper import get_nx_class, decode_bytes_string
+from nexus_constructor.nexus.nexus_wrapper import get_nx_class, to_string
 from nexus_constructor.field_utils import get_fields_with_update_functions
 from nexus_constructor.pixel_data import PixelMapping, PixelGrid, PixelData
 from nexus_constructor.pixel_data_to_nexus_utils import (
@@ -170,9 +170,7 @@ class Component:
             if (
                 transforms
                 and depends_on
-                == decode_bytes_string(
-                    transforms[-1].dataset.attrs[CommonAttrs.DEPENDS_ON]
-                )
+                == to_string(transforms[-1].dataset.attrs[CommonAttrs.DEPENDS_ON])
                 and depends_on
                 in [x.split("/")[-1] for x in transforms[-1].dataset.parent.keys()]
             ):

--- a/nexus_constructor/field_widget.py
+++ b/nexus_constructor/field_widget.py
@@ -270,7 +270,7 @@ class FieldWidget(QFrame):
     def _scalar_value_to_string(input_value: Any):
         """
         converts a scalar numpy value to string.
-        NB: this is different to decode_nexus_string() as numpy objects are cast-able to
+        NB: this is different to decode_bytes_string() as numpy objects are cast-able to
         string already unless they are bytes.
         """
         if isinstance(input_value, bytes):

--- a/nexus_constructor/field_widget.py
+++ b/nexus_constructor/field_widget.py
@@ -20,7 +20,10 @@ from nexus_constructor.array_dataset_table_widget import ArrayDatasetTableWidget
 from nexus_constructor.common_attrs import CommonAttrs
 from nexus_constructor.field_attrs import FieldAttrsDialog
 from nexus_constructor.invalid_field_names import INVALID_FIELD_NAMES
-from nexus_constructor.nexus.nexus_wrapper import create_temporary_in_memory_file
+from nexus_constructor.nexus.nexus_wrapper import (
+    create_temporary_in_memory_file,
+    decode_bytes_string,
+)
 from nexus_constructor.stream_fields_widget import StreamFieldsWidget
 from nexus_constructor.ui_utils import validate_line_edit
 from nexus_constructor.validators import (
@@ -269,7 +272,7 @@ class FieldWidget(QFrame):
     @value.setter
     def value(self, value):
         if self.field_type == FieldType.scalar_dataset:
-            self.value_line_edit.setText(str(value))
+            self.value_line_edit.setText(decode_bytes_string(value))
         elif self.field_type == FieldType.array_dataset:
             self.table_view.model.array = value
         elif self.field_type == FieldType.link:

--- a/nexus_constructor/field_widget.py
+++ b/nexus_constructor/field_widget.py
@@ -15,12 +15,15 @@ from PySide2.QtWidgets import (
 )
 from PySide2.QtWidgets import QCompleter, QLineEdit, QSizePolicy
 from PySide2.QtCore import QStringListModel, Qt, Signal, QEvent, QObject
-from typing import List, Union, Any
+from typing import List, Union
 from nexus_constructor.array_dataset_table_widget import ArrayDatasetTableWidget
 from nexus_constructor.common_attrs import CommonAttrs
 from nexus_constructor.field_attrs import FieldAttrsDialog
 from nexus_constructor.invalid_field_names import INVALID_FIELD_NAMES
-from nexus_constructor.nexus.nexus_wrapper import create_temporary_in_memory_file
+from nexus_constructor.nexus.nexus_wrapper import (
+    create_temporary_in_memory_file,
+    to_string,
+)
 from nexus_constructor.stream_fields_widget import StreamFieldsWidget
 from nexus_constructor.ui_utils import validate_line_edit
 from nexus_constructor.validators import (
@@ -266,21 +269,10 @@ class FieldWidget(QFrame):
                 )
         return return_object
 
-    @staticmethod
-    def _scalar_value_to_string(input_value: Any):
-        """
-        converts a scalar numpy value to string.
-        NB: this is different to decode_bytes_string() as numpy objects are cast-able to
-        string already unless they are bytes.
-        """
-        if isinstance(input_value, bytes):
-            return input_value.decode("utf-8")
-        return str(input_value)
-
     @value.setter
     def value(self, value):
         if self.field_type == FieldType.scalar_dataset:
-            self.value_line_edit.setText(self._scalar_value_to_string(value))
+            self.value_line_edit.setText(to_string(value))
         elif self.field_type == FieldType.array_dataset:
             self.table_view.model.array = value
         elif self.field_type == FieldType.link:

--- a/nexus_constructor/field_widget.py
+++ b/nexus_constructor/field_widget.py
@@ -15,15 +15,12 @@ from PySide2.QtWidgets import (
 )
 from PySide2.QtWidgets import QCompleter, QLineEdit, QSizePolicy
 from PySide2.QtCore import QStringListModel, Qt, Signal, QEvent, QObject
-from typing import List, Union
+from typing import List, Union, Any
 from nexus_constructor.array_dataset_table_widget import ArrayDatasetTableWidget
 from nexus_constructor.common_attrs import CommonAttrs
 from nexus_constructor.field_attrs import FieldAttrsDialog
 from nexus_constructor.invalid_field_names import INVALID_FIELD_NAMES
-from nexus_constructor.nexus.nexus_wrapper import (
-    create_temporary_in_memory_file,
-    decode_bytes_string,
-)
+from nexus_constructor.nexus.nexus_wrapper import create_temporary_in_memory_file
 from nexus_constructor.stream_fields_widget import StreamFieldsWidget
 from nexus_constructor.ui_utils import validate_line_edit
 from nexus_constructor.validators import (
@@ -269,10 +266,21 @@ class FieldWidget(QFrame):
                 )
         return return_object
 
+    @staticmethod
+    def _scalar_value_to_string(input_value: Any):
+        """
+        converts a scalar numpy value to string.
+        NB: this is different to decode_nexus_string() as numpy objects are cast-able to
+        string already unless they are bytes.
+        """
+        if isinstance(input_value, bytes):
+            return input_value.decode("utf-8")
+        return str(input_value)
+
     @value.setter
     def value(self, value):
         if self.field_type == FieldType.scalar_dataset:
-            self.value_line_edit.setText(decode_bytes_string(value))
+            self.value_line_edit.setText(self._scalar_value_to_string(value))
         elif self.field_type == FieldType.array_dataset:
             self.table_view.model.array = value
         elif self.field_type == FieldType.link:

--- a/nexus_constructor/nexus/nexus_wrapper.py
+++ b/nexus_constructor/nexus/nexus_wrapper.py
@@ -35,14 +35,19 @@ def get_nx_class(group: h5py.Group) -> Optional[str]:
         return None
 
     nx_class = group.attrs[CommonAttrs.NX_CLASS]
-    return decode_bytes_string(nx_class)
+    return to_string(nx_class)
 
 
-def decode_bytes_string(nexus_string):
-    try:
-        return str(nexus_string, encoding="utf8")
-    except TypeError:
-        return nexus_string
+def to_string(input_to_convert: Any) -> str:
+    """
+    Converts to string, assumes utf-8 encoding for bytes
+    Input can be bytes, str, numpy array
+    :param input_to_convert: Dataset value to convert
+    :return: str
+    """
+    if isinstance(input_to_convert, bytes):
+        return input_to_convert.decode("utf-8")
+    return str(input_to_convert)
 
 
 def create_temporary_in_memory_file() -> h5py.File:

--- a/nexus_constructor/transformations.py
+++ b/nexus_constructor/transformations.py
@@ -9,7 +9,7 @@ from nexus_constructor.common_attrs import CommonAttrs
 from nexus_constructor.nexus import nexus_wrapper as nx
 from typing import TypeVar, Union, List, Optional
 
-from nexus_constructor.nexus.nexus_wrapper import h5Node, decode_bytes_string
+from nexus_constructor.nexus.nexus_wrapper import h5Node, to_string
 from nexus_constructor.transformation_types import TransformationType
 
 TransformationOrComponent = TypeVar(
@@ -369,7 +369,7 @@ def create_transformation(wrapper: nx.NexusWrapper, node: h5Node) -> Transformat
     """
     if (
         CommonAttrs.NX_CLASS in node.attrs
-        and decode_bytes_string(node.attrs[CommonAttrs.NX_CLASS]) == "NXlog"
+        and to_string(node.attrs[CommonAttrs.NX_CLASS]) == "NXlog"
     ):
         return NXLogTransformation(wrapper, node)
     return Transformation(wrapper, node)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
+import uuid
 from unittest.mock import Mock
 
+import h5py
 import pytest
 from PySide2.QtWidgets import QDialog
 
@@ -18,7 +20,7 @@ def template(qtbot) -> QDialog:
 
 @pytest.fixture(scope="function")
 def nexus_wrapper() -> NexusWrapper:
-    nexus_wrapper = NexusWrapper("test")
+    nexus_wrapper = NexusWrapper(str(uuid.uuid4()))
     yield nexus_wrapper
     nexus_wrapper.nexus_file.close()
 
@@ -51,3 +53,22 @@ def mock_pixel_options():
     change_mapping_filename(None)
 
     return pixel_options
+
+
+class InMemoryFile(object):
+    def __init__(self, filename):
+        self.file_obj = h5py.File(
+            filename, mode="x", driver="core", backing_store=False
+        )
+
+    def __enter__(self):
+        return self.file_obj
+
+    def __exit__(self, type, value, traceback):
+        self.file_obj.close()
+
+
+@pytest.fixture
+def file():
+    with InMemoryFile("test_file") as file:
+        yield file

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,5 +1,3 @@
-import h5py
-import pytest
 from typing import Any
 from nexus_constructor.component.component import Component
 from nexus_constructor.nexus.nexus_wrapper import NexusWrapper
@@ -15,22 +13,3 @@ def add_component_to_file(
     component_group.create_dataset(field_name, data=field_value)
     component = Component(nexus_wrapper, component_group)
     return component
-
-
-class InMemoryFile(object):
-    def __init__(self, filename):
-        self.file_obj = h5py.File(
-            filename, mode="x", driver="core", backing_store=False
-        )
-
-    def __enter__(self):
-        return self.file_obj
-
-    def __exit__(self, type, value, traceback):
-        self.file_obj.close()
-
-
-@pytest.fixture
-def file():
-    with InMemoryFile("test_file") as file:
-        yield file

--- a/tests/test_component_factory.py
+++ b/tests/test_component_factory.py
@@ -4,7 +4,6 @@ from nexus_constructor.component.chopper_shape import ChopperShape
 from nexus_constructor.component.component_shape import ComponentShape
 from nexus_constructor.component.pixel_shape import PixelShape
 from nexus_constructor.component.component_factory import create_component
-from nexus_constructor.nexus import nexus_wrapper as nx
 from nexus_constructor.geometry import (
     OFFGeometryNoNexus,
     NoShapeGeometry,
@@ -36,22 +35,24 @@ def add_dataset(group, name, data, attributes=None):
     return dataset
 
 
-def test_GIVEN_an_NXdisk_chopper_group_WHEN_calling_create_component_THEN_component_has_a_ChopperShape():
-    wrapper = nx.NexusWrapper("file_with_chopper")
-    chopper_group = wrapper.create_nx_group(
-        "chopper", "NXdisk_chopper", wrapper.instrument
+def test_GIVEN_an_NXdisk_chopper_group_WHEN_calling_create_component_THEN_component_has_a_ChopperShape(
+    nexus_wrapper,
+):
+    chopper_group = nexus_wrapper.create_nx_group(
+        "chopper", "NXdisk_chopper", nexus_wrapper.instrument
     )
-    new_component = create_component(wrapper, chopper_group)
+    new_component = create_component(nexus_wrapper, chopper_group)
     assert isinstance(new_component._shape, ChopperShape)
     assert isinstance(
         new_component.shape[0], NoShapeGeometry
     ), "Expect chopper component to return NoShapeGeometry as it has insufficient details to create a mesh of the disk shape"
 
 
-def test_GIVEN_an_NXdisk_chopper_group_WHEN_calling_create_component_THEN_component_returns_OFFGeometry_of_chopper():
-    wrapper = nx.NexusWrapper("file_with_chopper")
-    chopper_group = wrapper.create_nx_group(
-        "chopper", "NXdisk_chopper", wrapper.instrument
+def test_GIVEN_an_NXdisk_chopper_group_WHEN_calling_create_component_THEN_component_returns_OFFGeometry_of_chopper(
+    nexus_wrapper,
+):
+    chopper_group = nexus_wrapper.create_nx_group(
+        "chopper", "NXdisk_chopper", nexus_wrapper.instrument
     )
     add_dataset(
         chopper_group,
@@ -78,7 +79,7 @@ def test_GIVEN_an_NXdisk_chopper_group_WHEN_calling_create_component_THEN_compon
     add_dataset(chopper_group, "slits", 6)
     add_dataset(chopper_group, "slit_height", 130.0, attributes={"units": "mm"})
     add_dataset(chopper_group, "radius", 300.0, attributes={"units": "mm"})
-    new_component = create_component(wrapper, chopper_group)
+    new_component = create_component(nexus_wrapper, chopper_group)
     assert isinstance(new_component._shape, ChopperShape)
     assert isinstance(new_component.shape[0], OFFGeometryNoNexus)
     assert (
@@ -86,51 +87,59 @@ def test_GIVEN_an_NXdisk_chopper_group_WHEN_calling_create_component_THEN_compon
     ), "Expect chopper geometry with many vertices, not just a placeholder cube with 8 vertices"
 
 
-def test_GIVEN_an_nx_group_with_no_shape_WHEN_calling_create_component_THEN_component_has_a_ComponentShape():
-    wrapper = nx.NexusWrapper("file_with_component_with_no_shape")
-    monitor_group = wrapper.create_nx_group("monitor", "NXmonitor", wrapper.instrument)
-    new_component = create_component(wrapper, monitor_group)
+def test_GIVEN_an_nx_group_with_no_shape_WHEN_calling_create_component_THEN_component_has_a_ComponentShape(
+    nexus_wrapper,
+):
+    monitor_group = nexus_wrapper.create_nx_group(
+        "monitor", "NXmonitor", nexus_wrapper.instrument
+    )
+    new_component = create_component(nexus_wrapper, monitor_group)
     assert isinstance(new_component._shape, ComponentShape)
 
 
-def test_GIVEN_an_nx_group_with_shape_WHEN_calling_create_component_THEN_component_returns_OFFGeometry():
-    wrapper = nx.NexusWrapper("file_with_component_with_shape")
-    monitor_group = wrapper.create_nx_group("monitor", "NXmonitor", wrapper.instrument)
-    new_component = create_component(wrapper, monitor_group)
+def test_GIVEN_an_nx_group_with_shape_WHEN_calling_create_component_THEN_component_returns_OFFGeometry(
+    nexus_wrapper,
+):
+    monitor_group = nexus_wrapper.create_nx_group(
+        "monitor", "NXmonitor", nexus_wrapper.instrument
+    )
+    new_component = create_component(nexus_wrapper, monitor_group)
 
-    shape_group = wrapper.create_nx_group(
+    shape_group = nexus_wrapper.create_nx_group(
         "shape", "NXoff_geometry", new_component.group
     )
-    vertices_dataset = wrapper.set_field_value(
+    vertices_dataset = nexus_wrapper.set_field_value(
         shape_group,
         "vertices",
         np.array([[0, 2, -2], [-1, -1, 1], [1, -1, 1]]),
         dtype=np.float,
     )
-    wrapper.set_field_value(
+    nexus_wrapper.set_field_value(
         shape_group, "winding_order", np.array([0, 1, 2]), dtype=np.int32
     )
-    wrapper.set_field_value(shape_group, "faces", np.array([0]), dtype=np.int32)
-    wrapper.set_attribute_value(vertices_dataset, "units", "m")
+    nexus_wrapper.set_field_value(shape_group, "faces", np.array([0]), dtype=np.int32)
+    nexus_wrapper.set_attribute_value(vertices_dataset, "units", "m")
 
     assert isinstance(new_component.shape[0], OFFGeometryNexus)
 
 
-def test_GIVEN_an_NXdetector_group_with_detector_shape_WHEN_calling_create_component_THEN_component_has_a_ComponentShape():
-    wrapper = nx.NexusWrapper("file_with_detector")
-    detector_group = wrapper.create_nx_group(
-        "detector", "NXdetector", wrapper.instrument
+def test_GIVEN_an_NXdetector_group_with_detector_shape_WHEN_calling_create_component_THEN_component_has_a_ComponentShape(
+    nexus_wrapper,
+):
+    detector_group = nexus_wrapper.create_nx_group(
+        "detector", "NXdetector", nexus_wrapper.instrument
     )
-    wrapper.create_nx_group("detector_shape", "NXoff_geometry", detector_group)
-    new_component = create_component(wrapper, detector_group)
+    nexus_wrapper.create_nx_group("detector_shape", "NXoff_geometry", detector_group)
+    new_component = create_component(nexus_wrapper, detector_group)
     assert isinstance(new_component._shape, ComponentShape)
 
 
-def test_GIVEN_an_NXdetector_group_with_pixel_shape_WHEN_calling_create_component_THEN_component_has_a_PixelShape():
-    wrapper = nx.NexusWrapper("file_with_detector")
-    detector_group = wrapper.create_nx_group(
-        "detector", "NXdetector", wrapper.instrument
+def test_GIVEN_an_NXdetector_group_with_pixel_shape_WHEN_calling_create_component_THEN_component_has_a_PixelShape(
+    nexus_wrapper,
+):
+    detector_group = nexus_wrapper.create_nx_group(
+        "detector", "NXdetector", nexus_wrapper.instrument
     )
-    wrapper.create_nx_group("pixel_shape", "NXoff_geometry", detector_group)
-    new_component = create_component(wrapper, detector_group)
+    nexus_wrapper.create_nx_group("pixel_shape", "NXoff_geometry", detector_group)
+    new_component = create_component(nexus_wrapper, detector_group)
     assert isinstance(new_component._shape, PixelShape)

--- a/tests/test_component_fields.py
+++ b/tests/test_component_fields.py
@@ -1,4 +1,3 @@
-from nexus_constructor.nexus.nexus_wrapper import NexusWrapper
 from nexus_constructor.component.component import Component, add_fields_to_component
 import numpy as np
 
@@ -26,11 +25,12 @@ class DummyField:
         self.dtype = dtype
 
 
-def test_GIVEN_single_scalar_field_and_float_WHEN_adding_fields_to_component_THEN_field_appears_in_component_fields_with_correct_name_and_value():
-    file = NexusWrapper("test_fields_1")
+def test_GIVEN_single_scalar_field_and_float_WHEN_adding_fields_to_component_THEN_field_appears_in_component_fields_with_correct_name_and_value(
+    nexus_wrapper,
+):
 
-    component_group = file.nexus_file.create_group("test_component")
-    component = Component(file, component_group)
+    component_group = nexus_wrapper.nexus_file.create_group("test_component")
+    component = Component(nexus_wrapper, component_group)
 
     field_name = "test_field"
     field_dtype = np.float32
@@ -48,11 +48,12 @@ def test_GIVEN_single_scalar_field_and_float_WHEN_adding_fields_to_component_THE
     assert component.get_field(field_name)[...] == field_value
 
 
-def test_GIVEN_single_scalar_field_and_string_WHEN_adding_fields_to_component_THEN_field_appears_in_component_fields_with_correct_name_and_value():
-    file = NexusWrapper("test_fields_2")
+def test_GIVEN_single_scalar_field_and_string_WHEN_adding_fields_to_component_THEN_field_appears_in_component_fields_with_correct_name_and_value(
+    nexus_wrapper,
+):
 
-    component_group = file.nexus_file.create_group("test_component")
-    component = Component(file, component_group)
+    component_group = nexus_wrapper.nexus_file.create_group("test_component")
+    component = Component(nexus_wrapper, component_group)
 
     field_name = "test_field"
     field_value = np.string_(b"some_value")

--- a/tests/test_component_tree_model.py
+++ b/tests/test_component_tree_model.py
@@ -499,9 +499,8 @@ def test_duplicate_transform_fail():
     assert False  # Failure
 
 
-def test_remove_component():
-    wrapper = NexusWrapper("test_remove_component")
-    instrument = Instrument(wrapper, NX_CLASS_DEFINITIONS)
+def test_remove_component(nexus_wrapper):
+    instrument = Instrument(nexus_wrapper, NX_CLASS_DEFINITIONS)
     under_test = ComponentTreeModel(instrument)
     instrument.create_component("Some name", "some class", "desc")
     component_index = under_test.index(0, 0, QModelIndex())
@@ -510,9 +509,8 @@ def test_remove_component():
     assert under_test.rowCount(QModelIndex()) == 0
 
 
-def test_remove_transformation():
-    wrapper = NexusWrapper("test_remove_transformation")
-    instrument = Instrument(wrapper, NX_CLASS_DEFINITIONS)
+def test_remove_transformation(nexus_wrapper):
+    instrument = Instrument(nexus_wrapper, NX_CLASS_DEFINITIONS)
     under_test = ComponentTreeModel(instrument)
     instrument.create_component("Some name", "some class", "desc")
     component_index = under_test.index(0, 0, QModelIndex())
@@ -524,9 +522,8 @@ def test_remove_transformation():
     assert under_test.rowCount(transformation_list_index) == 0
 
 
-def test_remove_link():
-    wrapper = NexusWrapper("test_remove_link")
-    instrument = Instrument(wrapper, NX_CLASS_DEFINITIONS)
+def test_remove_link(nexus_wrapper):
+    instrument = Instrument(nexus_wrapper, NX_CLASS_DEFINITIONS)
     under_test = ComponentTreeModel(instrument)
     instrument.create_component("Some name", "some class", "desc")
     component_index = under_test.index(0, 0, QModelIndex())
@@ -539,9 +536,11 @@ def test_remove_link():
     assert under_test.rowCount(transformation_list_index) == 0
 
 
-def test_GIVEN_component_with_cylindrical_shape_information_WHEN_duplicating_component_THEN_shape_information_is_stored_in_nexus_file():
-    wrapper = NexusWrapper("test_duplicate_cyl_shape")
-    instrument = Instrument(wrapper, NX_CLASS_DEFINITIONS)
+def test_GIVEN_component_with_cylindrical_shape_information_WHEN_duplicating_component_THEN_shape_information_is_stored_in_nexus_file(
+    nexus_wrapper,
+):
+
+    instrument = Instrument(nexus_wrapper, NX_CLASS_DEFINITIONS)
 
     first_component_name = "component1"
     first_component_nx_class = "NXdetector"
@@ -571,9 +570,10 @@ def test_GIVEN_component_with_cylindrical_shape_information_WHEN_duplicating_com
     assert second_shape.units == units
 
 
-def test_GIVEN_component_with_off_shape_information_WHEN_duplicating_component_THEN_shape_information_is_stored_in_nexus_file():
-    wrapper = NexusWrapper("test_duplicate_off_shape")
-    instrument = Instrument(wrapper, NX_CLASS_DEFINITIONS)
+def test_GIVEN_component_with_off_shape_information_WHEN_duplicating_component_THEN_shape_information_is_stored_in_nexus_file(
+    nexus_wrapper,
+):
+    instrument = Instrument(nexus_wrapper, NX_CLASS_DEFINITIONS)
 
     first_component_name = "component1"
     first_component_nx_class = "NXdetector"

--- a/tests/test_disk_chopper_checker.py
+++ b/tests/test_disk_chopper_checker.py
@@ -22,7 +22,6 @@ from tests.chopper_test_helpers import (  # noqa: F401
     SLIT_HEIGHT_LENGTH,
     RADIANS_EDGES_ARR,
 )
-from tests.helpers import InMemoryFile
 
 IMPROPER_UNITS = {
     SLIT_EDGES_NAME: "lumen",
@@ -68,18 +67,17 @@ def fields_dict():
 
 
 @pytest.fixture(scope="function")
-def nexus_disk_chopper():
-    with InMemoryFile("test_disk_chopper") as nexus_file:
-        disk_chopper_group = nexus_file.create_group("Disk Chopper")
-        disk_chopper_group[NAME] = "abc"
-        disk_chopper_group[SLITS_NAME] = N_SLITS
-        disk_chopper_group[SLIT_EDGES_NAME] = RADIANS_EDGES_ARR
-        disk_chopper_group[RADIUS_NAME] = RADIUS_LENGTH
-        disk_chopper_group[SLIT_HEIGHT_NAME] = SLIT_HEIGHT_LENGTH
-        disk_chopper_group[SLIT_EDGES_NAME].attrs["units"] = str.encode("rad")
-        disk_chopper_group[RADIUS_NAME].attrs["units"] = str.encode("m")
-        disk_chopper_group[SLIT_HEIGHT_NAME].attrs["units"] = str.encode("m")
-        yield disk_chopper_group
+def nexus_disk_chopper(file):
+    disk_chopper_group = file.create_group("Disk Chopper")
+    disk_chopper_group[NAME] = "abc"
+    disk_chopper_group[SLITS_NAME] = N_SLITS
+    disk_chopper_group[SLIT_EDGES_NAME] = RADIANS_EDGES_ARR
+    disk_chopper_group[RADIUS_NAME] = RADIUS_LENGTH
+    disk_chopper_group[SLIT_HEIGHT_NAME] = SLIT_HEIGHT_LENGTH
+    disk_chopper_group[SLIT_EDGES_NAME].attrs["units"] = str.encode("rad")
+    disk_chopper_group[RADIUS_NAME].attrs["units"] = str.encode("m")
+    disk_chopper_group[SLIT_HEIGHT_NAME].attrs["units"] = str.encode("m")
+    yield disk_chopper_group
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -1,8 +1,6 @@
 from nexus_constructor.transformations import Transformation
 from nexus_constructor.instrument import _convert_name_with_spaces, Instrument
-from nexus_constructor.nexus.nexus_wrapper import NexusWrapper
 from tests.test_utils import NX_CLASS_DEFINITIONS
-from tests.helpers import file  # noqa: F401
 
 
 def test_GIVEN_name_with_spaces_WHEN_converting_name_with_spaces_THEN_converts_spaces_in_name_to_underscores():
@@ -15,9 +13,10 @@ def test_GIVEN_name_without_spaces_WHEN_converting_name_with_spaces_THEN_name_do
     assert _convert_name_with_spaces(name) == name
 
 
-def test_GIVEN_nothing_WHEN_getting_components_list_THEN_list_contains_sample_and_no_components():
-    wrapper = NexusWrapper("component_list_with_sample")
-    instrument = Instrument(wrapper, NX_CLASS_DEFINITIONS)
+def test_GIVEN_nothing_WHEN_getting_components_list_THEN_list_contains_sample_and_no_components(
+    nexus_wrapper,
+):
+    instrument = Instrument(nexus_wrapper, NX_CLASS_DEFINITIONS)
     assert len(instrument.get_component_list()) == 1
 
 
@@ -34,9 +33,10 @@ def check_if_component_is_in_component_list(
     assert found_component == expect_component_present
 
 
-def test_GIVEN_component_WHEN_adding_component_THEN_components_list_contains_added_component():
-    wrapper = NexusWrapper("test_components_list")
-    instrument = Instrument(wrapper, NX_CLASS_DEFINITIONS)
+def test_GIVEN_component_WHEN_adding_component_THEN_components_list_contains_added_component(
+    nexus_wrapper,
+):
+    instrument = Instrument(nexus_wrapper, NX_CLASS_DEFINITIONS)
 
     component_type = "NXcrystal"
     name = "test_crystal"
@@ -48,9 +48,10 @@ def test_GIVEN_component_WHEN_adding_component_THEN_components_list_contains_add
     )
 
 
-def test_GIVEN_instrument_with_component_WHEN_component_is_removed_THEN_components_list_does_not_contain_component():
-    wrapper = NexusWrapper("test_components_list")
-    instrument = Instrument(wrapper, NX_CLASS_DEFINITIONS)
+def test_GIVEN_instrument_with_component_WHEN_component_is_removed_THEN_components_list_does_not_contain_component(
+    nexus_wrapper,
+):
+    instrument = Instrument(nexus_wrapper, NX_CLASS_DEFINITIONS)
 
     component_type = "NXcrystal"
     name = "test_crystal"
@@ -70,7 +71,7 @@ def test_GIVEN_instrument_with_component_WHEN_component_is_removed_THEN_componen
     )
 
 
-def test_dependents_list_is_created_by_instrument(file):  # noqa: F811
+def test_dependents_list_is_created_by_instrument(file, nexus_wrapper):  # noqa: F811
     """
     The dependents list for transforms is stored in the "dependent_of" attribute,
     which is not part of the NeXus standard,
@@ -93,7 +94,6 @@ def test_dependents_list_is_created_by_instrument(file):  # noqa: F811
     transform_3.attrs["depends_on"] = transform_2.name
     transform_4.attrs["depends_on"] = transform_2.name
 
-    nexus_wrapper = NexusWrapper("test_file_with_transforms")
     nexus_wrapper.load_file(entry_group, file)
     Instrument(nexus_wrapper, NX_CLASS_DEFINITIONS)
 
@@ -109,7 +109,7 @@ def test_dependents_list_is_created_by_instrument(file):  # noqa: F811
 
 
 def test_dependent_is_created_by_instrument_if_depends_on_is_relative(
-    file,  # noqa: F811
+    file, nexus_wrapper  # noqa: F811
 ):
     entry_group = file.create_group("entry")
     entry_group.attrs["NX_class"] = "NXentry"
@@ -122,7 +122,6 @@ def test_dependent_is_created_by_instrument_if_depends_on_is_relative(
     transformations_group.attrs["NX_class"] = "NXtransformations"
     transform_1 = transformations_group.create_dataset("translation1", data=1)
 
-    nexus_wrapper = NexusWrapper("test_file_with_transforms")
     nexus_wrapper.load_file(entry_group, file)
     Instrument(nexus_wrapper, NX_CLASS_DEFINITIONS)
 
@@ -131,7 +130,7 @@ def test_dependent_is_created_by_instrument_if_depends_on_is_relative(
 
 
 def test_dependee_of_contains_both_components_when_generating_dependee_of_chain_with_mixture_of_absolute_and_relative_paths(
-    file,  # noqa: F811
+    file, nexus_wrapper  # noqa: F811
 ):
     entry_group = file.create_group("entry")
     entry_group.attrs["NX_class"] = "NXentry"
@@ -152,7 +151,6 @@ def test_dependee_of_contains_both_components_when_generating_dependee_of_chain_
         "depends_on", data="/entry/instrument/a/Transforms1/transform1"
     )
 
-    nexus_wrapper = NexusWrapper("test_dependent_transforms_1")
     nexus_wrapper.load_file(entry_group, file)
     Instrument(nexus_wrapper, NX_CLASS_DEFINITIONS)
     transform_1_loaded = Transformation(nexus_wrapper, transform_1)

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -71,7 +71,7 @@ def test_GIVEN_instrument_with_component_WHEN_component_is_removed_THEN_componen
     )
 
 
-def test_dependents_list_is_created_by_instrument(file, nexus_wrapper):  # noqa: F811
+def test_dependents_list_is_created_by_instrument(file, nexus_wrapper):
     """
     The dependents list for transforms is stored in the "dependent_of" attribute,
     which is not part of the NeXus standard,
@@ -109,7 +109,7 @@ def test_dependents_list_is_created_by_instrument(file, nexus_wrapper):  # noqa:
 
 
 def test_dependent_is_created_by_instrument_if_depends_on_is_relative(
-    file, nexus_wrapper  # noqa: F811
+    file, nexus_wrapper
 ):
     entry_group = file.create_group("entry")
     entry_group.attrs["NX_class"] = "NXentry"
@@ -130,7 +130,7 @@ def test_dependent_is_created_by_instrument_if_depends_on_is_relative(
 
 
 def test_dependee_of_contains_both_components_when_generating_dependee_of_chain_with_mixture_of_absolute_and_relative_paths(
-    file, nexus_wrapper  # noqa: F811
+    file, nexus_wrapper
 ):
     entry_group = file.create_group("entry")
     entry_group.attrs["NX_class"] = "NXentry"

--- a/tests/test_json_writer.py
+++ b/tests/test_json_writer.py
@@ -16,7 +16,6 @@ from nexus_constructor.json.filewriter_json_writer import (
 )
 from nexus_constructor.json.helpers import object_to_json_file
 from nexus_constructor.json.forwarder_json_writer import generate_forwarder_command
-from tests.helpers import file  # noqa: F401
 from tests.test_utils import NX_CLASS_DEFINITIONS
 
 

--- a/tests/test_nexus_validation.py
+++ b/tests/test_nexus_validation.py
@@ -1,10 +1,10 @@
 from nexus_constructor.nexus.validation import validate_group, ValidateDataset
-from nexus_constructor.nexus.nexus_wrapper import NexusWrapper
 import numpy as np
 
 
-def test_validate_dataset_reports_problem_when_expected_dataset_is_not_present():
-    nexus_wrapper = NexusWrapper()
+def test_validate_dataset_reports_problem_when_expected_dataset_is_not_present(
+    nexus_wrapper,
+):
     nexus_wrapper.set_field_value(nexus_wrapper.nexus_file, "a_dataset", 0)
 
     dataset_name = "test_dataset"
@@ -16,8 +16,9 @@ def test_validate_dataset_reports_problem_when_expected_dataset_is_not_present()
     ), "Expected there to be a reported problem because dataset is not present"
 
 
-def test_validate_dataset_does_not_report_problem_when_expected_dataset_is_present():
-    nexus_wrapper = NexusWrapper()
+def test_validate_dataset_does_not_report_problem_when_expected_dataset_is_present(
+    nexus_wrapper,
+):
     dataset_name = "test_dataset"
     nexus_wrapper.set_field_value(nexus_wrapper.nexus_file, dataset_name, 0)
 
@@ -29,8 +30,9 @@ def test_validate_dataset_does_not_report_problem_when_expected_dataset_is_prese
     ), "Expected there to be no reported problem because dataset is present"
 
 
-def test_validate_dataset_reports_problem_when_expected_attribute_is_not_present():
-    nexus_wrapper = NexusWrapper()
+def test_validate_dataset_reports_problem_when_expected_attribute_is_not_present(
+    nexus_wrapper,
+):
     dataset_name = "test_dataset"
     nexus_wrapper.set_field_value(nexus_wrapper.nexus_file, dataset_name, 0)
 
@@ -42,8 +44,9 @@ def test_validate_dataset_reports_problem_when_expected_attribute_is_not_present
     ), "Expected there to be a reported problem because attribute is not present"
 
 
-def test_validate_dataset_does_not_report_problem_when_expected_attribute_is_present():
-    nexus_wrapper = NexusWrapper()
+def test_validate_dataset_does_not_report_problem_when_expected_attribute_is_present(
+    nexus_wrapper,
+):
     dataset_name = "test_dataset"
     dataset = nexus_wrapper.set_field_value(nexus_wrapper.nexus_file, dataset_name, 0)
     attr_name = "test_attribute"
@@ -57,8 +60,9 @@ def test_validate_dataset_does_not_report_problem_when_expected_attribute_is_pre
     ), "Expected there to be no reported problem because attribute is present"
 
 
-def test_validate_dataset_reports_problem_when_attribute_does_not_have_expected_value():
-    nexus_wrapper = NexusWrapper()
+def test_validate_dataset_reports_problem_when_attribute_does_not_have_expected_value(
+    nexus_wrapper,
+):
     dataset_name = "test_dataset"
     dataset = nexus_wrapper.set_field_value(nexus_wrapper.nexus_file, dataset_name, 0)
     attr_name = "test_attribute"
@@ -74,8 +78,9 @@ def test_validate_dataset_reports_problem_when_attribute_does_not_have_expected_
     ), "Expected there to be a reported problem because attribute does not have expected value"
 
 
-def test_validate_dataset_does_not_report_problem_when_attribute_has_expected_value():
-    nexus_wrapper = NexusWrapper()
+def test_validate_dataset_does_not_report_problem_when_attribute_has_expected_value(
+    nexus_wrapper,
+):
     dataset_name = "test_dataset"
     dataset = nexus_wrapper.set_field_value(nexus_wrapper.nexus_file, dataset_name, 0)
     attr_name = "test_attribute"
@@ -90,8 +95,9 @@ def test_validate_dataset_does_not_report_problem_when_attribute_has_expected_va
     ), "Expected there to be no reported problem because attribute has expected value"
 
 
-def test_validate_dataset_reports_problem_when_dataset_does_not_have_expected_shape():
-    nexus_wrapper = NexusWrapper()
+def test_validate_dataset_reports_problem_when_dataset_does_not_have_expected_shape(
+    nexus_wrapper,
+):
     dataset_name = "test_dataset"
     dataset_value = np.array(list(range(12)))
     dataset_shape = (3, 4)
@@ -106,8 +112,9 @@ def test_validate_dataset_reports_problem_when_dataset_does_not_have_expected_sh
     ), "Expected there to be a reported problem because dataset does not have expected shape"
 
 
-def test_validate_dataset_does_not_report_problem_when_dataset_has_expected_shape():
-    nexus_wrapper = NexusWrapper()
+def test_validate_dataset_does_not_report_problem_when_dataset_has_expected_shape(
+    nexus_wrapper,
+):
     dataset_name = "test_dataset"
     dataset_value = np.array(list(range(12)))
     dataset_shape = (3, 4)
@@ -122,8 +129,9 @@ def test_validate_dataset_does_not_report_problem_when_dataset_has_expected_shap
     ), "Expected there to be no reported problem because dataset has expected shape"
 
 
-def test_validate_group_reports_problem_when_group_does_not_have_an_nx_class():
-    nexus_wrapper = NexusWrapper()
+def test_validate_group_reports_problem_when_group_does_not_have_an_nx_class(
+    nexus_wrapper,
+):
     group = nexus_wrapper.create_nx_group(
         "test_group", "NXsomething", nexus_wrapper.nexus_file
     )
@@ -135,8 +143,9 @@ def test_validate_group_reports_problem_when_group_does_not_have_an_nx_class():
     ), "Expected there to be a reported problem because group does not have an nx_class attribute"
 
 
-def test_validate_group_reports_problem_when_group_does_not_have_expected_nx_class():
-    nexus_wrapper = NexusWrapper()
+def test_validate_group_reports_problem_when_group_does_not_have_expected_nx_class(
+    nexus_wrapper,
+):
     group = nexus_wrapper.create_nx_group(
         "test_group", "NXsomething", nexus_wrapper.nexus_file
     )
@@ -147,8 +156,9 @@ def test_validate_group_reports_problem_when_group_does_not_have_expected_nx_cla
     ), "Expected there to be a reported problem because group does not have expected NX_class"
 
 
-def test_validate_group_does_not_report_problem_when_group_has_expected_nx_class():
-    nexus_wrapper = NexusWrapper()
+def test_validate_group_does_not_report_problem_when_group_has_expected_nx_class(
+    nexus_wrapper,
+):
     nexus_class = "NXtest"
     group = nexus_wrapper.create_nx_group(
         "test_group", nexus_class, nexus_wrapper.nexus_file

--- a/tests/test_nexus_wrapper.py
+++ b/tests/test_nexus_wrapper.py
@@ -5,7 +5,6 @@ from nexus_constructor.nexus.nexus_wrapper import (
     append_nxs_extension,
     get_nx_class,
 )
-from tests.helpers import InMemoryFile
 
 
 def test_GIVEN_nothing_WHEN_creating_nexus_wrapper_THEN_file_contains_entry_group_with_correct_nx_class():
@@ -33,129 +32,140 @@ def test_nxs_not_appended_to_filename_if_already_present():
     assert append_nxs_extension(test_filename) == f"{test_filename}"
 
 
-def test_GIVEN_entry_group_with_one_instrument_group_WHEN_getting_instrument_group_from_entry_THEN_group_is_returned():
-    with InMemoryFile("test_file") as file:
-        entry = file.create_group("entry")
-        entry.attrs["NX_class"] = "NXentry"
+def test_GIVEN_entry_group_with_one_instrument_group_WHEN_getting_instrument_group_from_entry_THEN_group_is_returned(
+    file,
+):
+    entry = file.create_group("entry")
+    entry.attrs["NX_class"] = "NXentry"
 
-        inst_group = entry.create_group("instrument")
-        inst_group.attrs["NX_class"] = "NXinstrument"
+    inst_group = entry.create_group("instrument")
+    inst_group.attrs["NX_class"] = "NXinstrument"
 
-        wrapper = NexusWrapper(filename="test_nw")
-        wrapper.load_file(entry, file)
+    wrapper = NexusWrapper(filename="test_nw")
+    wrapper.load_file(entry, file)
 
-        assert wrapper.instrument == inst_group
-        assert wrapper.entry == entry
-        assert wrapper.nexus_file == file
-
-
-def test_GIVEN_multiple_entry_groups_WHEN_getting_instrument_group_from_entry_THEN_first_group_is_returned_and_others_are_ignored():
-    with InMemoryFile("test_file") as file:
-        entry = file.create_group("entry")
-        entry.attrs["NX_class"] = "NXentry"
-
-        inst_group = entry.create_group("instrument")
-        inst_group.attrs["NX_class"] = "NXinstrument"
-
-        inst_group2 = entry.create_group("instrument2")
-        inst_group2.attrs["NX_class"] = "NXinstrument"
-
-        wrapper = NexusWrapper(filename="test_nw2")
-        wrapper.load_file(entry, file)
-
-        assert wrapper.nexus_file == file
-        assert wrapper.entry == entry
-        assert wrapper.instrument == inst_group
+    assert wrapper.instrument == inst_group
+    assert wrapper.entry == entry
+    assert wrapper.nexus_file == file
 
 
-def test_GIVEN_single_entry_group_with_instrument_group_WHEN_finding_entry_THEN_file_is_loaded_correctly():
-    with InMemoryFile("test_file") as file:
-        entry = file.create_group("entry")
-        entry.attrs["NX_class"] = "NXentry"
+def test_GIVEN_multiple_entry_groups_WHEN_getting_instrument_group_from_entry_THEN_first_group_is_returned_and_others_are_ignored(
+    file,
+):
+    entry = file.create_group("entry")
+    entry.attrs["NX_class"] = "NXentry"
 
-        inst_group = entry.create_group("instrument")
-        inst_group.attrs["NX_class"] = "NXinstrument"
+    inst_group = entry.create_group("instrument")
+    inst_group.attrs["NX_class"] = "NXinstrument"
 
-        wrapper = NexusWrapper(filename="test_nw5")
+    inst_group2 = entry.create_group("instrument2")
+    inst_group2.attrs["NX_class"] = "NXinstrument"
 
-        wrapper.find_entries_in_file(file)
+    wrapper = NexusWrapper(filename="test_nw2")
+    wrapper.load_file(entry, file)
 
-        assert wrapper.nexus_file == file
-        assert wrapper.entry == entry
-        assert wrapper.instrument == inst_group
-
-
-def test_GIVEN_multiple_entry_groups_in_file_WHEN_finding_entry_THEN_signal_is_emitted_with_entry_options():
-    with InMemoryFile("test_file") as file:
-        entry = file.create_group("entry")
-        # Test with byte string as well as python string.
-        entry.attrs["NX_class"] = b"NXentry"
-
-        inst_group = entry.create_group("instrument")
-        inst_group.attrs["NX_class"] = "NXinstrument"
-
-        entry2 = file.create_group("entry2")
-        entry2.attrs["NX_class"] = "NXentry"
-
-        inst_group2 = entry2.create_group("instrument2")
-        inst_group2.attrs["NX_class"] = "NXinstrument"
-
-        wrapper = NexusWrapper(filename="test_nw7")
-        wrapper.show_entries_dialog = Mock()
-        wrapper.show_entries_dialog.emit = Mock()
-
-        wrapper.find_entries_in_file(file)
-
-        expected_entry_dict = {entry.name: entry, entry2.name: entry2}
-
-        assert wrapper.show_entries_dialog.emit.called_once_with(
-            expected_entry_dict, file
-        )
+    assert wrapper.nexus_file == file
+    assert wrapper.entry == entry
+    assert wrapper.instrument == inst_group
 
 
-def test_GIVEN_group_without_nx_class_WHEN_getting_nx_class_THEN_returns_none():
-    with InMemoryFile("test_file") as file:
-        entry = file.create_group("entry")
-        assert get_nx_class(entry) is None
+def test_GIVEN_single_entry_group_with_instrument_group_WHEN_finding_entry_THEN_file_is_loaded_correctly(
+    file,
+):
+    entry = file.create_group("entry")
+    entry.attrs["NX_class"] = "NXentry"
+
+    inst_group = entry.create_group("instrument")
+    inst_group.attrs["NX_class"] = "NXinstrument"
+
+    wrapper = NexusWrapper(filename="test_nw5")
+
+    wrapper.find_entries_in_file(file)
+
+    assert wrapper.nexus_file == file
+    assert wrapper.entry == entry
+    assert wrapper.instrument == inst_group
 
 
-def test_GIVEN_group_with_nx_class_as_str_WHEN_getting_nx_class_THEN_returns_nx_class_as_str():
-    with InMemoryFile("test_file") as file:
-        entry = file.create_group("entry")
-        nx_class = "NXentry"
-        entry.attrs["NX_class"] = nx_class
-        assert get_nx_class(entry) == nx_class
+def test_GIVEN_multiple_entry_groups_in_file_WHEN_finding_entry_THEN_signal_is_emitted_with_entry_options(
+    file,
+):
+
+    entry = file.create_group("entry")
+    # Test with byte string as well as python string.
+    entry.attrs["NX_class"] = b"NXentry"
+
+    inst_group = entry.create_group("instrument")
+    inst_group.attrs["NX_class"] = "NXinstrument"
+
+    entry2 = file.create_group("entry2")
+    entry2.attrs["NX_class"] = "NXentry"
+
+    inst_group2 = entry2.create_group("instrument2")
+    inst_group2.attrs["NX_class"] = "NXinstrument"
+
+    wrapper = NexusWrapper(filename="test_nw7")
+    wrapper.show_entries_dialog = Mock()
+    wrapper.show_entries_dialog.emit = Mock()
+
+    wrapper.find_entries_in_file(file)
+
+    expected_entry_dict = {entry.name: entry, entry2.name: entry2}
+
+    assert wrapper.show_entries_dialog.emit.called_once_with(expected_entry_dict, file)
 
 
-def test_GIVEN_group_with_nx_class_as_bytes_WHEN_getting_nx_class_THEN_returns_nx_class_as_str():
-    with InMemoryFile("test_file") as file:
-        entry = file.create_group("entry")
-        nx_class = b"NXentry"
-        entry.attrs["NX_class"] = nx_class
-        assert get_nx_class(entry) == str(nx_class, encoding="utf-8")
+def test_GIVEN_group_without_nx_class_WHEN_getting_nx_class_THEN_returns_none(file):
+    entry = file.create_group("entry")
+    assert get_nx_class(entry) is None
 
 
-def test_GIVEN_group_with_bytes_attribute_WHEN_getting_attribute_value_THEN_returns_value_as_str():
-    wrapper = NexusWrapper(filename="test_attr_as_str")
-    test_group = wrapper.nexus_file.create_group("test_group")
+def test_GIVEN_group_with_nx_class_as_str_WHEN_getting_nx_class_THEN_returns_nx_class_as_str(
+    file,
+):
+
+    entry = file.create_group("entry")
+    nx_class = "NXentry"
+    entry.attrs["NX_class"] = nx_class
+    assert get_nx_class(entry) == nx_class
+
+
+def test_GIVEN_group_with_nx_class_as_bytes_WHEN_getting_nx_class_THEN_returns_nx_class_as_str(
+    file,
+):
+
+    entry = file.create_group("entry")
+    nx_class = b"NXentry"
+    entry.attrs["NX_class"] = nx_class
+    assert get_nx_class(entry) == str(nx_class, encoding="utf-8")
+
+
+def test_GIVEN_group_with_bytes_attribute_WHEN_getting_attribute_value_THEN_returns_value_as_str(
+    nexus_wrapper,
+):
+
+    test_group = nexus_wrapper.nexus_file.create_group("test_group")
     attr_value = b"test_attr_value"
     attr_name = "test_attr"
     test_group.attrs[attr_name] = attr_value
 
     attr_value_as_str = attr_value.decode("utf-8")
 
-    assert wrapper.get_attribute_value(test_group, attr_name) == attr_value_as_str
+    assert nexus_wrapper.get_attribute_value(test_group, attr_name) == attr_value_as_str
 
 
-def test_GIVEN_variable_length_string_type_dataset_WHEN_getting_value_THEN_returned_as_str():
-    wrapper = NexusWrapper(filename="test_read_vlen_str_dataset")
+def test_GIVEN_variable_length_string_type_dataset_WHEN_getting_value_THEN_returned_as_str(
+    nexus_wrapper,
+):
     dataset_name = "vlen_str_dataset"
     string_data = b"This is a string"
-    wrapper.nexus_file.create_dataset(
+    nexus_wrapper.nexus_file.create_dataset(
         dataset_name, dtype=h5py.special_dtype(vlen=str), data=string_data
     )
 
-    assert wrapper.get_field_value(
-        wrapper.nexus_file, dataset_name
+    assert nexus_wrapper.get_field_value(
+        nexus_wrapper.nexus_file, dataset_name
     ) == string_data.decode("utf8")
-    assert isinstance(wrapper.get_field_value(wrapper.nexus_file, dataset_name), str)
+    assert isinstance(
+        nexus_wrapper.get_field_value(nexus_wrapper.nexus_file, dataset_name), str
+    )

--- a/tests/test_pixel_shape.py
+++ b/tests/test_pixel_shape.py
@@ -1,15 +1,15 @@
 from nexus_constructor.component.pixel_shape import PixelShape
-from nexus_constructor.nexus import nexus_wrapper as nx
 from nexus_constructor.ui_utils import qvector3d_to_numpy_array
 import numpy as np
 
 
-def test_GIVEN_a_PixelShape_WHEN_calling_get_shape_THEN_shape_and_transformations_are_returned():
-    wrapper = nx.NexusWrapper("file_with_detector")
-    detector_group = wrapper.create_nx_group(
-        "detector", "NXdetector", wrapper.instrument
+def test_GIVEN_a_PixelShape_WHEN_calling_get_shape_THEN_shape_and_transformations_are_returned(
+    nexus_wrapper,
+):
+    detector_group = nexus_wrapper.create_nx_group(
+        "detector", "NXdetector", nexus_wrapper.instrument
     )
-    shape_group = wrapper.create_nx_group(
+    shape_group = nexus_wrapper.create_nx_group(
         "pixel_shape", "NXoff_geometry", detector_group
     )
 
@@ -23,19 +23,19 @@ def test_GIVEN_a_PixelShape_WHEN_calling_get_shape_THEN_shape_and_transformation
     faces = [0]
     winding_order = [0, 1, 2, 3]
 
-    vertices_field = wrapper.set_field_value(shape_group, "vertices", vertices)
-    wrapper.set_attribute_value(vertices_field, "units", "m")
-    wrapper.set_field_value(shape_group, "winding_order", winding_order)
-    wrapper.set_field_value(shape_group, "faces", faces)
+    vertices_field = nexus_wrapper.set_field_value(shape_group, "vertices", vertices)
+    nexus_wrapper.set_attribute_value(vertices_field, "units", "m")
+    nexus_wrapper.set_field_value(shape_group, "winding_order", winding_order)
+    nexus_wrapper.set_field_value(shape_group, "faces", faces)
 
     # Add pixel offsets to detector group
     x_offsets = np.array([[-0.05, 0.05], [-0.05, 0.05]])
     y_offsets = np.array([[-0.05, -0.05], [0.05, 0.05]])
 
-    wrapper.set_field_value(detector_group, "x_pixel_offset", x_offsets)
-    wrapper.set_field_value(detector_group, "y_pixel_offset", y_offsets)
+    nexus_wrapper.set_field_value(detector_group, "x_pixel_offset", x_offsets)
+    nexus_wrapper.set_field_value(detector_group, "y_pixel_offset", y_offsets)
 
-    pixel_shape = PixelShape(wrapper, detector_group)
+    pixel_shape = PixelShape(nexus_wrapper, detector_group)
     assert isinstance(pixel_shape, PixelShape)
     shape, transformations = pixel_shape.get_shape()
 

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -488,7 +488,7 @@ def test_GIVEN_nexus_file_with_linked_transformation_but_without_dependee_of_att
 
 
 def test_GIVEN_transformation_with_scalar_value_that_is_not_castable_to_int_WHEN_getting_ui_value_THEN_ui_placeholder_value_is_returned_instead(
-    file, nexus_wrapper  # noqa: F811
+    file, nexus_wrapper
 ):
     transform_name = "transform_1"
     transform = create_transform(nexus_wrapper, transform_name)
@@ -501,7 +501,7 @@ def test_GIVEN_transformation_with_scalar_value_that_is_not_castable_to_int_WHEN
 
 
 def test_multiple_relative_transform_paths_are_converted_to_absolute_path_in_dependee_of_field(
-    file, nexus_wrapper  # noqa: F811
+    file, nexus_wrapper
 ):
     component_name = "component_1"
 
@@ -540,9 +540,7 @@ def test_multiple_relative_transform_paths_are_converted_to_absolute_path_in_dep
     )
 
 
-def test_transforms_with_no_dependees_return_None_for_depends_on(
-    file, nexus_wrapper
-):  # noqa: F811
+def test_transforms_with_no_dependees_return_None_for_depends_on(file, nexus_wrapper):
     component_name = "component_1"
 
     component1 = add_component_to_file(nexus_wrapper, component_name=component_name)

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -9,8 +9,7 @@ from nexus_constructor.transformations import Transformation, QVector3D
 from nexus_constructor.nexus.nexus_wrapper import NexusWrapper
 from typing import Any
 from nexus_constructor.ui_utils import qvector3d_to_numpy_array
-from uuid import uuid1
-from tests.helpers import add_component_to_file, file  # noqa:F401
+from tests.helpers import add_component_to_file  # noqa:F401
 
 transform_type = "Transformation"
 rotation_type = "Rotation"
@@ -30,8 +29,7 @@ def _add_transform_to_file(
     return transform_dataset
 
 
-def test_can_get_transform_properties():
-    nexus_wrapper = NexusWrapper(str(uuid1()))
+def test_can_get_transform_properties(nexus_wrapper):
 
     test_name = "slartibartfast"
     test_value = 42
@@ -58,8 +56,9 @@ def test_can_get_transform_properties():
     ), "Expected the transform type to match what was in the NeXus file"
 
 
-def test_transform_dependents_depends_on_are_updated_when_transformation_name_is_changed():
-    nexus_wrapper = NexusWrapper(str(uuid1()))
+def test_transform_dependents_depends_on_are_updated_when_transformation_name_is_changed(
+    nexus_wrapper,
+):
 
     test_name = "slartibartfast"
     test_value = 42
@@ -88,8 +87,7 @@ def test_transform_dependents_depends_on_are_updated_when_transformation_name_is
 
 
 @pytest.mark.parametrize("test_input", ["translation", "Translation", "TRANSLATION"])
-def test_transform_type_is_capitalised(test_input):
-    nexus_wrapper = NexusWrapper(str(uuid1()))
+def test_transform_type_is_capitalised(test_input, nexus_wrapper):
     test_name = "slartibartfast"
     test_value = 42
     test_vector = QVector3D(1.0, 0.0, 0.0)
@@ -110,8 +108,7 @@ def create_transform(nexus_file, name):
     return Transformation(nexus_file, dataset)
 
 
-def test_ui_value_for_transform_with_array_magnitude_returns_first_value():
-    nexus_wrapper = NexusWrapper(str(uuid1()))
+def test_ui_value_for_transform_with_array_magnitude_returns_first_value(nexus_wrapper):
     transform_name = "transform1"
     array = [1.1, 2.2, 3.3]
     transform_value = np.asarray(array, dtype=float)
@@ -128,8 +125,9 @@ def test_ui_value_for_transform_with_array_magnitude_returns_first_value():
     assert transformation.ui_value == array[0]
 
 
-def test_ui_value_for_transform_with_array_magnitude_of_strings_returns_zero():
-    nexus_wrapper = NexusWrapper(str(uuid1()))
+def test_ui_value_for_transform_with_array_magnitude_of_strings_returns_zero(
+    nexus_wrapper,
+):
     transform_name = "transform1"
     array = ["a1", "b1", "c1"]
     transform_value = np.asarray(array, dtype=h5py.special_dtype(vlen=str))
@@ -146,8 +144,7 @@ def test_ui_value_for_transform_with_array_magnitude_of_strings_returns_zero():
     assert transformation.ui_value == 0
 
 
-def test_can_set_transform_properties():
-    nexus_wrapper = NexusWrapper(str(uuid1()))
+def test_can_set_transform_properties(nexus_wrapper):
 
     initial_name = "slartibartfast"
 
@@ -177,8 +174,7 @@ def test_can_set_transform_properties():
     ), "Expected the transform type to match what was in the NeXus file"
 
 
-def test_set_one_dependent():
-    nexus_wrapper = NexusWrapper(str(uuid1()))
+def test_set_one_dependent(nexus_wrapper):
 
     transform1 = create_transform(nexus_wrapper, "transform_1")
 
@@ -192,8 +188,7 @@ def test_set_one_dependent():
     assert set_dependents[0] == transform2
 
 
-def test_set_two_dependents():
-    nexus_wrapper = NexusWrapper(str(uuid1()))
+def test_set_two_dependents(nexus_wrapper):
 
     transform1 = create_transform(nexus_wrapper, "transform_1")
 
@@ -211,8 +206,7 @@ def test_set_two_dependents():
     assert set_dependents[1] == transform3
 
 
-def test_set_three_dependents():
-    nexus_wrapper = NexusWrapper(str(uuid1()))
+def test_set_three_dependents(nexus_wrapper):
 
     transform1 = create_transform(nexus_wrapper, "transform_1")
 
@@ -234,8 +228,7 @@ def test_set_three_dependents():
     assert set_dependents[2] == transform4
 
 
-def test_deregister_dependent():
-    nexus_wrapper = NexusWrapper(str(uuid1()))
+def test_deregister_dependent(nexus_wrapper):
 
     transform1 = create_transform(nexus_wrapper, "transform_1")
 
@@ -249,8 +242,7 @@ def test_deregister_dependent():
     assert not set_dependents
 
 
-def test_deregister_unregistered_dependent_alt1():
-    nexus_wrapper = NexusWrapper(str(uuid1()))
+def test_deregister_unregistered_dependent_alt1(nexus_wrapper):
 
     transform1 = create_transform(nexus_wrapper, "transform_1")
     transform2 = create_transform(nexus_wrapper, "transform_2")
@@ -260,8 +252,7 @@ def test_deregister_unregistered_dependent_alt1():
     assert not transform1.get_dependents()
 
 
-def test_deregister_unregistered_dependent_alt2():
-    nexus_wrapper = NexusWrapper(str(uuid1()))
+def test_deregister_unregistered_dependent_alt2(nexus_wrapper):
 
     transform1 = create_transform(nexus_wrapper, "transform_1")
     transform2 = create_transform(nexus_wrapper, "transform_2")
@@ -274,8 +265,7 @@ def test_deregister_unregistered_dependent_alt2():
     assert transform1.get_dependents()[0] == transform3
 
 
-def test_deregister_unregistered_dependent_alt3():
-    nexus_wrapper = NexusWrapper(str(uuid1()))
+def test_deregister_unregistered_dependent_alt3(nexus_wrapper):
 
     transform1 = create_transform(nexus_wrapper, "transform_1")
     transform2 = create_transform(nexus_wrapper, "transform_2")
@@ -291,8 +281,7 @@ def test_deregister_unregistered_dependent_alt3():
     assert transform1.get_dependents()[1] == transform4
 
 
-def test_reregister_dependent():
-    nexus_wrapper = NexusWrapper(str(uuid1()))
+def test_reregister_dependent(nexus_wrapper):
 
     transform1 = create_transform(nexus_wrapper, "transform_1")
 
@@ -310,8 +299,7 @@ def test_reregister_dependent():
     assert set_dependents[0] == transform3
 
 
-def test_set_one_dependent_component():
-    nexus_wrapper = NexusWrapper(str(uuid1()))
+def test_set_one_dependent_component(nexus_wrapper):
 
     transform = create_transform(nexus_wrapper, "transform_1")
 
@@ -325,8 +313,7 @@ def test_set_one_dependent_component():
     assert set_dependents[0] == component
 
 
-def test_set_two_dependent_components():
-    nexus_wrapper = NexusWrapper(str(uuid1()))
+def test_set_two_dependent_components(nexus_wrapper):
 
     transform = create_transform(nexus_wrapper, "transform_1")
 
@@ -343,8 +330,7 @@ def test_set_two_dependent_components():
     assert set_dependents[1] == component2
 
 
-def test_set_three_dependent_components():
-    nexus_wrapper = NexusWrapper(str(uuid1()))
+def test_set_three_dependent_components(nexus_wrapper):
 
     transform = create_transform(nexus_wrapper, "transform_1")
 
@@ -364,8 +350,7 @@ def test_set_three_dependent_components():
     assert set_dependents[2] == component3
 
 
-def test_deregister_three_dependent_components():
-    nexus_wrapper = NexusWrapper(str(uuid1()))
+def test_deregister_three_dependent_components(nexus_wrapper):
 
     transform = create_transform(nexus_wrapper, "transform_1")
 
@@ -386,8 +371,7 @@ def test_deregister_three_dependent_components():
     assert len(set_dependents) == 0
 
 
-def test_register_dependent_twice():
-    nexus_wrapper = NexusWrapper(str(uuid1()))
+def test_register_dependent_twice(nexus_wrapper):
 
     transform = create_transform(nexus_wrapper, "transform_1")
 
@@ -401,8 +385,7 @@ def test_register_dependent_twice():
     assert len(set_dependents) == 1
 
 
-def test_can_get_translation_as_4_by_4_matrix():
-    nexus_wrapper = NexusWrapper(str(uuid1()))
+def test_can_get_translation_as_4_by_4_matrix(nexus_wrapper):
 
     test_value = 42.0
     # Note, it should not matter if this is not set to a unit vector
@@ -420,8 +403,7 @@ def test_can_get_translation_as_4_by_4_matrix():
     assert np.allclose(expected_matrix, np.array(test_matrix.data()))
 
 
-def test_can_get_rotation_as_4_by_4_matrix():
-    nexus_wrapper = NexusWrapper(str(uuid1()))
+def test_can_get_rotation_as_4_by_4_matrix(nexus_wrapper):
 
     test_value = 45.0  # degrees
     test_vector = QVector3D(0.0, 1.0, 0.0)  # around y-axis
@@ -457,8 +439,9 @@ def test_can_get_rotation_as_4_by_4_matrix():
     assert np.allclose(expected_matrix, np.array(test_matrix.data()), atol=1.0e-7)
 
 
-def test_GIVEN_nexus_file_with_linked_transformation_but_without_dependee_of_attr_WHEN_opening_nexus_file_THEN_components_linked_contain_dependee_of_attribute():
-    nexus_wrapper = NexusWrapper(str(uuid1()))
+def test_GIVEN_nexus_file_with_linked_transformation_but_without_dependee_of_attr_WHEN_opening_nexus_file_THEN_components_linked_contain_dependee_of_attribute(
+    nexus_wrapper,
+):
     transform_name = "transform_1"
     transform = create_transform(nexus_wrapper, transform_name)
 
@@ -485,8 +468,9 @@ def test_GIVEN_nexus_file_with_linked_transformation_but_without_dependee_of_att
     )
 
 
-def test_GIVEN_nexus_file_with_linked_transformation_but_without_dependee_of_attr_WHEN_opening_nexus_file_THEN_component_linked_contains_dependee_of_attribute():
-    nexus_wrapper = NexusWrapper(str(uuid1()))
+def test_GIVEN_nexus_file_with_linked_transformation_but_without_dependee_of_attr_WHEN_opening_nexus_file_THEN_component_linked_contains_dependee_of_attribute(
+    nexus_wrapper,
+):
     transform_name = "transform_1"
     transform = create_transform(nexus_wrapper, transform_name)
 
@@ -504,9 +488,8 @@ def test_GIVEN_nexus_file_with_linked_transformation_but_without_dependee_of_att
 
 
 def test_GIVEN_transformation_with_scalar_value_that_is_not_castable_to_int_WHEN_getting_ui_value_THEN_ui_placeholder_value_is_returned_instead(
-    file,  # noqa: F811
+    file, nexus_wrapper  # noqa: F811
 ):
-    nexus_wrapper = NexusWrapper(str(uuid1()))
     transform_name = "transform_1"
     transform = create_transform(nexus_wrapper, transform_name)
 
@@ -518,9 +501,8 @@ def test_GIVEN_transformation_with_scalar_value_that_is_not_castable_to_int_WHEN
 
 
 def test_multiple_relative_transform_paths_are_converted_to_absolute_path_in_dependee_of_field(
-    file,  # noqa: F811
+    file, nexus_wrapper  # noqa: F811
 ):
-    nexus_wrapper = NexusWrapper(str(uuid1()))
     component_name = "component_1"
 
     component1 = add_component_to_file(nexus_wrapper, component_name=component_name)
@@ -558,8 +540,9 @@ def test_multiple_relative_transform_paths_are_converted_to_absolute_path_in_dep
     )
 
 
-def test_transforms_with_no_dependees_return_None_for_depends_on(file,):  # noqa: F811
-    nexus_wrapper = NexusWrapper(str(uuid1()))
+def test_transforms_with_no_dependees_return_None_for_depends_on(
+    file, nexus_wrapper
+):  # noqa: F811
     component_name = "component_1"
 
     component1 = add_component_to_file(nexus_wrapper, component_name=component_name)

--- a/tests/ui_tests/test_ui_field_attrs.py
+++ b/tests/ui_tests/test_ui_field_attrs.py
@@ -6,7 +6,6 @@ from PySide2.QtWidgets import QListWidget
 
 from nexus_constructor.field_attrs import FieldAttrsDialog, FieldAttrFrame
 import numpy as np
-from tests.helpers import file  # noqa: F401
 from tests.ui_tests.ui_test_utils import show_and_close_window
 
 

--- a/tests/ui_tests/test_ui_fields.py
+++ b/tests/ui_tests/test_ui_fields.py
@@ -17,7 +17,6 @@ from nexus_constructor.stream_fields_widget import (
     ADC_PULSE_DEBUG,
     NEXUS_INDICES_INDEX_EVERY_MB,
 )
-from tests.helpers import file  # noqa: F401
 
 
 @pytest.fixture
@@ -236,7 +235,7 @@ def test_GIVEN_element_that_has_been_filled_in_WHEN_creating_dataset_from_spinne
 
 
 def test_GIVEN_stream_group_that_has_f142_advanced_option_WHEN_filling_in_existing_field_widget_THEN_f142_group_box_is_shown(
-    file, qtbot
+    file, qtbot, nexus_wrapper
 ):
     group = file.create_group("stream1")
     group.attrs["NX_class"] = "NCstream"
@@ -248,7 +247,7 @@ def test_GIVEN_stream_group_that_has_f142_advanced_option_WHEN_filling_in_existi
     group.create_dataset("source", dtype=vlen_str, data="source1")
     group.create_dataset(NEXUS_INDICES_INDEX_EVERY_MB, dtype=int, data=1)
 
-    wrapper = NexusWrapper()
+    wrapper = nexus_wrapper
     wrapper.load_file(file, file)
 
     instrument = Instrument(wrapper, {})
@@ -275,7 +274,7 @@ def test_GIVEN_stream_group_that_has_f142_advanced_option_WHEN_filling_in_existi
 
 
 def test_GIVEN_stream_group_that_has_ev42_advanced_option_WHEN_filling_in_existing_field_widget_THEN_ev42_group_box_is_shown(
-    file, qtbot
+    file, qtbot, nexus_wrapper
 ):
     group = file.create_group("stream2")
     group.attrs["NX_class"] = "NCstream"
@@ -286,7 +285,7 @@ def test_GIVEN_stream_group_that_has_ev42_advanced_option_WHEN_filling_in_existi
     group.create_dataset("source", dtype=vlen_str, data="source1")
     group.create_dataset(ADC_PULSE_DEBUG, dtype=bool, data=True)
 
-    wrapper = NexusWrapper()
+    wrapper = nexus_wrapper
     wrapper.load_file(file, file)
 
     instrument = Instrument(wrapper, {})

--- a/tests/ui_tests/test_ui_transformation_view.py
+++ b/tests/ui_tests/test_ui_transformation_view.py
@@ -66,7 +66,7 @@ def test_UI_GIVEN_scalar_angle_WHEN_creating_rotation_view_THEN_ui_is_filled_cor
 
 
 def test_UI_GIVEN_array_dataset_as_magnitude_WHEN_creating_translation_THEN_ui_is_filled_correctly(
-    qtbot, file, nexus_wrapper  # noqa:F811
+    qtbot, file, nexus_wrapper
 ):
     instrument = Instrument(nexus_wrapper, {})
 
@@ -94,7 +94,7 @@ def test_UI_GIVEN_array_dataset_as_magnitude_WHEN_creating_translation_THEN_ui_i
 
 
 def test_UI_GIVEN_stream_group_as_angle_WHEN_creating_rotation_THEN_ui_is_filled_correctly(
-    qtbot, file, nexus_wrapper  # noqa:F811
+    qtbot, file, nexus_wrapper
 ):
     instrument = Instrument(nexus_wrapper, {})
 

--- a/tests/ui_tests/test_ui_transformation_view.py
+++ b/tests/ui_tests/test_ui_transformation_view.py
@@ -3,19 +3,17 @@ from PySide2.QtGui import QVector3D
 from mock import Mock
 
 from nexus_constructor.instrument import Instrument
-from nexus_constructor.nexus.nexus_wrapper import NexusWrapper
 from nexus_constructor.transformation_view import EditRotation, EditTranslation
 from nexus_constructor.validators import FieldType
 import numpy as np
 from pytestqt.qtbot import QtBot  # noqa: F401
-from tests.helpers import file  # noqa: F401
 
 
 def test_UI_GIVEN_scalar_vector_WHEN_creating_translation_view_THEN_ui_is_filled_correctly(
-    qtbot,
+    qtbot, nexus_wrapper
 ):
-    wrapper = NexusWrapper()
-    instrument = Instrument(wrapper, {})
+
+    instrument = Instrument(nexus_wrapper, {})
 
     component = instrument.create_component("test", "NXaperture", "")
 
@@ -39,10 +37,10 @@ def test_UI_GIVEN_scalar_vector_WHEN_creating_translation_view_THEN_ui_is_filled
 
 
 def test_UI_GIVEN_scalar_angle_WHEN_creating_rotation_view_THEN_ui_is_filled_correctly(
-    qtbot,
+    qtbot, nexus_wrapper
 ):
-    wrapper = NexusWrapper()
-    instrument = Instrument(wrapper, {})
+
+    instrument = Instrument(nexus_wrapper, {})
 
     component = instrument.create_component("test", "NXaperture", "")
 
@@ -68,10 +66,9 @@ def test_UI_GIVEN_scalar_angle_WHEN_creating_rotation_view_THEN_ui_is_filled_cor
 
 
 def test_UI_GIVEN_array_dataset_as_magnitude_WHEN_creating_translation_THEN_ui_is_filled_correctly(
-    qtbot, file  # noqa:F811
+    qtbot, file, nexus_wrapper  # noqa:F811
 ):
-    wrapper = NexusWrapper()
-    instrument = Instrument(wrapper, {})
+    instrument = Instrument(nexus_wrapper, {})
 
     component = instrument.create_component("test", "NXaperture", "")
 
@@ -97,10 +94,9 @@ def test_UI_GIVEN_array_dataset_as_magnitude_WHEN_creating_translation_THEN_ui_i
 
 
 def test_UI_GIVEN_stream_group_as_angle_WHEN_creating_rotation_THEN_ui_is_filled_correctly(
-    qtbot, file  # noqa:F811
+    qtbot, file, nexus_wrapper  # noqa:F811
 ):
-    wrapper = NexusWrapper(filename="test")
-    instrument = Instrument(wrapper, {})
+    instrument = Instrument(nexus_wrapper, {})
 
     component = instrument.create_component("test", "NXaperture", "")
 
@@ -140,10 +136,9 @@ def test_UI_GIVEN_stream_group_as_angle_WHEN_creating_rotation_THEN_ui_is_filled
 
 
 def test_UI_GIVEN_link_as_rotation_magnitude_WHEN_creating_rotation_view_THEN_ui_is_filled_correctly(
-    qtbot,
+    qtbot, nexus_wrapper
 ):
-    wrapper = NexusWrapper(filename="asdfgsdfh")
-    instrument = Instrument(wrapper, {})
+    instrument = Instrument(nexus_wrapper, {})
 
     component = instrument.create_component("test", "NXaperture", "")
 
@@ -153,7 +148,7 @@ def test_UI_GIVEN_link_as_rotation_magnitude_WHEN_creating_rotation_view_THEN_ui
     path = "/entry"
 
     transform = component.add_rotation(QVector3D(x, y, z), 0, name="test")
-    link = wrapper.instrument["asdfgh"] = h5py.SoftLink(path)
+    link = nexus_wrapper.instrument["asdfgh"] = h5py.SoftLink(path)
 
     transform.dataset = link
 
@@ -168,9 +163,10 @@ def test_UI_GIVEN_link_as_rotation_magnitude_WHEN_creating_rotation_view_THEN_ui
     assert view.transformation_frame.magnitude_widget.value.path == path
 
 
-def test_UI_GIVEN_vector_updated_WHEN_saving_view_changes_THEN_model_is_updated(qtbot):
-    wrapper = NexusWrapper()
-    instrument = Instrument(wrapper, {})
+def test_UI_GIVEN_vector_updated_WHEN_saving_view_changes_THEN_model_is_updated(
+    qtbot, nexus_wrapper
+):
+    instrument = Instrument(nexus_wrapper, {})
 
     component = instrument.create_component("test", "NXaperture", "")
 
@@ -198,10 +194,9 @@ def test_UI_GIVEN_vector_updated_WHEN_saving_view_changes_THEN_model_is_updated(
 
 
 def test_UI_GIVEN_view_gains_focus_WHEN_transformation_view_exists_THEN_spinboxes_are_enabled(
-    qtbot,
+    qtbot, nexus_wrapper
 ):
-    wrapper = NexusWrapper()
-    instrument = Instrument(wrapper, {})
+    instrument = Instrument(nexus_wrapper, {})
 
     component = instrument.create_component("test", "NXaperture", "")
 
@@ -224,10 +219,9 @@ def test_UI_GIVEN_view_gains_focus_WHEN_transformation_view_exists_THEN_spinboxe
 
 
 def test_UI_GIVEN_view_loses_focus_WHEN_transformation_view_exists_THEN_spinboxes_are_disabled(
-    qtbot,
+    qtbot, nexus_wrapper
 ):
-    wrapper = NexusWrapper()
-    instrument = Instrument(wrapper, {})
+    instrument = Instrument(nexus_wrapper, {})
 
     component = instrument.create_component("test", "NXaperture", "")
 
@@ -250,10 +244,9 @@ def test_UI_GIVEN_view_loses_focus_WHEN_transformation_view_exists_THEN_spinboxe
 
 
 def test_UI_GIVEN_new_values_are_provided_WHEN_save_changes_is_called_THEN_transformation_changed_signal_is_called_to_update_3d_view(
-    qtbot,
+    qtbot, nexus_wrapper
 ):
-    wrapper = NexusWrapper()
-    instrument = Instrument(wrapper, {})
+    instrument = Instrument(nexus_wrapper, {})
 
     component = instrument.create_component("test", "NXaperture", "")
 


### PR DESCRIPTION
# Issue

Closes #661 

### Description of work

Fixes byte-strings not being displayed correctly in the `value` edit of `FieldWidget`. 

Previously they would look like this: 
`b'some_value'`

As well as this, I changed some of the tests to use the `nexus_wrapper` and `file` fixtures, which in theory should reduce memory usage as it guarantees that all of the files are closed when the test teardown is run. 

### Acceptance Criteria 

Load up a file with byte-string datasets in (eg. bigfake.nxs) and edit the component they are contained in. 

### UI tests

None

### Nominate for Group Code Review

- [ ] Nominate for code review 
