### PR TITLE
754: Restore transformation view tests

### DIFF
--- a/nexus_constructor/field_attrs.py
+++ b/nexus_constructor/field_attrs.py
@@ -23,6 +23,19 @@ from nexus_constructor.validators import DATASET_TYPE, FieldValueValidator
 ATTRS_BLACKLIST = [CommonAttrs.UNITS]
 
 
+def _get_human_readable_type(new_value: Any):
+    if isinstance(new_value, str):
+        return "String"
+    elif isinstance(new_value, int):
+        return "Int"
+    elif isinstance(new_value, float):
+        return "Double"
+    else:
+        return next(
+            key for key, value in DATASET_TYPE.items() if value == new_value.dtype
+        )
+
+
 class FieldAttrsDialog(QDialog):
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -159,7 +172,7 @@ class FieldAttrFrame(QFrame):
         if isinstance(new_value, bytes):
             new_value = new_value.decode("utf-8")
 
-        self.attr_dtype_combo.setCurrentText(self._get_human_readable_type(new_value))
+        self.attr_dtype_combo.setCurrentText(_get_human_readable_type(new_value))
         if np.isscalar(new_value):
             self.type_changed("Scalar")
             self.attr_value_lineedit.setText(str(new_value))
@@ -168,16 +181,3 @@ class FieldAttrFrame(QFrame):
             self.dialog.model.array = new_value
             self.dialog.model.update_array_dtype(new_value.dtype)
         self.dtype_changed(None)
-
-    @staticmethod
-    def _get_human_readable_type(new_value: Any):
-        if isinstance(new_value, str):
-            return "String"
-        elif isinstance(new_value, int):
-            return "Int"
-        elif isinstance(new_value, float):
-            return "Double"
-        else:
-            return next(
-                key for key, value in DATASET_TYPE.items() if value == new_value.dtype
-            )

