### PR TITLE
730: Transformation magnitudes in UI value spinbox

### DIFF
--- a/nexus_constructor/field_widget.py
+++ b/nexus_constructor/field_widget.py
@@ -67,6 +67,7 @@ class FieldNameLineEdit(QLineEdit):
 class FieldWidget(QFrame):
     # Used for deletion of field
     something_clicked = Signal()
+    value_changed = Signal(float)
 
     def dataset_type_changed(self, _):
         self.value_line_edit.validator().dataset_type_combo = self.value_type_combo
@@ -115,6 +116,7 @@ class FieldWidget(QFrame):
 
         self.value_line_edit = QLineEdit()
         self.value_line_edit.setPlaceholderText("value")
+        self.value_line_edit.textChanged.connect(self.update_ui_value)
 
         self._set_up_value_validator(False)
         self.dataset_type_changed(0)
@@ -164,6 +166,14 @@ class FieldWidget(QFrame):
 
         # Set the layout for the default field type
         self.field_type_changed()
+
+    def update_ui_value(self, text: str):
+
+        try:
+            ui_value = float(text)
+            self.value_changed.emit(ui_value)
+        except ValueError:
+            return
 
     def _set_up_name_validator(self):
         field_widgets = []

--- a/nexus_constructor/field_widget.py
+++ b/nexus_constructor/field_widget.py
@@ -67,7 +67,7 @@ class FieldNameLineEdit(QLineEdit):
 class FieldWidget(QFrame):
     # Used for deletion of field
     something_clicked = Signal()
-    show_3d_value_spinbox = Signal(bool)
+    enable_3d_value_spinbox = Signal(bool)
 
     def dataset_type_changed(self, _):
         self.value_line_edit.validator().dataset_type_combo = self.value_type_combo
@@ -279,7 +279,7 @@ class FieldWidget(QFrame):
     def field_type_changed(self):
         self.edit_dialog = QDialog(parent=self)
         self._set_up_value_validator(False)
-        self.show_3d_value_spinbox.emit(not self.field_type_is_scalar())
+        self.enable_3d_value_spinbox.emit(not self.field_type_is_scalar())
 
         if self.field_type == FieldType.scalar_dataset:
             self.set_visibility(True, False, False, True)

--- a/nexus_constructor/field_widget.py
+++ b/nexus_constructor/field_widget.py
@@ -273,10 +273,13 @@ class FieldWidget(QFrame):
         else:
             return False
 
+    def scalar_field_type(self):
+        return self.field_type == FieldType.scalar_dataset
+
     def field_type_changed(self):
         self.edit_dialog = QDialog(parent=self)
         self._set_up_value_validator(False)
-        self.show_3d_value_spinbox.emit(self.field_type != FieldType.scalar_dataset)
+        self.show_3d_value_spinbox.emit(not self.scalar_field_type())
 
         if self.field_type == FieldType.scalar_dataset:
             self.set_visibility(True, False, False, True)

--- a/nexus_constructor/field_widget.py
+++ b/nexus_constructor/field_widget.py
@@ -67,7 +67,6 @@ class FieldNameLineEdit(QLineEdit):
 class FieldWidget(QFrame):
     # Used for deletion of field
     something_clicked = Signal()
-    value_changed = Signal(float)
 
     def dataset_type_changed(self, _):
         self.value_line_edit.validator().dataset_type_combo = self.value_type_combo
@@ -116,7 +115,6 @@ class FieldWidget(QFrame):
 
         self.value_line_edit = QLineEdit()
         self.value_line_edit.setPlaceholderText("value")
-        self.value_line_edit.textChanged.connect(self._update_ui_value)
 
         self._set_up_value_validator(False)
         self.dataset_type_changed(0)
@@ -166,13 +164,6 @@ class FieldWidget(QFrame):
 
         # Set the layout for the default field type
         self.field_type_changed()
-
-    def _update_ui_value(self, text: str):
-        try:
-            ui_value = float(text)
-            self.value_changed.emit(ui_value)
-        except ValueError:
-            return
 
     def _set_up_name_validator(self):
         field_widgets = []

--- a/nexus_constructor/field_widget.py
+++ b/nexus_constructor/field_widget.py
@@ -67,6 +67,7 @@ class FieldNameLineEdit(QLineEdit):
 class FieldWidget(QFrame):
     # Used for deletion of field
     something_clicked = Signal()
