### PR TITLE
Attempting to make nexus-constructor.py work from any directory

### DIFF
--- a/nexus-constructor.py
+++ b/nexus-constructor.py
@@ -27,7 +27,9 @@ if __name__ == "__main__":
     app.setWindowIcon(QIcon(os.path.join("ui", "icon.png")))
     window = QMainWindow()
     nexus_wrapper = NexusWrapper()
-    definitions_dir = os.path.abspath(os.path.join(os.getcwd(), "definitions"))
+    definitions_dir = os.path.abspath(
+        os.path.join(os.path.dirname(os.path.realpath(__file__)), "definitions")
+    )
     _, nx_component_classes = make_dictionary_of_class_definitions(definitions_dir)
     instrument = Instrument(nexus_wrapper, nx_component_classes)
     ui = MainWindow(instrument, nx_component_classes)

--- a/nexus-constructor.py
+++ b/nexus-constructor.py
@@ -17,6 +17,12 @@ from nexus_constructor.instrument import Instrument
 import os
 import argparse
 
+if getattr(sys, "frozen", False):
+    # frozen
+    root_dir = os.path.dirname(sys.executable)
+else:
+    root_dir = os.path.dirname(os.path.realpath(__file__))
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Nexus Constructor")
     if "help" in parser.parse_args():
@@ -27,9 +33,7 @@ if __name__ == "__main__":
     app.setWindowIcon(QIcon(os.path.join("ui", "icon.png")))
     window = QMainWindow()
     nexus_wrapper = NexusWrapper()
-    definitions_dir = os.path.abspath(
-        os.path.join(os.path.dirname(os.path.realpath(__file__)), "definitions")
-    )
+    definitions_dir = os.path.abspath(os.path.join(root_dir, "definitions"))
     _, nx_component_classes = make_dictionary_of_class_definitions(definitions_dir)
     instrument = Instrument(nexus_wrapper, nx_component_classes)
     ui = MainWindow(instrument, nx_component_classes)

--- a/nexus_constructor/treeview_utils.py
+++ b/nexus_constructor/treeview_utils.py
@@ -16,6 +16,8 @@ from nexus_constructor.transformation_view import (
 )
 from nexus_constructor.transformations import Transformation
 
+root_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..")
+
 
 def create_and_add_toolbar_action(
     icon_path: str,
@@ -37,7 +39,9 @@ def create_and_add_toolbar_action(
     :return The new QAction.
     """
     toolbar_action = QAction(
-        QIcon(os.path.join("ui", icon_path)), mouse_over_text, component_tree_view_tab
+        QIcon(os.path.join(root_dir, "ui", icon_path)),
+        mouse_over_text,
+        component_tree_view_tab,
     )
     toolbar_action.triggered.connect(trigger_method)
     toolbar_action.setEnabled(set_enabled)

--- a/nexus_constructor/treeview_utils.py
+++ b/nexus_constructor/treeview_utils.py
@@ -1,5 +1,5 @@
 import os
-
+import sys
 from PySide2.QtCore import QModelIndex, Qt
 from PySide2.QtGui import QIcon, QColor
 from PySide2.QtWidgets import QAction, QToolBar, QWidget, QTreeView, QLabel
@@ -16,7 +16,13 @@ from nexus_constructor.transformation_view import (
 )
 from nexus_constructor.transformations import Transformation
 
-root_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..")
+# We have to use this for cx freeze as __file__ does not work
+if getattr(sys, "frozen", False):
+    dir_ = os.path.dirname(sys.executable)
+else:
+    dir_ = os.path.dirname(os.path.realpath(__file__))
+
+root_dir = os.path.join(dir_, "..")
 
 
 def create_and_add_toolbar_action(

--- a/nexus_constructor/treeview_utils.py
+++ b/nexus_constructor/treeview_utils.py
@@ -18,11 +18,11 @@ from nexus_constructor.transformations import Transformation
 
 # We have to use this for cx freeze as __file__ does not work
 if getattr(sys, "frozen", False):
-    dir_ = os.path.dirname(sys.executable)
+    current_file = os.path.dirname(sys.executable)
 else:
-    dir_ = os.path.dirname(os.path.realpath(__file__))
+    current_file = os.path.dirname(os.path.realpath(__file__))
 
-root_dir = os.path.join(dir_, "..")
+root_dir = os.path.join(current_file, "..")
 
 
 def create_and_add_toolbar_action(

--- a/nexus_constructor/treeview_utils.py
+++ b/nexus_constructor/treeview_utils.py
@@ -18,11 +18,9 @@ from nexus_constructor.transformations import Transformation
 
 # We have to use this for cx freeze as __file__ does not work
 if getattr(sys, "frozen", False):
-    current_file = os.path.dirname(sys.executable)
+    root_dir = os.path.dirname(sys.executable)
 else:
-    current_file = os.path.dirname(os.path.realpath(__file__))
-
-root_dir = os.path.join(current_file, "..")
+    root_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..")
 
 
 def create_and_add_toolbar_action(


### PR DESCRIPTION
### Issue
Follows on from #706 as i stole the bit of code that does it for the test locations. 
Closes #567 

### Description of work

Previously `nexus-constructor.py` had to be run from the root directory of the project. Now it should be able to run even if the current working directory is not the root.  This should fix the executables, I will test this before assigning a reviewer. 

### Acceptance Criteria 

used `sys.executable` instead of `__file__` when python is running in a frozen environment. This means both the python script and the executable can be run from any directory (i.e you do not need to be in the 'root' folder of the nexus-constructor) 

### UI tests

None changed

### Nominate for Group Code Review

- [ ] Nominate for code review 
