### PR TITLE
Refactor extract dataset and attribute value types

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,9 +130,7 @@ return {
                 } // stage
                 stage('Archive Executable') {
                     def git_commit_short = scm_vars.GIT_COMMIT.take(7)
-                    // Compress-Archive cmdlet is really really slow, so better to install and use 7zip if not already present
-                    powershell label: 'Install 7zip', script: "Install-Module -Name 7Zip4PowerShell"
-                    powershell label: 'Archiving build folder', script: "Compress-7Zip -Path .\\build -ArchiveFileName nexus-constructor_windows_${git_commit_short}.zip -Format Zip"
+                    powershell label: 'Archiving build folder', script: "Compress-Archive -Path .\\build -DestinationPath nexus-constructor_windows_${git_commit_short}.zip"
                     archiveArtifacts 'nexus-constructor*.zip'
                 } // stage
                 stage("Test executable") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,7 +130,9 @@ return {
                 } // stage
                 stage('Archive Executable') {
                     def git_commit_short = scm_vars.GIT_COMMIT.take(7)
-                    powershell label: 'Archiving build folder', script: "Compress-Archive -Path .\\build -DestinationPath nexus-constructor_windows_${git_commit_short}.zip"
+                    // Compress-Archive cmdlet is really really slow, so better to install and use 7zip if not already present
+                    powershell label: 'Install 7zip', script: "Install-Module -Name 7Zip4PowerShell"
+                    powershell label: 'Archiving build folder', script: "Compress-7Zip -Path .\\build -ArchiveFileName nexus-constructor_windows_${git_commit_short}.zip -Format Zip"
                     archiveArtifacts 'nexus-constructor*.zip'
                 } // stage
                 stage("Test executable") {

--- a/nexus_constructor/field_attrs.py
+++ b/nexus_constructor/field_attrs.py
@@ -18,7 +18,8 @@ from nexus_constructor.array_dataset_table_widget import ArrayDatasetTableWidget
 from nexus_constructor.common_attrs import CommonAttrs
 from nexus_constructor.model.dataset import Dataset
 from nexus_constructor.ui_utils import validate_line_edit
-from nexus_constructor.validators import DATASET_TYPE, FieldValueValidator
+from nexus_constructor.validators import FieldValueValidator
+from nexus_constructor.model.value_type import VALUE_TYPE, ValueType
 
 ATTRS_BLACKLIST = [CommonAttrs.UNITS]
 
@@ -32,7 +33,7 @@ def _get_human_readable_type(new_value: Any):
         return "Double"
     else:
         return next(
-            key for key, value in DATASET_TYPE.items() if value == new_value.dtype
+            key for key, value in VALUE_TYPE.items() if value == new_value.dtype
         )
 
 
@@ -100,7 +101,7 @@ class FieldAttrFrame(QFrame):
         self.array_edit_button.clicked.connect(self.show_edit_array_dialog)
 
         self.attr_dtype_combo = QComboBox()
-        self.attr_dtype_combo.addItems([*DATASET_TYPE.keys()])
+        self.attr_dtype_combo.addItems([*VALUE_TYPE.keys()])
         self.attr_dtype_combo.currentTextChanged.connect(self.dtype_changed)
         self.dtype_changed(self.attr_dtype_combo.currentText())
         self.dialog = ArrayDatasetTableWidget(self.dtype)
@@ -139,8 +140,8 @@ class FieldAttrFrame(QFrame):
         )
 
     @property
-    def dtype(self):
-        return DATASET_TYPE[self.attr_dtype_combo.currentText()]
+    def dtype(self) -> ValueType:
+        return VALUE_TYPE[self.attr_dtype_combo.currentText()]
 
     @property
     def is_scalar(self):
@@ -161,7 +162,7 @@ class FieldAttrFrame(QFrame):
     def value(self) -> Union[np.generic, np.ndarray]:
 
         if self.is_scalar:
-            if self.dtype == DATASET_TYPE["String"] or isinstance(self.dtype, str):
+            if self.dtype == VALUE_TYPE["String"] or isinstance(self.dtype, str):
                 return self.attr_value_lineedit.text()
             return self.dtype(self.attr_value_lineedit.text())
         return np.squeeze(self.dialog.model.array)

--- a/nexus_constructor/field_widget.py
+++ b/nexus_constructor/field_widget.py
@@ -28,10 +28,10 @@ from nexus_constructor.ui_utils import validate_line_edit
 from nexus_constructor.validators import (
     FieldValueValidator,
     FieldType,
-    DATASET_TYPE,
     NameValidator,
     UnitValidator,
 )
+from nexus_constructor.model.value_type import VALUE_TYPE
 
 
 class FieldNameLineEdit(QLineEdit):
