### PR TITLE
Removed explicit instructions for interviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,18 +30,6 @@ Binary packages for release versions can be downloaded on the [releases page](ht
 Python 3.6 or greater is required. https://www.python.org/downloads/
 
 It is **HIGHLY** recommended that a virtual environment is created for running the nexus-constructor.
-On a UNIX-like system using the systen installed version of Python, the commands required would be something like:
-```
-python3 -m venv nc_env
-. nc_env/bin/activate
-```
-On Windows (assuming Python3.6+ is installed and on the PATH):
-```
-python -m venv nc_env
-nc_env\bin\activate.bat
-```
-
-For users of Conda or similar, please see the associated documentation for instructions on creating a virtual environment.
 
 Runtime Python dependencies are listed in requirements.txt at the root of the
 repository. They can be installed from a terminal by running


### PR DESCRIPTION
We don't need explicit instructions on how to create a virtual environment now the interviews are over.

Interesting aside: all the candidates failed to read this part of the documentation anyway!

### Issue

N/A

### Description of work

Documentation updated

### Acceptance Criteria 

N/A

### UI tests
N/A

### Nominate for Group Code Review

- [ ] Nominate for code review 