--- a/nexus_constructor/model/component.py
+++ b/nexus_constructor/model/component.py
@@ -136,11 +136,11 @@ class Component(Group):
         :param depends_on: existing transformation which the new one depends on (otherwise relative to origin)
         :param values: The translation distance information.
         """
-        unit_vector, magnitude = _normalise(vector)
+        unit_vector, _ = _normalise(vector)
         return self._create_transform(
             name,
             TransformationType.TRANSLATION,
-            magnitude,
+            0.0,
             "m",
             unit_vector,
             depends_on,
@@ -183,12 +183,11 @@ class Component(Group):
         depends_on: Transformation,
         values: Dataset,
     ):
-
         if name is None:
             name = _generate_incremental_name(transformation_type, self.transforms_list)
         transform = Transformation(name, angle_or_magnitude)
         transform.type = transformation_type
-        transform.ui_value = 0.0
+        transform.ui_value = angle_or_magnitude
         transform.units = units
         transform.vector = vector
         transform.depends_on = depends_on

--- a/tests/ui_tests/test_ui_transformation_view.py
+++ b/tests/ui_tests/test_ui_transformation_view.py
@@ -315,7 +315,7 @@ def test_UI_GIVEN_scalar_value_WHEN_creating_new_transformation_THEN_ui_values_s
 
 
 @pytest.mark.parametrize("field_type", [item.value for item in FieldType][1:])
-def test_UI_GIVEN_array_value_WHEN_creating_new_transformation_THEN_ui_values_spinbox_is_enabled(
+def test_UI_GIVEN_change_to_non_scalar_value_WHEN_creating_new_transformation_THEN_ui_values_spinbox_is_enabled(
     qtbot, component, instrument, field_type
 ):
     x = 1
@@ -330,3 +330,24 @@ def test_UI_GIVEN_array_value_WHEN_creating_new_transformation_THEN_ui_values_sp
     qtbot.addWidget(view)
 
     assert view.transformation_frame.value_spinbox.isEnabled()
+
+
+def test_UI_GIVEN_change_to_scalar_value_WHEN_creating_new_transformation_THEN_ui_values_spinbox_is_disabled(
+    qtbot, component, instrument
+):
+    x = 1
+    y = 0
+    z = 0
+    value = np.array([1, 0, 2.0])
+
+    transform = component.add_translation(QVector3D(x, y, z), name="transform")
+    transform.values = create_corresponding_value_dataset(value)
+
+    view = EditTranslation(parent=None, transformation=transform, instrument=instrument)
+    print(view.transformation_frame.magnitude_widget.field_type)
+    view.transformation_frame.magnitude_widget.field_type = (
+        FieldType.scalar_dataset.value
+    )
+    qtbot.addWidget(view)
+
+    assert not view.transformation_frame.value_spinbox.isEnabled()

--- a/tests/ui_tests/test_ui_transformation_view.py
+++ b/tests/ui_tests/test_ui_transformation_view.py
@@ -204,20 +204,16 @@ def test_UI_GIVEN_link_as_rotation_magnitude_WHEN_creating_rotation_view_THEN_ui
     assert view.transformation_frame.magnitude_widget.value.path == path
 
 
-@pytest.mark.skip
 def test_UI_GIVEN_vector_updated_WHEN_saving_view_changes_THEN_model_is_updated(
-    qtbot, nexus_wrapper
+    qtbot, component, instrument
 ):
-    instrument = Instrument(nexus_wrapper, {})
-
-    component = instrument.create_component("test", "NXaperture", "")
-
     x = 1
     y = 2
     z = 3
-    angle = 90
+    angle = 90.0
 
     transform = component.add_rotation(angle=angle, axis=QVector3D(x, y, z))
+    transform.values = create_corresponding_value_dataset(angle)
 
     view = EditRotation(parent=None, transformation=transform, instrument=instrument)
     qtbot.addWidget(view)

--- a/tests/ui_tests/test_ui_transformation_view.py
+++ b/tests/ui_tests/test_ui_transformation_view.py
@@ -231,20 +231,16 @@ def test_UI_GIVEN_vector_updated_WHEN_saving_view_changes_THEN_model_is_updated(
     assert transform.vector == QVector3D(new_x, new_y, new_z)
 
 
-@pytest.mark.skip
 def test_UI_GIVEN_view_gains_focus_WHEN_transformation_view_exists_THEN_spinboxes_are_enabled(
-    qtbot, nexus_wrapper
+    qtbot, component
 ):
-    instrument = Instrument(nexus_wrapper, {})
-
-    component = instrument.create_component("test", "NXaperture", "")
-
     x = 1
     y = 2
     z = 3
     angle = 90
 
     transform = component.add_rotation(angle=angle, axis=QVector3D(x, y, z))
+    transform.values = create_corresponding_value_dataset(angle)
 
     view = EditRotation(parent=None, transformation=transform, instrument=instrument)
     qtbot.addWidget(view)
@@ -257,20 +253,16 @@ def test_UI_GIVEN_view_gains_focus_WHEN_transformation_view_exists_THEN_spinboxe
     assert view.transformation_frame.name_line_edit.isEnabled()
 
 
-@pytest.mark.skip
 def test_UI_GIVEN_view_loses_focus_WHEN_transformation_view_exists_THEN_spinboxes_are_disabled(
-    qtbot, nexus_wrapper
+    qtbot, component
 ):
-    instrument = Instrument(nexus_wrapper, {})
-
-    component = instrument.create_component("test", "NXaperture", "")
-
     x = 1
     y = 2
     z = 3
     angle = 90
 
     transform = component.add_rotation(angle=angle, axis=QVector3D(x, y, z))
+    transform.values = create_corresponding_value_dataset(angle)
 
     view = EditRotation(parent=None, transformation=transform, instrument=instrument)
     qtbot.addWidget(view)
@@ -283,20 +275,16 @@ def test_UI_GIVEN_view_loses_focus_WHEN_transformation_view_exists_THEN_spinboxe
     assert not view.transformation_frame.name_line_edit.isEnabled()
 
 
-@pytest.mark.skip
 def test_UI_GIVEN_new_values_are_provided_WHEN_save_changes_is_called_THEN_transformation_changed_signal_is_called_to_update_3d_view(
-    qtbot, nexus_wrapper
+    qtbot, component, instrument
 ):
-    instrument = Instrument(nexus_wrapper, {})
-
-    component = instrument.create_component("test", "NXaperture", "")
-
     x = 1
     y = 2
     z = 3
     angle = 90
 
     transform = component.add_rotation(angle=angle, axis=QVector3D(x, y, z))
+    transform.values = create_corresponding_value_dataset(angle)
 
     view = EditRotation(parent=None, transformation=transform, instrument=instrument)
     instrument.nexus.transformation_changed = Mock()

--- a/tests/ui_tests/test_ui_transformation_view.py
+++ b/tests/ui_tests/test_ui_transformation_view.py
@@ -296,3 +296,20 @@ def test_UI_GIVEN_new_values_are_provided_WHEN_save_changes_is_called_THEN_trans
     view.saveChanges()
     instrument.nexus.transformation_changed.emit.assert_called_once()
     assert transform.vector == QVector3D(new_x, y, z)
+
+
+def test_UI_GIVEN_scalar_value_WHEN_creating_new_transformation_THEN_ui_values_spinbox_is_disabled(
+    qtbot, component, instrument
+):
+
+    x = 1
+    y = 0
+    z = 0
+    value = 0.0
+    transform = component.add_translation(QVector3D(x, y, z), name="transform")
+    transform.values = create_corresponding_value_dataset(value)
+
+    view = EditTranslation(parent=None, transformation=transform, instrument=instrument)
+    qtbot.addWidget(view)
+
+    assert not view.transformation_frame.value_spinbox.isEnabled()

--- a/tests/ui_tests/test_ui_transformation_view.py
+++ b/tests/ui_tests/test_ui_transformation_view.py
@@ -2,14 +2,12 @@ from typing import Any
 
 import h5py
 from PySide2.QtGui import QVector3D
-from PySide2.QtWidgets import QDialog
 from mock import Mock
 
 from nexus_constructor.field_attrs import _get_human_readable_type
 from nexus_constructor.model.component import Component
 from nexus_constructor.model.dataset import Dataset, DatasetMetadata
 from nexus_constructor.model.entry import Instrument
-from nexus_constructor.model.transformation import Transformation
 from nexus_constructor.transformation_view import EditRotation, EditTranslation
 from nexus_constructor.validators import FieldType
 import numpy as np
@@ -75,7 +73,7 @@ def test_UI_GIVEN_scalar_angle_WHEN_creating_rotation_view_THEN_ui_is_filled_cor
     x = 1
     y = 2
     z = 3
-    angle = 90.0
+    angle = 90
 
     transform = component.add_rotation(angle=angle, axis=QVector3D(x, y, z))
     transform.values = create_corresponding_value_dataset(angle)
@@ -199,7 +197,7 @@ def test_UI_GIVEN_vector_updated_WHEN_saving_view_changes_THEN_model_is_updated(
     x = 1
     y = 2
     z = 3
-    angle = 90.0
+    angle = 90
 
     transform = component.add_rotation(angle=angle, axis=QVector3D(x, y, z))
     transform.values = create_corresponding_value_dataset(angle)

--- a/tests/ui_tests/test_ui_transformation_view.py
+++ b/tests/ui_tests/test_ui_transformation_view.py
@@ -44,11 +44,12 @@ def create_corresponding_value_dataset(value: Any):
 
     if np.isscalar(value):
         size = 1
+        value = str(value)
     else:
         size = len(value)
 
     return Dataset(
-        name=name, dataset=DatasetMetadata(type=type, size=[size]), values=str(value),
+        name=name, dataset=DatasetMetadata(type=type, size=[size]), values=value,
     )
 
 
@@ -70,7 +71,9 @@ def test_UI_GIVEN_scalar_vector_WHEN_creating_translation_view_THEN_ui_is_filled
     assert view.transformation_frame.y_spinbox.value() == y
     assert view.transformation_frame.z_spinbox.value() == z
     assert view.transformation_frame.value_spinbox.value() == value
-    assert view.transformation_frame.magnitude_widget.value.values == str(value)
+    assert view.transformation_frame.magnitude_widget.value_line_edit.text() == str(
+        value
+    )
     assert (
         view.transformation_frame.magnitude_widget.field_type
         == FieldType.scalar_dataset
@@ -104,22 +107,16 @@ def test_UI_GIVEN_scalar_angle_WHEN_creating_rotation_view_THEN_ui_is_filled_cor
     )
 
 
-@pytest.mark.skip
 def test_UI_GIVEN_array_dataset_as_magnitude_WHEN_creating_translation_THEN_ui_is_filled_correctly(
-    qtbot, file, nexus_wrapper
+    qtbot, file, component
 ):
-    instrument = Instrument(nexus_wrapper, {})
-
-    component = instrument.create_component("test", "NXaperture", "")
-
     array = np.array([1, 2, 3, 4])
 
     x = 1
     y = 0
     z = 0
     transform = component.add_translation(QVector3D(x, y, z), name="test")
-
-    transform.dataset = file.create_dataset("test", data=array)
+    transform.values = create_corresponding_value_dataset(array)
 
     view = EditTranslation(parent=None, transformation=transform, instrument=instrument)
     qtbot.addWidget(view)
@@ -127,7 +124,9 @@ def test_UI_GIVEN_array_dataset_as_magnitude_WHEN_creating_translation_THEN_ui_i
     assert view.transformation_frame.x_spinbox.value() == x
     assert view.transformation_frame.y_spinbox.value() == y
     assert view.transformation_frame.z_spinbox.value() == z
-    assert np.allclose(view.transformation.dataset[...], array)
+    assert np.allclose(
+        view.transformation_frame.magnitude_widget.table_view.model.array, array
+    )
     assert (
         view.transformation_frame.magnitude_widget.field_type == FieldType.array_dataset
     )

--- a/tests/ui_tests/test_ui_transformation_view.py
+++ b/tests/ui_tests/test_ui_transformation_view.py
@@ -301,7 +301,6 @@ def test_UI_GIVEN_new_values_are_provided_WHEN_save_changes_is_called_THEN_trans
 def test_UI_GIVEN_scalar_value_WHEN_creating_new_transformation_THEN_ui_values_spinbox_is_disabled(
     qtbot, component, instrument
 ):
-
     x = 1
     y = 0
     z = 0
@@ -313,3 +312,21 @@ def test_UI_GIVEN_scalar_value_WHEN_creating_new_transformation_THEN_ui_values_s
     qtbot.addWidget(view)
 
     assert not view.transformation_frame.value_spinbox.isEnabled()
+
+
+@pytest.mark.parametrize("field_type", [item.value for item in FieldType][1:])
+def test_UI_GIVEN_array_value_WHEN_creating_new_transformation_THEN_ui_values_spinbox_is_enabled(
+    qtbot, component, instrument, field_type
+):
+    x = 1
+    y = 0
+    z = 0
+    value = 0.0
+    transform = component.add_translation(QVector3D(x, y, z), name="transform")
+    transform.values = create_corresponding_value_dataset(value)
+
+    view = EditTranslation(parent=None, transformation=transform, instrument=instrument)
+    view.transformation_frame.magnitude_widget.field_type = field_type
+    qtbot.addWidget(view)
+
+    assert view.transformation_frame.value_spinbox.isEnabled()

--- a/tests/ui_tests/test_ui_transformation_view.py
+++ b/tests/ui_tests/test_ui_transformation_view.py
@@ -2,28 +2,47 @@ import h5py
 from PySide2.QtGui import QVector3D
 from mock import Mock
 
+from nexus_constructor.model.component import Component
+from nexus_constructor.model.dataset import Dataset, DatasetMetadata
 from nexus_constructor.model.entry import Instrument
+from nexus_constructor.model.transformation import Transformation
 from nexus_constructor.transformation_view import EditRotation, EditTranslation
 from nexus_constructor.validators import FieldType
 import numpy as np
 from pytestqt.qtbot import QtBot  # noqa: F401
 import pytest
 
-pytest.skip("Disabled whilst working on model change", allow_module_level=True)
+
+def create_transformation(vector):
+    transformation = Transformation("Transformation1", dataset=None, values=[])
+    transformation.vector = vector
+    return transformation
+
+
+@pytest.fixture
+def instrument():
+    return Instrument()
+
+
+@pytest.fixture
+def component():
+    return Component("Component", [])
+
+
+@pytest.fixture
+def values():
+    return Dataset(name="", dataset=DatasetMetadata(type="Double", size=[1]), values="")
 
 
 def test_UI_GIVEN_scalar_vector_WHEN_creating_translation_view_THEN_ui_is_filled_correctly(
-    qtbot, nexus_wrapper
+    qtbot, instrument, component, values
 ):
-
-    instrument = Instrument(nexus_wrapper, {})
-
-    component = instrument.create_component("test", "NXaperture", "")
 
     x = 1
     y = 0
     z = 0
-    transform = component.add_translation(QVector3D(x, y, z), name="test")
+    transform = component.add_translation(QVector3D(x, y, z), name="transform")
+    transform.values = values
 
     view = EditTranslation(parent=None, transformation=transform, instrument=instrument)
     qtbot.addWidget(view)
@@ -31,14 +50,15 @@ def test_UI_GIVEN_scalar_vector_WHEN_creating_translation_view_THEN_ui_is_filled
     assert view.transformation_frame.x_spinbox.value() == x
     assert view.transformation_frame.y_spinbox.value() == y
     assert view.transformation_frame.z_spinbox.value() == z
-    assert view.transformation_frame.value_spinbox.value() == 1
-    assert view.transformation_frame.magnitude_widget.value[()] == 1
+    # assert view.transformation_frame.value_spinbox.value() == 1
+    assert view.transformation_frame.magnitude_widget.value.values == ""
     assert (
         view.transformation_frame.magnitude_widget.field_type
         == FieldType.scalar_dataset
     )
 
 
+@pytest.mark.skip
 def test_UI_GIVEN_scalar_angle_WHEN_creating_rotation_view_THEN_ui_is_filled_correctly(
     qtbot, nexus_wrapper
 ):
@@ -68,6 +88,7 @@ def test_UI_GIVEN_scalar_angle_WHEN_creating_rotation_view_THEN_ui_is_filled_cor
     )
 
 
+@pytest.mark.skip
 def test_UI_GIVEN_array_dataset_as_magnitude_WHEN_creating_translation_THEN_ui_is_filled_correctly(
     qtbot, file, nexus_wrapper
 ):
@@ -96,6 +117,7 @@ def test_UI_GIVEN_array_dataset_as_magnitude_WHEN_creating_translation_THEN_ui_i
     )
 
 
+@pytest.mark.skip
 def test_UI_GIVEN_stream_group_as_angle_WHEN_creating_rotation_THEN_ui_is_filled_correctly(
     qtbot, file, nexus_wrapper
 ):
@@ -138,6 +160,7 @@ def test_UI_GIVEN_stream_group_as_angle_WHEN_creating_rotation_THEN_ui_is_filled
     assert view.transformation_frame.magnitude_widget.value["source"][()] == source
 
 
+@pytest.mark.skip
 def test_UI_GIVEN_link_as_rotation_magnitude_WHEN_creating_rotation_view_THEN_ui_is_filled_correctly(
     qtbot, nexus_wrapper
 ):
@@ -166,6 +189,7 @@ def test_UI_GIVEN_link_as_rotation_magnitude_WHEN_creating_rotation_view_THEN_ui
     assert view.transformation_frame.magnitude_widget.value.path == path
 
 
+@pytest.mark.skip
 def test_UI_GIVEN_vector_updated_WHEN_saving_view_changes_THEN_model_is_updated(
     qtbot, nexus_wrapper
 ):
@@ -196,6 +220,7 @@ def test_UI_GIVEN_vector_updated_WHEN_saving_view_changes_THEN_model_is_updated(
     assert transform.vector == QVector3D(new_x, new_y, new_z)
 
 
+@pytest.mark.skip
 def test_UI_GIVEN_view_gains_focus_WHEN_transformation_view_exists_THEN_spinboxes_are_enabled(
     qtbot, nexus_wrapper
 ):
@@ -221,6 +246,7 @@ def test_UI_GIVEN_view_gains_focus_WHEN_transformation_view_exists_THEN_spinboxe
     assert view.transformation_frame.name_line_edit.isEnabled()
 
 
+@pytest.mark.skip
 def test_UI_GIVEN_view_loses_focus_WHEN_transformation_view_exists_THEN_spinboxes_are_disabled(
     qtbot, nexus_wrapper
 ):
@@ -246,6 +272,7 @@ def test_UI_GIVEN_view_loses_focus_WHEN_transformation_view_exists_THEN_spinboxe
     assert not view.transformation_frame.name_line_edit.isEnabled()
 
 
+@pytest.mark.skip
 def test_UI_GIVEN_new_values_are_provided_WHEN_save_changes_is_called_THEN_transformation_changed_signal_is_called_to_update_3d_view(
     qtbot, nexus_wrapper
 ):

--- a/tests/ui_tests/test_ui_transformation_view.py
+++ b/tests/ui_tests/test_ui_transformation_view.py
@@ -17,12 +17,6 @@ from pytestqt.qtbot import QtBot  # noqa: F401
 import pytest
 
 
-def create_transformation(vector):
-    transformation = Transformation("Transformation1", dataset=None, values=[])
-    transformation.vector = vector
-    return transformation
-
-
 @pytest.fixture
 def instrument():
     return Instrument()
@@ -31,11 +25,6 @@ def instrument():
 @pytest.fixture
 def component():
     return Component("Component", [])
-
-
-@pytest.fixture(scope="function")
-def template(qtbot) -> QDialog:
-    return QDialog()
 
 
 def create_corresponding_value_dataset(value: Any):


### PR DESCRIPTION
### Issue

Progresses #754

### Description of work

Restores most of the UI transformation tests. Still skipping the ones pertaining to links and groups. Also added a few more tests involving the 3D value spinbox being enabled/disabled depending on the data type.

### Acceptance Criteria 

Check that the tests are sensible and that they pass.

### UI tests

n/a

### Nominate for Group Code Review

- [ ] Nominate for code review 
