### PR TITLE
Adding general information about purpose of nexus constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ Currently it does not work on Mac due to a bug in Qt, but we hope to resolve thi
 
 Binary packages for release versions can be downloaded on the [releases page](https://github.com/ess-dmsc/nexus-constructor/releases), or to run the latest development version please follow the instructions below.
 
-This project is developed for Python 3.6, so an install of 3.6 or higher
-is required. https://www.python.org/downloads/
+Python 3.6 or greater is required. https://www.python.org/downloads/
 
 Runtime Python dependencies are listed in requirements.txt at the root of the
 repository. They can be installed from a terminal by running

--- a/README.md
+++ b/README.md
@@ -36,18 +36,18 @@ pip install -r requirements.txt
 
 ### Development dependencies
 
-Development dependencies (including all runtime dependencies) can be installed by using the following command: 
+Development dependencies (including all runtime dependencies) can be installed by using the following command
 
 ```
 pip install -r requirements-dev.txt
 ```
 
 The black pre-commit hook (installed by [pre-commit](https://pre-commit.com/)) requires Python 3.6 or above.
-You need to once run
+You need to run
 ```
 pre-commit install
 ```
-to activate the pre-commit check.
+once to activate the pre-commit check.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![License (2-Clause BSD)](https://img.shields.io/badge/license-BSD%202--Clause-blue.svg)](https://github.com/ess-dmsc/nexus-constructor/blob/master/LICENSE) [![codecov](https://codecov.io/gh/ess-dmsc/nexus-constructor/branch/master/graph/badge.svg)](https://codecov.io/gh/ess-dmsc/nexus-constructor) [![Build Status](https://jenkins.esss.dk/dm/job/ess-dmsc/job/nexus-constructor/job/master/badge/icon)](https://jenkins.esss.dk/dm/job/ess-dmsc/job/nexus-constructor/job/master/) [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
 
 # NeXus Constructor
-The NeXus Constructor is used for constructing [NeXus files](https://www.nexusformat.org/),
+The NeXus Constructor facilitates constructing [NeXus files](https://www.nexusformat.org/) in which to record data from experiments at neutron science facilities. This includes all supporting metadata typically required to perform analysis of such experiments,
 including instrument geometry information.
 
 The application can directly output a NeXus file, or create a 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ The application can directly output a NeXus file, or create a [_NeXus structure_
 
 ![NeXus Constructor](resources/images/nc_screenshot.png)
 
+Although the application may be useful to other institutions using NeXus, the NeXus Constructor is being developed as part of the software suite for the [European Spallation Source (ESS)](https://europeanspallationsource.se/). Please see [this (open access) paper](https://iopscience.iop.org/article/10.1088/1748-0221/13/10/T10001) for more information on the ESS software.   
+
 Currently tested on Windows 10, Ubuntu 18.04/19.10 and CentOS 7, it should also work on other Linux distributions. Currently it does not work on Mac due to a bug in Qt, but we hope to resolve this soon.
 
 ## Installing dependencies
@@ -40,11 +42,6 @@ to activate the pre-commit check.
 ## Usage
 
 Run the python script `nexus-constructor.py` located in the root of the repository.
-
-The NeXus Constructor both constructs and identifies components as groups and determines the type of component by using the `NX_class` attribute. 
-
-Components with (or without) shape and position information are shown in the 3d view the Constructor offers, which aims to visualise how beamline instruments are/will be set up. Methods for adding and editing components and translations can be found in the toolbar above the treeview which displays them.
-
 
 ## Developer Documentation
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,17 @@
 [![License (2-Clause BSD)](https://img.shields.io/badge/license-BSD%202--Clause-blue.svg)](https://github.com/ess-dmsc/nexus-constructor/blob/master/LICENSE) [![codecov](https://codecov.io/gh/ess-dmsc/nexus-constructor/branch/master/graph/badge.svg)](https://codecov.io/gh/ess-dmsc/nexus-constructor) [![Build Status](https://jenkins.esss.dk/dm/job/ess-dmsc/job/nexus-constructor/job/master/badge/icon)](https://jenkins.esss.dk/dm/job/ess-dmsc/job/nexus-constructor/job/master/) [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
 
 # NeXus Constructor
-The NeXus Constructor is used for constructing [NeXus files](https://www.nexusformat.org/) with instrument geometry information using a GUI.
+The NeXus Constructor is used for constructing [NeXus files](https://www.nexusformat.org/), including instrument geometry information.
 
-The Constructor can also be used to output and send run start and stop messages to the [File-Writer](https://github.com/ess-dmsc/kafka-to-nexus) to configure a template of the instrument information for data aggregation.
-
-The file-writer uses streams from the [Apache Kafka](https://kafka.apache.org/) streaming platform to aggregate experiment data which need to be configured by the constructor before use. This is typically dynamic data which may change during an experiment run, such as a motor's position. 
+The application can directly output a NeXus file, or create a [_NeXus structure_, JSON template](https://github.com/ess-dmsc/kafka-to-nexus/blob/master/documentation/commands.md#defining-a-nexus-structure) of the file to send to the [File Writer](https://github.com/ess-dmsc/kafka-to-nexus). The JSON template can include data stream details, such that the File Writer populates the NeXus file it creates with data acquired from the detector and other beamline apparatus during an experiment. 
 
 ![NeXus Constructor](resources/images/nc_screenshot.png)
 
 Currently tested on Windows 10, Ubuntu 18.04/19.10 and CentOS 7, it should also work on other Linux distributions. Currently it does not work on Mac due to a bug in Qt, but we hope to resolve this soon.
 
-
 ## Installing dependencies
+
+Binary packages for release versions can be downloaded on the [releases page](https://github.com/ess-dmsc/nexus-constructor/releases), or to run the latest development version please follow the instructions below.
 
 This project is developed for Python 3.6, so an install of 3.6 or higher
 is required. https://www.python.org/downloads/

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 [![License (2-Clause BSD)](https://img.shields.io/badge/license-BSD%202--Clause-blue.svg)](https://github.com/ess-dmsc/nexus-constructor/blob/master/LICENSE) [![codecov](https://codecov.io/gh/ess-dmsc/nexus-constructor/branch/master/graph/badge.svg)](https://codecov.io/gh/ess-dmsc/nexus-constructor) [![Build Status](https://jenkins.esss.dk/dm/job/ess-dmsc/job/nexus-constructor/job/master/badge/icon)](https://jenkins.esss.dk/dm/job/ess-dmsc/job/nexus-constructor/job/master/) [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
 
 # NeXus Constructor
-Construct [NeXus files](https://www.nexusformat.org/) with instrument geometry information using a GUI.
+The NeXus Constructor is used for constructing [NeXus files](https://www.nexusformat.org/) with instrument geometry information using a GUI. It does this by treating everything with an `NX_class` as a component which can contain properties relevant to their respective devices, including position information and component-specific fields.
+
+The Constructor can also be used to output and send run start and stop messages to the [File-Writer](https://github.com/ess-dmsc/kafka-to-nexus) to configure a template of the instrument information for data aggregation.
+
+The file-writer uses streams from the [Apache Kafka](https://kafka.apache.org/) streaming platform to aggregate experiment data which need to be configured by the constructor before use. This is typically dynamic data which may change during an experiment run, such as a motor's position. 
 
 ![NeXus Constructor](resources/images/nc_screenshot.png)
 
-Currently tested on Windows 10 and CentOS 7, it should also work on other Linux distributions. Currently it does not work on Mac due to a bug in Qt, but we hope to resolve this soon.
+Currently tested on Windows 10, Ubuntu 18.04/19.10 and CentOS 7, it should also work on other Linux distributions. Currently it does not work on Mac due to a bug in Qt, but we hope to resolve this soon.
 
 ## Installing dependencies
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,25 @@
 [![License (2-Clause BSD)](https://img.shields.io/badge/license-BSD%202--Clause-blue.svg)](https://github.com/ess-dmsc/nexus-constructor/blob/master/LICENSE) [![codecov](https://codecov.io/gh/ess-dmsc/nexus-constructor/branch/master/graph/badge.svg)](https://codecov.io/gh/ess-dmsc/nexus-constructor) [![Build Status](https://jenkins.esss.dk/dm/job/ess-dmsc/job/nexus-constructor/job/master/badge/icon)](https://jenkins.esss.dk/dm/job/ess-dmsc/job/nexus-constructor/job/master/) [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
 
 # NeXus Constructor
-The NeXus Constructor is used for constructing [NeXus files](https://www.nexusformat.org/), including instrument geometry information.
+The NeXus Constructor is used for constructing [NeXus files](https://www.nexusformat.org/),
+including instrument geometry information.
 
-The application can directly output a NeXus file, or create a [_NeXus structure_, JSON template](https://github.com/ess-dmsc/kafka-to-nexus/blob/master/documentation/commands.md#defining-a-nexus-structure) of the file to send to the [File Writer](https://github.com/ess-dmsc/kafka-to-nexus). The JSON template can include data stream details, such that the File Writer populates the NeXus file it creates with data acquired from the detector and other beamline apparatus during an experiment. 
+The application can directly output a NeXus file, or create a 
+[_NeXus structure_, JSON template](https://github.com/ess-dmsc/kafka-to-nexus/blob/master/documentation/commands.md#defining-a-nexus-structure)
+of the file to send to the [File Writer](https://github.com/ess-dmsc/kafka-to-nexus). The JSON template can
+include data stream details, such that the File Writer populates the NeXus file it creates with data acquired
+from the detector and other beamline apparatus during an experiment. 
 
 ![NeXus Constructor](resources/images/nc_screenshot.png)
 
-Although the application may be useful to other institutions using NeXus, the NeXus Constructor is being developed as part of the software suite for the [European Spallation Source (ESS)](https://europeanspallationsource.se/). Please see [this (open access) paper](https://iopscience.iop.org/article/10.1088/1748-0221/13/10/T10001) for more information on the ESS software.   
+Although the application may be useful to other institutions using NeXus, the NeXus Constructor is being
+developed as part of the software suite for the
+[European Spallation Source (ESS)](https://europeanspallationsource.se/). Please see
+[this (open access) paper](https://iopscience.iop.org/article/10.1088/1748-0221/13/10/T10001)
+for more information on the ESS software.   
 
-Currently tested on Windows 10, Ubuntu 18.04/19.10 and CentOS 7, it should also work on other Linux distributions. Currently it does not work on Mac due to a bug in Qt, but we hope to resolve this soon.
+Currently tested on Windows 10, Ubuntu 18.04/19.10 and CentOS 7, it should also work on other Linux distributions.
+Currently it does not work on Mac due to a bug in Qt, but we hope to resolve this soon.
 
 ## Installing dependencies
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![License (2-Clause BSD)](https://img.shields.io/badge/license-BSD%202--Clause-blue.svg)](https://github.com/ess-dmsc/nexus-constructor/blob/master/LICENSE) [![codecov](https://codecov.io/gh/ess-dmsc/nexus-constructor/branch/master/graph/badge.svg)](https://codecov.io/gh/ess-dmsc/nexus-constructor) [![Build Status](https://jenkins.esss.dk/dm/job/ess-dmsc/job/nexus-constructor/job/master/badge/icon)](https://jenkins.esss.dk/dm/job/ess-dmsc/job/nexus-constructor/job/master/) [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
 
 # NeXus Constructor
-The NeXus Constructor is used for constructing [NeXus files](https://www.nexusformat.org/) with instrument geometry information using a GUI. It does this by treating everything with an `NX_class` as a component which can contain properties relevant to their respective devices, including position information and component-specific fields.
+The NeXus Constructor is used for constructing [NeXus files](https://www.nexusformat.org/) with instrument geometry information using a GUI.
 
 The Constructor can also be used to output and send run start and stop messages to the [File-Writer](https://github.com/ess-dmsc/kafka-to-nexus) to configure a template of the instrument information for data aggregation.
 
@@ -10,6 +10,7 @@ The file-writer uses streams from the [Apache Kafka](https://kafka.apache.org/) 
 ![NeXus Constructor](resources/images/nc_screenshot.png)
 
 Currently tested on Windows 10, Ubuntu 18.04/19.10 and CentOS 7, it should also work on other Linux distributions. Currently it does not work on Mac due to a bug in Qt, but we hope to resolve this soon.
+
 
 ## Installing dependencies
 
@@ -37,9 +38,14 @@ pre-commit install
 ```
 to activate the pre-commit check.
 
-## Running the application
+## Usage
 
 Run the python script `nexus-constructor.py` located in the root of the repository.
+
+The NeXus Constructor both constructs and identifies components as groups and determines the type of component by using the `NX_class` attribute. 
+
+Components with (or without) shape and position information are shown in the 3d view the Constructor offers, which aims to visualise how beamline instruments are/will be set up. Methods for adding and editing components and translations can be found in the toolbar above the treeview which displays them.
+
 
 ## Developer Documentation
 


### PR DESCRIPTION
### Issue

Closes #697 

### Description of work

Adds the purpose of the nexus constructor to try and make it easier to understand for people who are not yet familiar of the data streaming pipeline and existing technology surrounding it.

### Acceptance Criteria 

May be easier to read https://github.com/ess-dmsc/nexus-constructor/blob/bd1bf6a6cd9774804f67f6732a49d9428e639e9f/README.md than the diff.

### UI tests

N/A

### Nominate for Group Code Review

- [ ] Nominate for code review 
