### PR TITLE
679 - Disabling edit component button when transformation is selected

### DIFF
--- a/nexus_constructor/treeview_utils.py
+++ b/nexus_constructor/treeview_utils.py
@@ -78,14 +78,14 @@ def set_button_states(
         )
     else:
         selected_object = selection_indices[0].internalPointer()
-
-        zoom_action.setEnabled(isinstance(selected_object, Component))
+        selected_object_is_component = isinstance(selected_object, Component)
+        zoom_action.setEnabled(selected_object_is_component)
 
         selected_object_is_component_or_transform = isinstance(
             selected_object, (Component, Transformation)
         )
         duplicate_action.setEnabled(selected_object_is_component_or_transform)
-        edit_component_action.setEnabled(selected_object_is_component_or_transform)
+        edit_component_action.setEnabled(selected_object_is_component)
 
         selected_object_is_not_link_transform = not isinstance(
             selected_object, LinkTransformation

--- a/tests/ui_tests/test_main_window_utils.py
+++ b/tests/ui_tests/test_main_window_utils.py
@@ -348,7 +348,6 @@ def test_GIVEN_transformation_is_selected_WHEN_changing_button_states_THEN_expec
     transformation_selected_actions = {
         delete_action,
         duplicate_action,
-        edit_component_action,
         new_rotation_action,
         new_translation_action,
         create_link_action,


### PR DESCRIPTION
### Issue

Closes #679 

### Description of work

Disables the edit component button if anything besides a component is selected. 

### Acceptance Criteria 

components are still editable
button cannot be pressed when transformation is selected

### UI tests

Modified to suit changes.

### Nominate for Group Code Review

- [ ] Nominate for code review 
