### PR TITLE
Optimisation in mesh generation

### DIFF
--- a/nexus_constructor/geometry/cylindrical_geometry.py
+++ b/nexus_constructor/geometry/cylindrical_geometry.py
@@ -150,7 +150,7 @@ class CylindricalGeometry:
         return QVector3D(0, 0, 1)
 
     @property
-    def off_geometry(self, steps: int = 20) -> OFFGeometry:
+    def off_geometry(self, steps: int = 10) -> OFFGeometry:
         unit_conversion_factor = calculate_unit_conversion_factor(self.units, METRES)
 
         # A list of vertices describing the circle at the bottom of the cylinder

--- a/nexus_constructor/off_renderer.py
+++ b/nexus_constructor/off_renderer.py
@@ -49,7 +49,7 @@ def convert_faces_into_triangles(faces):
     return triangles
 
 
-def create_vertex_buffer(vertices, faces):
+def create_vertex_buffer(vertices, triangles):
     """
     For each point in each triangle in each face, add its points to the vertices list.
     To do this we:
@@ -57,11 +57,9 @@ def create_vertex_buffer(vertices, faces):
     Get the vertices that are in the triangles
     Adding them into a flat list of points
     :param vertices: The vertices in the mesh
-    :param faces: The faces in the mesh
+    :param triangles: A list of the triangles that make up each face in the mesh
     :return: A list of the points in the faces
     """
-    triangles = convert_faces_into_triangles(faces)
-
     flattened_triangles = flatten(triangles)
 
     return flatten(
@@ -69,15 +67,14 @@ def create_vertex_buffer(vertices, faces):
     )
 
 
-def create_normal_buffer(vertices, faces):
+def create_normal_buffer(vertices, triangles):
     """
     Creates normal vectors for each vertex on the mesh.
     Qt requires each vertex to have it's own normal.
     :param vertices: The vertices for the mesh
-    :param faces: The faces in the mesh
+    :param triangles: A list of the triangles that make up each face in the mesh
     :return: A list of the normal points for the faces
     """
-    triangles = convert_faces_into_triangles(faces)
     normal_buffer_values = []
     for triangle in triangles:
         # Get the vertices of each triangle
@@ -131,8 +128,9 @@ class QtOFFGeometry(Qt3DRender.QGeometry):
 
         faces, vertices = repeat_shape_over_positions(model, positions)
 
-        vertex_buffer_values = list(create_vertex_buffer(vertices, faces))
-        normal_buffer_values = create_normal_buffer(vertices, faces)
+        triangles = convert_faces_into_triangles(faces)
+        vertex_buffer_values = list(create_vertex_buffer(vertices, triangles))
+        normal_buffer_values = create_normal_buffer(vertices, triangles)
 
         positionAttribute = self.create_attribute(
             vertex_buffer_values, self.q_attribute.defaultPositionAttributeName()

--- a/tests/test_off_renderer.py
+++ b/tests/test_off_renderer.py
@@ -52,9 +52,10 @@ def test_GIVEN_a_square_WHEN_creating_vertex_buffer_THEN_length_is_correct():
         QVector3D(0, 1, 0),
         QVector3D(1, 1, 0),
     ]
-    faces = [[0, 1, 2, 3]]
+    # 2 triangles make up the square
+    triangles = [[0, 1, 2], [2, 3, 0]]
 
-    vertex_buffer = create_vertex_buffer(vertices, faces)
+    vertex_buffer = create_vertex_buffer(vertices, triangles)
 
     assert (
         len(list(vertex_buffer))
@@ -80,9 +81,10 @@ def test_GIVEN_a_square_face_WHEN_creating_normal_buffer_THEN_output_is_correct(
         QVector3D(1, 1, 0),
         QVector3D(1, 0, 0),
     ]
-    faces = [[0, 1, 2, 3]]
+    # 2 triangles make up the square
+    triangles = [[0, 1, 2], [2, 3, 0]]
 
-    normal = create_normal_buffer(vertices, faces)
+    normal = create_normal_buffer(vertices, triangles)
 
     expected_output = [0.0, 0.0, -1.0] * TRIANGLES_IN_SQUARE * VERTICES_IN_TRIANGLE
 


### PR DESCRIPTION
### Description of work

Grabbing an easy win in the mesh generation whilst I've spotted it.
Also halved the default number of vertices in generated cylinder meshes. In the long term we could consider scaling this based on the number of cylinders in the mesh.

### Acceptance Criteria 

Code review should be sufficient, a function call is removed so it can never have a detrimental effect.
I tested with a LOKI file and got an 18% reduction in load time from the removed call change alone.
