### PR TITLE
Disabling nexus actions + silx treeview

### DIFF
--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -51,7 +51,7 @@ class Ui_MainWindow(object):
     def _set_up_silx_view(self):
         self.silx_tab = QWidget()
         self.silx_tab_layout = QGridLayout(self.silx_tab)
-        # self.tab_widget.addTab(self.silx_tab, "")
+        # self.tab_widget.addTab(self.silx_tab, "") Disabled while changing model
 
     def _set_up_component_tree_view(self):
         self.component_tree_view_tab = ComponentTreeViewTab(parent=self)
@@ -70,10 +70,10 @@ class Ui_MainWindow(object):
         self.export_to_nexus_file_action = QAction(MainWindow)
         self.export_to_filewriter_JSON_action = QAction(MainWindow)
         self.export_to_forwarder_JSON_action = QAction(MainWindow)
-        # self.file_menu.addAction(self.open_nexus_file_action)
+        # self.file_menu.addAction(self.open_nexus_file_action) Disabled while changing model
         self.file_menu.addAction(self.open_json_file_action)
-        # self.file_menu.addAction(self.open_idf_file_action)
-        # self.file_menu.addAction(self.export_to_nexus_file_action)
+        # self.file_menu.addAction(self.open_idf_file_action) Disabled while changing model
+        # self.file_menu.addAction(self.export_to_nexus_file_action) Disabled while changing model
         self.file_menu.addAction(self.export_to_filewriter_JSON_action)
         self.file_menu.addAction(self.export_to_forwarder_JSON_action)
         self.menu_bar.addAction(self.file_menu.menuAction())

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -51,7 +51,7 @@ class Ui_MainWindow(object):
     def _set_up_silx_view(self):
         self.silx_tab = QWidget()
         self.silx_tab_layout = QGridLayout(self.silx_tab)
-        self.tab_widget.addTab(self.silx_tab, "")
+        # self.tab_widget.addTab(self.silx_tab, "")
 
     def _set_up_component_tree_view(self):
         self.component_tree_view_tab = ComponentTreeViewTab(parent=self)
@@ -70,10 +70,10 @@ class Ui_MainWindow(object):
         self.export_to_nexus_file_action = QAction(MainWindow)
         self.export_to_filewriter_JSON_action = QAction(MainWindow)
         self.export_to_forwarder_JSON_action = QAction(MainWindow)
-        self.file_menu.addAction(self.open_nexus_file_action)
+        # self.file_menu.addAction(self.open_nexus_file_action)
         self.file_menu.addAction(self.open_json_file_action)
-        self.file_menu.addAction(self.open_idf_file_action)
-        self.file_menu.addAction(self.export_to_nexus_file_action)
+        # self.file_menu.addAction(self.open_idf_file_action)
+        # self.file_menu.addAction(self.export_to_nexus_file_action)
         self.file_menu.addAction(self.export_to_filewriter_JSON_action)
         self.file_menu.addAction(self.export_to_forwarder_JSON_action)
         self.menu_bar.addAction(self.file_menu.menuAction())


### PR DESCRIPTION
### Issue

Refs #607 

### Description of work

Disables any actions such as loading or saving to JSON, including IDF files. 
Also disables the silx tree view tab.

### Acceptance Criteria 

I didn't remove any logic, just disabled the places in the UI where nexus files can be used as I/O.

### UI tests

None changed

### Nominate for Group Code Review

- [ ] Nominate for code review 