+    show_3d_value_spinbox = Signal(bool)
 
     def dataset_type_changed(self, _):
         self.value_line_edit.validator().dataset_type_combo = self.value_type_combo
@@ -275,6 +276,8 @@ class FieldWidget(QFrame):
     def field_type_changed(self):
         self.edit_dialog = QDialog(parent=self)
         self._set_up_value_validator(False)
+        self.show_3d_value_spinbox.emit(self.field_type != FieldType.scalar_dataset)
+
         if self.field_type == FieldType.scalar_dataset:
             self.set_visibility(True, False, False, True)
         elif self.field_type == FieldType.array_dataset:

--- a/nexus_constructor/field_widget.py
+++ b/nexus_constructor/field_widget.py
@@ -273,13 +273,13 @@ class FieldWidget(QFrame):
         else:
             return False
 
-    def scalar_field_type(self):
+    def field_type_is_scalar(self) -> bool:
         return self.field_type == FieldType.scalar_dataset
 
     def field_type_changed(self):
         self.edit_dialog = QDialog(parent=self)
         self._set_up_value_validator(False)
-        self.show_3d_value_spinbox.emit(not self.scalar_field_type())
+        self.show_3d_value_spinbox.emit(not self.field_type_is_scalar())
 
         if self.field_type == FieldType.scalar_dataset:
             self.set_visibility(True, False, False, True)

--- a/nexus_constructor/field_widget.py
+++ b/nexus_constructor/field_widget.py
@@ -116,7 +116,7 @@ class FieldWidget(QFrame):
 
         self.value_line_edit = QLineEdit()
         self.value_line_edit.setPlaceholderText("value")
-        self.value_line_edit.textChanged.connect(self.update_ui_value)
+        self.value_line_edit.textChanged.connect(self._update_ui_value)
 
         self._set_up_value_validator(False)
         self.dataset_type_changed(0)
@@ -167,8 +167,7 @@ class FieldWidget(QFrame):
         # Set the layout for the default field type
         self.field_type_changed()
 
-    def update_ui_value(self, text: str):
-
+    def _update_ui_value(self, text: str):
         try:
             ui_value = float(text)
             self.value_changed.emit(ui_value)

--- a/nexus_constructor/transformation_view.py
+++ b/nexus_constructor/transformation_view.py
@@ -23,7 +23,13 @@ class EditTransformation(QGroupBox):
         self.transformation = transformation
         current_vector = self.transformation.vector
         self._fill_in_existing_fields(current_vector)
+        self.transformation_frame.magnitude_widget.show_3d_value_spinbox.connect(
+            self._change_3d_value_spinbox_visibility
+        )
         self.disable()
+
+    def _change_3d_value_spinbox_visibility(self, show: bool):
+        self.transformation_frame.value_spinbox.setVisible(show)
 
     def _fill_in_existing_fields(self, current_vector):
         self.transformation_frame.name_line_edit.setText(self.transformation.name)

--- a/nexus_constructor/transformation_view.py
+++ b/nexus_constructor/transformation_view.py
@@ -22,14 +22,8 @@ class EditTransformation(QGroupBox):
         self.transformation_frame.setupUi(self)
         self.transformation = transformation
         current_vector = self.transformation.vector
-        self.transformation_frame.magnitude_widget.value_changed.connect(
-            self._sync_ui_value_with_magnitude
-        )
         self._fill_in_existing_fields(current_vector)
         self.disable()
-
-    def _sync_ui_value_with_magnitude(self, val: float):
-        self.transformation_frame.value_spinbox.setValue(val)
 
     def _fill_in_existing_fields(self, current_vector):
         self.transformation_frame.name_line_edit.setText(self.transformation.name)

--- a/nexus_constructor/transformation_view.py
+++ b/nexus_constructor/transformation_view.py
@@ -23,7 +23,7 @@ class EditTransformation(QGroupBox):
         self.transformation = transformation
         current_vector = self.transformation.vector
         self._fill_in_existing_fields(current_vector)
