### PR TITLE
Updating 3d view when link is deleted

### DIFF
--- a/nexus_constructor/component_tree_model.py
+++ b/nexus_constructor/component_tree_model.py
@@ -96,6 +96,7 @@ class ComponentTreeModel(QAbstractItemModel):
         if len(transformation_list) > 0:
             parent_transform = transformation_list[len(transformation_list) - 1]
             parent_transform.depends_on = None
+        self.instrument.nexus.transformation_changed.emit()
 
     def __update_link_rows(self):
         nr_of_components = self.rowCount(QModelIndex())


### PR DESCRIPTION
### Issue

Closes #683 

### Description of work

Fixes the 3d view not updating when a link is deleted. Previously it would do nothing. 

This was caused by the transformation_changed() signal not being called when a link was deleted. 

### Acceptance Criteria 

Follow steps in issue and make sure 3d view is updated when a link is deleted. 

### UI tests

None

### Nominate for Group Code Review

- [ ] Nominate for code review 
