### PR TITLE
Add unit test and fix for deleting component with transformation

### DIFF
--- a/nexus_constructor/component_tree_model.py
+++ b/nexus_constructor/component_tree_model.py
@@ -130,18 +130,22 @@ class ComponentTreeModel(QAbstractItemModel):
     def _remove_component(self, index: QModelIndex):
         component = index.internalPointer()
         transforms = component.transforms
-        if transforms and transforms[0].dependents():
-            reply = QMessageBox.question(
-                None,
-                "Delete component?",
-                "this component has transformations that are depended on. Are you sure you want to delete it?",
-                QMessageBox.Yes,
-                QMessageBox.No,
+        if transforms:
+            has_dependents_other_than_the_component_being_deleted = (
+                len(transforms[0].dependents) > 1
             )
-            if reply == QMessageBox.Yes:
-                pass
-            elif reply == QMessageBox.No:
-                return
+            if has_dependents_other_than_the_component_being_deleted:
+                reply = QMessageBox.question(
+                    None,
+                    "Delete component?",
+                    "this component has transformations that are depended on. Are you sure you want to delete it?",
+                    QMessageBox.Yes,
+                    QMessageBox.No,
+                )
+                if reply == QMessageBox.Yes:
+                    pass
+                elif reply == QMessageBox.No:
+                    return
         remove_index = self.components.index(index.internalPointer())
         self.beginRemoveRows(QModelIndex(), remove_index, remove_index)
         for transform in transforms:

--- a/tests/test_component_tree_model.py
+++ b/tests/test_component_tree_model.py
@@ -509,6 +509,20 @@ def test_remove_component(nexus_wrapper):
     assert under_test.rowCount(QModelIndex()) == 0
 
 
+def test_remove_component_with_transformation(nexus_wrapper):
+    instrument = Instrument(nexus_wrapper, NX_CLASS_DEFINITIONS)
+    under_test = ComponentTreeModel(instrument)
+    instrument.create_component("Some name", "some class", "desc")
+    component_index = under_test.index(0, 0, QModelIndex())
+    under_test.add_rotation(component_index)
+    assert under_test.rowCount(QModelIndex()) == 1
+    under_test.remove_node(component_index)
+    assert under_test.rowCount(QModelIndex()) == 0, (
+        "Expected component to be successfully deleted because it has "
+        "a transformation that only has it as a dependent"
+    )
+
+
 def test_remove_transformation(nexus_wrapper):
     instrument = Instrument(nexus_wrapper, NX_CLASS_DEFINITIONS)
     under_test = ComponentTreeModel(instrument)


### PR DESCRIPTION
### Issue

Closes #689

### Description of work

If a component's transformation only has the component as a dependent then allow deletion of the component without warning the user.
Fixed implementation and covered with unit test.

### Nominate for Group Code Review

- [ ] Nominate for code review 