@@ -111,7 +111,7 @@ class FieldWidget(QFrame):
         self.field_type_combo.setSizePolicy(fix_horizontal_size)
 
         self.value_type_combo = QComboBox()
-        self.value_type_combo.addItems(list(DATASET_TYPE.keys()))
+        self.value_type_combo.addItems(list(VALUE_TYPE.keys()))
         self.value_type_combo.currentIndexChanged.connect(self.dataset_type_changed)
 
         self.value_line_edit = QLineEdit()
@@ -340,7 +340,7 @@ class FieldWidget(QFrame):
         if self.field_type == FieldType.array_dataset:
             self.edit_dialog.setLayout(QGridLayout())
             self.table_view.model.update_array_dtype(
-                DATASET_TYPE[self.value_type_combo.currentText()]
+                VALUE_TYPE[self.value_type_combo.currentText()]
             )
             self.edit_dialog.layout().addWidget(self.table_view)
             self.edit_dialog.setWindowTitle(

--- a/nexus_constructor/geometry/disk_chopper/disk_chopper_checker.py
+++ b/nexus_constructor/geometry/disk_chopper/disk_chopper_checker.py
@@ -12,7 +12,7 @@ from nexus_constructor.unit_utils import (
     units_are_expected_dimensionality,
     units_have_magnitude_of_one,
 )
-from nexus_constructor.validators import DATASET_TYPE
+from nexus_constructor.validators import VALUE_TYPE
 
 SLIT_EDGES_NAME = "slit_edges"
 SLITS_NAME = "slits"
@@ -29,8 +29,8 @@ EXPECTED_TYPE_ERROR_MSG = {
 }
 
 REQUIRED_CHOPPER_FIELDS = {SLIT_EDGES_NAME, SLITS_NAME, RADIUS_NAME, SLIT_HEIGHT_NAME}
-INT_TYPES = [value for value in DATASET_TYPE.values() if "int" in str(value)]
-FLOAT_TYPES = [value for value in DATASET_TYPE.values() if "float" in str(value)]
+INT_TYPES = [value for value in VALUE_TYPE.values() if "int" in str(value)]
+FLOAT_TYPES = [value for value in VALUE_TYPE.values() if "float" in str(value)]
 
 UNITS_REQUIRED = [RADIUS_NAME, SLIT_EDGES_NAME, SLIT_HEIGHT_NAME]
 EXPECTED_UNIT_TYPE = {

--- a/nexus_constructor/model/attribute.py
+++ b/nexus_constructor/model/attribute.py
@@ -1,6 +1,6 @@
-from typing import Any
-
 import attr
+
+from nexus_constructor.model.value_type import ValueType
 
 
 @attr.s
@@ -13,4 +13,4 @@ class FieldAttribute:
     """
 
     name = attr.ib(type=str)
-    values = attr.ib(type=Any)
+    values = attr.ib(type=ValueType)

--- a/nexus_constructor/model/dataset.py
+++ b/nexus_constructor/model/dataset.py
@@ -1,7 +1,9 @@
 import attr
+from typing import List
 
 from nexus_constructor.common_attrs import CommonAttrs
 from nexus_constructor.model.node import Node
+from nexus_constructor.model.value_type import ValueType
 
 
 @attr.s
@@ -13,7 +15,7 @@ class DatasetMetadata:
 @attr.s
 class Dataset(Node):
     dataset = attr.ib(type=DatasetMetadata)
-    values = attr.ib(factory=list)
+    values = attr.ib(factory=list, type=List[ValueType])
     type = attr.ib(type=str, default="dataset", init=False)
 
     @property

--- a/nexus_constructor/model/value_type.py
+++ b/nexus_constructor/model/value_type.py
@@ -1,0 +1,20 @@
+from typing import Union
+import numpy as np
+
+# Allowed types for dataset and attribute values
+VALUE_TYPE = {
+    "Byte": np.byte,
+    "UByte": np.ubyte,
+    "Short": np.short,
+    "UShort": np.ushort,
+    "Integer": np.intc,
+    "UInteger": np.uintc,
+    "Long": np.int_,
+    "ULong": np.uint,
+    "Float": np.single,
+    "Double": np.double,
+    "String": str,
+}
+
+# For use in type hints
+ValueType = Union[np.ndarray, str]

--- a/nexus_constructor/validators.py
+++ b/nexus_constructor/validators.py
@@ -2,7 +2,6 @@ import os
 import re
 from enum import Enum
 from typing import List
-
 import h5py
 import numpy as np
 import pint
@@ -17,6 +16,7 @@ from nexus_constructor.unit_utils import (
     units_are_expected_dimensionality,
     units_have_magnitude_of_one,
 )
+from nexus_constructor.model.value_type import VALUE_TYPE
 
 HDF_FILE_EXTENSIONS = ("nxs", "hdf", "hdf5")
 
@@ -295,21 +295,6 @@ class FieldType(Enum):
     nx_class = "NX class/group"
 
 
-DATASET_TYPE = {
-    "Byte": np.byte,
-    "UByte": np.ubyte,
-    "Short": np.short,
-    "UShort": np.ushort,
-    "Integer": np.intc,
-    "UInteger": np.uintc,
-    "Long": np.int_,
-    "ULong": np.uint,
-    "Float": np.single,
-    "Double": np.double,
-    "String": str,
-}
-
-
 class FieldValueValidator(QValidator):
     """
     Validates the field value line edit to check that the entered string is castable to the selected numpy type.
@@ -337,7 +322,7 @@ class FieldValueValidator(QValidator):
             return self._emit_and_return(False)
         elif self.field_type_combo.currentText() == self.scalar:
             try:
-                DATASET_TYPE[self.dataset_type_combo.currentText()](input)
+                VALUE_TYPE[self.dataset_type_combo.currentText()](input)
             except ValueError:
                 return self._emit_and_return(False)
         return self._emit_and_return(True)

--- a/tests/ui_tests/test_ui_add_component_window.py
+++ b/tests/ui_tests/test_ui_add_component_window.py
@@ -30,7 +30,8 @@ from nexus_constructor.model.stream import StreamGroup, F142Stream
 from nexus_constructor.pixel_data import PixelGrid, PixelMapping, PixelData
 from nexus_constructor.pixel_data_to_nexus_utils import PIXEL_FIELDS
 from nexus_constructor.pixel_options import PixelOptions
-from nexus_constructor.validators import FieldType, PixelValidator, DATASET_TYPE
+from nexus_constructor.validators import FieldType, PixelValidator
+from nexus_constructor.model.value_type import VALUE_TYPE
 from tests.test_utils import NX_CLASS_DEFINITIONS
 from tests.ui_tests.ui_test_utils import (
     systematic_button_press,
@@ -101,7 +102,7 @@ NO_PIXEL_OPTIONS_SUBSET = {
 
 SHAPE_TYPE_BUTTONS = ["No Shape", "Mesh", "Cylinder"]
 
-FIELDS_VALUE_TYPES = {key: i for i, key in enumerate(DATASET_TYPE.keys())}
+FIELDS_VALUE_TYPES = {key: i for i, key in enumerate(VALUE_TYPE.keys())}
 FIELD_TYPES = {item.value: i for i, item in enumerate(FieldType)}
 
 

--- a/tests/ui_tests/test_ui_array_dataset_table_widget.py
+++ b/tests/ui_tests/test_ui_array_dataset_table_widget.py
@@ -5,7 +5,7 @@ from PySide2.QtWidgets import QWidget
 from mock import Mock
 
 from nexus_constructor.array_dataset_table_widget import ArrayDatasetTableWidget
-from nexus_constructor.validators import DATASET_TYPE
+from nexus_constructor.validators import VALUE_TYPE
 
 
 @pytest.fixture(scope="function")
@@ -47,8 +47,8 @@ def test_UI_GIVEN_data_has_different_shapes_WHEN_getting_array_from_component_TH
     )
 
 
-@pytest.mark.parametrize("orig_data_type", DATASET_TYPE.values())
-@pytest.mark.parametrize("new_data_type", DATASET_TYPE.values())
+@pytest.mark.parametrize("orig_data_type", VALUE_TYPE.values())
+@pytest.mark.parametrize("new_data_type", VALUE_TYPE.values())
 def test_UI_GIVEN_data_type_WHEN_changing_data_type_THEN_change_is_successful(
     array_dataset_table_widget, orig_data_type, new_data_type
 ):
@@ -68,7 +68,7 @@ def test_GIVEN_string_array_WHEN_changing_data_type_to_int_THEN_array_rests(
 ):
     array = np.array(["hello" for _ in range(10)])
     array_dataset_table_widget.model.array = array
-    array_dataset_table_widget.model.update_array_dtype(DATASET_TYPE["Integer"])
+    array_dataset_table_widget.model.update_array_dtype(VALUE_TYPE["Integer"])
 
     assert array_dataset_table_widget.model.array.item(0) == 0
 


### PR DESCRIPTION
### Description of work

Move dataset and attribute value type definitions to separate file.
Renamed `DATASET_TYPES` to `VALUE_TYPES` as it is used for attribute values as well as dataset values.
Added `ValueType` for use in type hints.

### Acceptance Criteria 

Code review and tests passing is sufficient, application behaviour should be unaffected.

### UI tests

Updated relevant tests.

### Nominate for Group Code Review

- [ ] Nominate for code review 