-        self.transformation_frame.magnitude_widget.show_3d_value_spinbox.connect(
+        self.transformation_frame.magnitude_widget.enable_3d_value_spinbox.connect(
             self._change_3d_value_spinbox_visibility
         )
         self.disable()
@@ -65,11 +65,13 @@ class EditTransformation(QGroupBox):
             ui_element.setEnabled(True)
 
     def saveChanges(self):
-        try:
-            value_3d_view = self.transformation_frame.magnitude_widget.value.values
-            self.transformation_frame.value_spinbox.setValue(float(value_3d_view))
-        except ValueError:
-            pass
+
+        if self.transformation_frame.magnitude_widget.field_type_is_scalar():
+            try:
+                value_3d_view = self.transformation_frame.magnitude_widget.value.values
+                self.transformation_frame.value_spinbox.setValue(float(value_3d_view))
+            except ValueError:
+                pass
 
         self.transformation.ui_value = self.transformation_frame.value_spinbox.value()
         self.transformation.values = self.transformation_frame.magnitude_widget.value

--- a/nexus_constructor/transformation_view.py
+++ b/nexus_constructor/transformation_view.py
@@ -29,7 +29,7 @@ class EditTransformation(QGroupBox):
         self.disable()
 
     def _change_3d_value_spinbox_visibility(self, show: bool):
-        self.transformation_frame.value_spinbox.setVisible(show)
+        self.transformation_frame.value_spinbox.setEnabled(show)
 
     def _fill_in_existing_fields(self, current_vector):
         self.transformation_frame.name_line_edit.setText(self.transformation.name)
@@ -52,7 +52,12 @@ class EditTransformation(QGroupBox):
             ui_element.setEnabled(False)
 
     def enable(self):
-        for ui_element in self.transformation_frame.spinboxes + [
+        if self.transformation_frame.magnitude_widget.scalar_field_type():
+            spinboxes = self.transformation_frame.spinboxes[:-1]
+        else:
+            spinboxes = self.transformation_frame.spinboxes
+
+        for ui_element in spinboxes + [
             self.transformation_frame.name_line_edit,
             self.transformation_frame.magnitude_widget,
         ]:

--- a/nexus_constructor/transformation_view.py
+++ b/nexus_constructor/transformation_view.py
@@ -59,6 +59,12 @@ class EditTransformation(QGroupBox):
             ui_element.setEnabled(True)
 
     def saveChanges(self):
+        try:
+            value_3d_view = self.transformation_frame.magnitude_widget.value.values
+            self.transformation_frame.value_spinbox.setValue(float(value_3d_view))
+        except ValueError:
+            pass
+
         self.transformation.ui_value = self.transformation_frame.value_spinbox.value()
         self.transformation.values = self.transformation_frame.magnitude_widget.value
         if self.transformation_frame.name_line_edit.text() != self.transformation.name:

--- a/nexus_constructor/transformation_view.py
+++ b/nexus_constructor/transformation_view.py
@@ -52,7 +52,8 @@ class EditTransformation(QGroupBox):
             ui_element.setEnabled(False)
 
     def enable(self):
-        if self.transformation_frame.magnitude_widget.scalar_field_type():
+        # Don't enable the 3D value spinbox if the magnitude is scalar
+        if self.transformation_frame.magnitude_widget.field_type_is_scalar():
             spinboxes = self.transformation_frame.spinboxes[:-1]
         else:
             spinboxes = self.transformation_frame.spinboxes

--- a/nexus_constructor/transformation_view.py
+++ b/nexus_constructor/transformation_view.py
@@ -22,8 +22,14 @@ class EditTransformation(QGroupBox):
         self.transformation_frame.setupUi(self)
         self.transformation = transformation
         current_vector = self.transformation.vector
+        self.transformation_frame.magnitude_widget.value_changed.connect(
+            self._sync_ui_value_with_magnitude
+        )
         self._fill_in_existing_fields(current_vector)
         self.disable()
+
+    def _sync_ui_value_with_magnitude(self, val: float):
+        self.transformation_frame.value_spinbox.setValue(val)
 
     def _fill_in_existing_fields(self, current_vector):
         self.transformation_frame.name_line_edit.setText(self.transformation.name)


### PR DESCRIPTION
### Issue

Closes #739
Closes #744

### Description of work

- Disables 3D value spinbox when scalar distance is selected, enables it otherwise (hiding a row in QFormLayout doesn't seem to be doable)
- Copies value from scalar distance line edit to 3D view value spin box

### Acceptance Criteria 

- Check that the 3D value spinbox is disabled for new transformations
- Check that it becomes enabled when switching to a different field type
- Check that exiting edit mode when a scalar value is given transfers this value to the spin box
- Check that non-float scalar distance values do not cause exceptions
- Check that the 3D value spinbox is not changed for non-scalar field types

### UI tests

n/a

### Nominate for Group Code Review

- [ ] Nominate for code review 
