### PR TITLE
662 - fixing array attributes not being set correctly

### DIFF
--- a/nexus_constructor/field_attrs.py
+++ b/nexus_constructor/field_attrs.py
@@ -75,7 +75,6 @@ class FieldAttrsDialog(QDialog):
 class FieldAttrFrame(QFrame):
     def __init__(self, name=None, value=None, parent=None):
         super().__init__(parent)
-        self.array = None
         self.setMinimumHeight(40)
         self.setLayout(QHBoxLayout())
         self.attr_name_lineedit = QLineEdit()
@@ -91,6 +90,7 @@ class FieldAttrFrame(QFrame):
         self.attr_dtype_combo.addItems([*DATASET_TYPE.keys()])
         self.attr_dtype_combo.currentTextChanged.connect(self.dtype_changed)
         self.dtype_changed(self.attr_dtype_combo.currentText())
+        self.dialog = ArrayDatasetTableWidget(self.dtype)
 
         self.layout().addWidget(self.attr_name_lineedit)
         self.layout().addWidget(self.array_or_scalar_combo)
@@ -102,6 +102,7 @@ class FieldAttrFrame(QFrame):
 
         if name is not None and value is not None:
             self.value = (name, value)
+            self.dtype_changed("")
 
     def type_changed(self, item: str):
         self.attr_value_lineedit.setVisible(item == "Scalar")
@@ -132,7 +133,6 @@ class FieldAttrFrame(QFrame):
         return self.array_or_scalar_combo.currentText() == "Scalar"
 
     def show_edit_array_dialog(self, _):
-        self.dialog = ArrayDatasetTableWidget(self.dtype)
         self.dialog.show()
 
     @property
@@ -169,4 +169,4 @@ class FieldAttrFrame(QFrame):
             self.attr_value_lineedit.setText(str(new_value))
         else:
             self.type_changed("Array")
-            self.array = new_value.data
+            self.dialog.model.array = new_value.data[...]

--- a/nexus_constructor/field_attrs.py
+++ b/nexus_constructor/field_attrs.py
@@ -151,7 +151,7 @@ class FieldAttrFrame(QFrame):
             if self.dtype == DATASET_TYPE["String"] or isinstance(self.dtype, str):
                 return self.attr_value_lineedit.text()
             return self.dtype(self.attr_value_lineedit.text())
-        return self.dialog.model.array
+        return np.squeeze(self.dialog.model.array)
 
     @value.setter
     def value(self, new_value: Union[np.generic, np.ndarray]):
@@ -172,4 +172,5 @@ class FieldAttrFrame(QFrame):
         else:
             self.type_changed("Array")
             self.dialog.model.array = new_value
+            self.dialog.model.update_array_dtype(new_value.dtype)
         self.dtype_changed(None)

--- a/tests/ui_tests/test_ui_add_component_window.py
+++ b/tests/ui_tests/test_ui_add_component_window.py
@@ -378,15 +378,18 @@ def enter_disk_chopper_fields(
     # Set the units attributes
     slit_edges_attribute_frame = FieldAttrFrame()
     slit_edges_attribute_frame.attr_dtype_combo.setCurrentText("String")
-    slit_edges_attribute_frame.value = ("units", "deg")
+    slit_edges_attribute_frame.name = "units"
+    slit_edges_attribute_frame.value = "deg"
 
     radius_attribute_frame = FieldAttrFrame()
     radius_attribute_frame.attr_dtype_combo.setCurrentText("String")
-    radius_attribute_frame.value = ("units", "mm")
+    radius_attribute_frame.name = "units"
+    radius_attribute_frame.value = "mm"
 
     slit_height_attribute_frame = FieldAttrFrame()
     slit_height_attribute_frame.attr_dtype_combo.setCurrentText("String")
-    slit_height_attribute_frame.value = ("units", "mm")
+    slit_height_attribute_frame.name = "units"
+    slit_height_attribute_frame.value = "mm"
 
     fields_widgets[1].attrs_dialog._add_attr(slit_edges_attribute_frame)
     fields_widgets[2].attrs_dialog._add_attr(radius_attribute_frame)

--- a/tests/ui_tests/test_ui_field_attrs.py
+++ b/tests/ui_tests/test_ui_field_attrs.py
@@ -113,9 +113,8 @@ def test_GIVEN_attribute_is_an_array_WHEN_getting_data_THEN_array_is_returned(
     attribute_name = "AttributeName"
     qtbot.keyClicks(widget.attr_name_lineedit, attribute_name)
 
-    name, value = widget.value
-    assert name == attribute_name
-    assert np.array_equal(value, data)
+    assert widget.name == attribute_name
+    assert np.array_equal(widget.value, data)
 
 
 def test_GIVEN_array_and_attribute_name_set_WHEN_changing_attribute_THEN_array_attribute_set(
@@ -123,9 +122,10 @@ def test_GIVEN_array_and_attribute_name_set_WHEN_changing_attribute_THEN_array_a
 ):
     widget = add_array_attribute(field_attributes_dialog, qtbot)
     data = np.arange(9).reshape((3, 3))
-    widget.value = ("AttributeName", data)
+    widget.name = "AttributeName"
+    widget.value = data
 
-    assert np.array_equal(widget.array, data)
+    assert np.array_equal(widget.dialog.model.array, data)
 
 
 def test_GIVEN_type_changed_to_array_WHEN_changing_attribute_THEN_edit_array_button_is_visible(


### PR DESCRIPTION
### Issue

Closes #662 

### Description of work

Fixes array attributes not being saved when editing has finished. 

### Acceptance Criteria 

- tidied up the interface - now has name property rather than passing in a tuple of name and value
- set the model array when an array attribute is loaded 
- updates the dtype of the view so values can be properly validated against 
- uses `np.squeeze` when returning the array. 

### UI tests

Test was incorrect so modified to test correct output

### Nominate for Group Code Review

- [ ] Nominate for code review 
