### PR TITLE
730: Distance change updates Instrument View

### DIFF
--- a/nexus_constructor/component_tree_model.py
+++ b/nexus_constructor/component_tree_model.py
@@ -225,7 +225,7 @@ class ComponentTreeModel(QAbstractItemModel):
         parent_component, transformation_list, transformation_type
     ):
         values = Dataset(
-            name="", dataset=DatasetMetadata(type="Byte", size=[1]), values="0"
+            name="", dataset=DatasetMetadata(type="Byte", size=[1]), values=""
         )
         if transformation_type == TransformationType.TRANSLATION:
             new_transformation = parent_component.add_translation(

--- a/nexus_constructor/component_tree_model.py
+++ b/nexus_constructor/component_tree_model.py
@@ -225,7 +225,7 @@ class ComponentTreeModel(QAbstractItemModel):
         parent_component, transformation_list, transformation_type
     ):
         values = Dataset(
-            name="", dataset=DatasetMetadata(type="Byte", size=[1]), values=""
+            name="", dataset=DatasetMetadata(type="Byte", size=[1]), values="0"
         )
         if transformation_type == TransformationType.TRANSLATION:
             new_transformation = parent_component.add_translation(

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -236,8 +236,7 @@ class MainWindow(Ui_MainWindow, QMainWindow):
     def _update_transformations_3d_view(self):
         self.sceneWidget.clear_all_transformations()
         for component in self.instrument.get_component_list():
-            if component.name != "sample":
-                self.sceneWidget.add_transformation(component.name, component.transform)
+            self.sceneWidget.add_transformation(component.name, component.transform)
 
     def _update_views(self):
         self.sceneWidget.clear_all_transformations()

--- a/nexus_constructor/model/component.py
+++ b/nexus_constructor/model/component.py
@@ -71,7 +71,7 @@ class Component(Group):
         :return: QTransform of final transformation
         """
         transform_matrix = QMatrix4x4()
-        for transform in self.transforms_full_chain:
+        for transform in self.transforms:
             transform_matrix *= transform.qmatrix
         transformation = Qt3DCore.QTransform()
         transformation.setMatrix(transform_matrix)

--- a/nexus_constructor/model/component.py
+++ b/nexus_constructor/model/component.py
@@ -188,7 +188,7 @@ class Component(Group):
             name = _generate_incremental_name(transformation_type, self.transforms_list)
         transform = Transformation(name, angle_or_magnitude)
         transform.type = transformation_type
-        transform.ui_value = angle_or_magnitude
+        transform.ui_value = 0.0
         transform.units = units
         transform.vector = vector
         transform.depends_on = depends_on

--- a/nexus_constructor/model/entry.py
+++ b/nexus_constructor/model/entry.py
@@ -27,10 +27,15 @@ class Instrument(Group):
         self.nx_class = "NXinstrument"
         self.nexus = Nexus()
 
-    def get_component_list(self):
         sample = Component("sample")
         sample.nx_class = "NXsample"
-        return [sample]
+        self.component_list = [sample]
+
+    def get_component_list(self):
+        return self.component_list
+
+    def remove_component(self, component: Component):
+        self.component_list.remove(component)
 
 
 class Entry(Group):


### PR DESCRIPTION
### Issue

Progresses #730

### Description of work

Brings back some transformation behaviour in the instrument view.
-  `_update_transformations_3d_view` doesn't ignore the sample component
- transform generates matrix using `transforms` rather than `transforms_full_chain`
- Default `ui_value` in new transforms is 0. Without this adding a new transform automatically makes the component move.
- Instrument keeps a list of components

### Acceptance Criteria 

Add multiple transformations to the sample or a new component. Check that the component moves in the instrument view.

### UI tests

n/a

### Nominate for Group Code Review

- [ ] Nominate for code review 
