### PR TITLE
Fixing windows-specific transformation view UI issue

### DIFF
--- a/ui/transformation.py
+++ b/ui/transformation.py
@@ -50,6 +50,7 @@ class Ui_Transformation(object):
 
         self.magnitude_widget = FieldWidget(hide_name_field=True, instrument=instrument)
         self.magnitude_widget.setFrameShape(QFrame.NoFrame)
+        self.magnitude_widget.setMinimumHeight(40)
         self.main_layout.addWidget(self.magnitude_widget)
 
         self.ui_placeholder_layout = QFormLayout()


### PR DESCRIPTION
### Issue

Closes #693 

### Description of work

Fixes a UI issue for the transformation view on windows being squashed when the frame is enabled. 

I will self-merge this when the build passes because it's pretty simple and shouldn't break anything. 

### Acceptance Criteria 

No functional changes besides setting a minimum height for the widget in the transformation view. This does not affect the "add component" window

### UI tests

None

### Nominate for Group Code Review

- [ ] Nominate for code review 
