### PR TITLE
Refactor top level of model

### DIFF
--- a/nexus-constructor.py
+++ b/nexus-constructor.py
@@ -13,7 +13,7 @@ from nexus_constructor.component.component_type import (
 )
 from nexus_constructor.main_window import MainWindow
 from nexus_constructor.model.entry import Instrument, Entry
-
+from nexus_constructor.model.model import Model
 import os
 import argparse
 
@@ -37,7 +37,8 @@ if __name__ == "__main__":
     instrument = Instrument()
     entry = Entry()
     entry.instrument = instrument
-    ui = MainWindow(instrument, nx_component_classes)
+    model = Model(entry)
+    ui = MainWindow(model, nx_component_classes)
     ui.setupUi(window)
     window.showMaximized()
     sys.exit(app.exec_())

--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -12,7 +12,7 @@ from nexus_constructor.field_utils import get_fields_with_update_functions
 from nexus_constructor.field_widget import FieldWidget
 from nexus_constructor.geometry.geometry_loader import load_geometry
 from nexus_constructor.model.component import Component, add_fields_to_component
-from nexus_constructor.model.entry import Instrument
+from nexus_constructor.model.model import Model
 from nexus_constructor.model.geometry import (
     OFFGeometryNexus,
     CylindricalGeometry,
@@ -40,7 +40,7 @@ class AddComponentDialog(Ui_AddComponentDialog, QObject):
 
     def __init__(
         self,
-        instrument: Instrument,
+        model: Model,
         component_model: ComponentTreeModel,
         component_to_edit: Component = None,
         nx_classes=None,
@@ -51,7 +51,8 @@ class AddComponentDialog(Ui_AddComponentDialog, QObject):
             nx_classes = {}
         if parent:
             self.setParent(parent)
-        self.instrument = instrument
+        self.signals = model.signals
+        self.instrument = model.entry.instrument
         self.component_model = component_model
         self.nx_component_classes = OrderedDict(sorted(nx_classes.items()))
 
@@ -405,9 +406,7 @@ class AddComponentDialog(Ui_AddComponentDialog, QObject):
                 component_name, description, nx_class, pixel_data
             )
 
-        self.instrument.nexus.component_added.emit(
-            self.nameLineEdit.text(), shape, positions
-        )
+        self.signals.component_added.emit(self.nameLineEdit.text(), shape, positions)
 
     def create_new_component(
         self,

--- a/nexus_constructor/component_tree_view.py
+++ b/nexus_constructor/component_tree_view.py
@@ -14,7 +14,7 @@ from PySide2.QtWidgets import (
 from nexus_constructor.component.transformations_list import TransformationsList
 from nexus_constructor.component_tree_model import ComponentInfo, LinkTransformation
 from nexus_constructor.model.component import Component
-from nexus_constructor.model.entry import Instrument
+from nexus_constructor.model.model import Model
 from nexus_constructor.model.transformation import Transformation
 from nexus_constructor.treeview_utils import (
     get_link_transformation_frame,
@@ -29,9 +29,9 @@ from nexus_constructor.treeview_utils import (
 class ComponentEditorDelegate(QStyledItemDelegate):
     frameSize = QSize(30, 10)
 
-    def __init__(self, parent: QObject, instrument: Instrument):
+    def __init__(self, parent: QObject, model: Model):
         super().__init__(parent)
-        self.instrument = instrument
+        self.model = model
 
     def get_frame(
         self,
@@ -59,9 +59,9 @@ class ComponentEditorDelegate(QStyledItemDelegate):
         elif isinstance(value, ComponentInfo):
             get_component_info_frame(frame)
         elif isinstance(value, Transformation):
-            get_transformation_frame(frame, self.instrument, value)
+            get_transformation_frame(frame, self.model, value)
         elif isinstance(value, LinkTransformation):
-            get_link_transformation_frame(frame, self.instrument, value)
+            get_link_transformation_frame(frame, self.model, value)
         return frame
 
     def paint(

--- a/nexus_constructor/file_writer_ctrl_window.py
+++ b/nexus_constructor/file_writer_ctrl_window.py
@@ -17,7 +17,7 @@ from nexus_constructor.json.filewriter_json_writer import (
 from nexus_constructor.kafka.command_producer import CommandProducer
 from nexus_constructor.kafka.kafka_interface import KafkaInterface
 from nexus_constructor.kafka.status_consumer import StatusConsumer
-from nexus_constructor.model.entry import Instrument
+from nexus_constructor.model.model import Model
 from nexus_constructor.ui_utils import validate_line_edit
 from nexus_constructor.validators import BrokerAndTopicValidator
 from ui.filewriter_ctrl_frame import Ui_FilewriterCtrl
@@ -56,10 +56,10 @@ def extract_bool_from_qsettings(setting: Union[str, bool]):
 
 
 class FileWriterCtrl(Ui_FilewriterCtrl, QMainWindow):
-    def __init__(self, instrument: Instrument, settings: QSettings):
+    def __init__(self, model: Model, settings: QSettings):
         super().__init__()
         self.settings = settings
-        self.instrument = instrument
+        self.model = model
         self.setupUi()
         self.known_writers = {}
         self.known_files = {}
@@ -298,7 +298,7 @@ class FileWriterCtrl(Ui_FilewriterCtrl, QMainWindow):
                         stop_time=stop_time,
                         broker=broker,
                         nexus_structure=generate_nexus_string(
-                            NexusToDictConverter(), self.instrument
+                            NexusToDictConverter(), self.model
                         ),
                         service_id=service_id,
                     )

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -1,5 +1,6 @@
 import uuid
 from typing import Dict
+import json
 
 import h5py
 import silx.gui.hdf5
@@ -10,8 +11,8 @@ from nexusutils.nexusbuilder import NexusBuilder
 
 from nexus_constructor.add_component_window import AddComponentDialog
 from nexus_constructor.model.component import Component
-from nexus_constructor.model.entry import Instrument
 from nexus_constructor.ui_utils import file_dialog
+from nexus_constructor.model.model import Model
 from ui.main_window import Ui_MainWindow
 
 
@@ -20,9 +21,9 @@ JSON_FILE_TYPES = {"JSON Files": ["json", "JSON"]}
 
 
 class MainWindow(Ui_MainWindow, QMainWindow):
-    def __init__(self, instrument: Instrument, nx_classes: Dict):
+    def __init__(self, model: Model, nx_classes: Dict):
         super().__init__()
-        self.instrument = instrument
+        self.model = model
         self.nx_classes = nx_classes
 
     def setupUi(self, main_window):
@@ -49,19 +50,15 @@ class MainWindow(Ui_MainWindow, QMainWindow):
         # self.treemodel.setDatasetDragEnabled(True)
         # self.treemodel.setFileDropEnabled(True)
         # self.treemodel.setFileMoveEnabled(True)
-        # self.treemodel.insertH5pyObject(self.instrument.nexus.nexus_file)
-        self.instrument.nexus.file_changed.connect(
-            self.update_nexus_file_structure_view
-        )
+        # self.treemodel.insertH5pyObject(self.model.signals.nexus_file)
+        self.model.signals.file_changed.connect(self.update_nexus_file_structure_view)
         self.silx_tab_layout.addWidget(self.widget)
-        # self.instrument.nexus.show_entries_dialog.connect(self.show_entries_dialog)
+        # self.model.signals.show_entries_dialog.connect(self.show_entries_dialog)
 
-        self.instrument.nexus.component_added.connect(self.sceneWidget.add_component)
-        self.instrument.nexus.component_removed.connect(
-            self.sceneWidget.delete_component
-        )
-        self.component_tree_view_tab.set_up_model(self.instrument)
-        self.instrument.nexus.transformation_changed.connect(
+        self.model.signals.component_added.connect(self.sceneWidget.add_component)
+        self.model.signals.component_removed.connect(self.sceneWidget.delete_component)
+        self.component_tree_view_tab.set_up_model(self.model)
+        self.model.signals.transformation_changed.connect(
             self._update_transformations_3d_view
         )
 
@@ -88,7 +85,7 @@ class MainWindow(Ui_MainWindow, QMainWindow):
             from nexus_constructor.file_writer_ctrl_window import FileWriterCtrl
 
             self.file_writer_ctrl_window = FileWriterCtrl(
-                self.instrument, QSettings("ess", "nexus-constructor")
+                self.model, QSettings("ess", "nexus-constructor")
             )
             self.file_writer_ctrl_window.show()
 
@@ -119,12 +116,12 @@ class MainWindow(Ui_MainWindow, QMainWindow):
         ok_button.clicked.connect(self.entries_dialog.close)
 
         def _load_current_entry():
-            self.instrument.nexus.load_file(
+            self.model.signals.load_file(
                 map_of_entries[combo.currentText()], nexus_file
             )
             self._update_views()
 
-        # Connect the clicked signal of the ok_button to instrument.load_file and pass the file and entry group object.
+        # Connect the clicked signal of the ok_button to signals.load_file and pass the file and entry group object.
         ok_button.clicked.connect(_load_current_entry)
 
         self.entries_dialog.setLayout(QGridLayout())
@@ -140,7 +137,7 @@ class MainWindow(Ui_MainWindow, QMainWindow):
 
     def save_to_nexus_file(self):
         filename = file_dialog(True, "Save Nexus File", NEXUS_FILE_TYPES)
-        self.instrument.nexus.save_file(filename)
+        self.model.signals.save_file(filename)
 
     def open_idf_file(self):
         filename = file_dialog(False, "Open IDF file", {"IDF files": ["xml"]})
@@ -155,7 +152,7 @@ class MainWindow(Ui_MainWindow, QMainWindow):
                 nx_entry_name="entry",
             )
             builder.add_instrument_geometry_from_idf()
-            self.instrument.nexus.load_nexus_file(builder.target_file)
+            self.model.signals.load_nexus_file(builder.target_file)
             self._update_views()
             QMessageBox.warning(
                 self,
@@ -166,13 +163,11 @@ class MainWindow(Ui_MainWindow, QMainWindow):
             QMessageBox.critical(self, "IDF Error", "Error whilst loading IDF file")
 
     def save_to_filewriter_json(self):
-        raise NotImplementedError
-        # filename = file_dialog(True, "Save Filewriter JSON File", JSON_FILE_TYPES)
-        # if filename:
-        #     with open(filename, "w") as file:
-        #         filewriter_json_writer.write_nexus_structure_to_json(
-        #             self.instrument, file
-        #         )
+        filename = file_dialog(True, "Save Filewriter JSON File", JSON_FILE_TYPES)
+
+        if filename:
+            with open(filename, "w") as file:
+                json.dump(self.model.as_dict(), file, indent=2)
 
     def save_to_forwarder_json(self):
         raise NotImplementedError
@@ -197,7 +192,7 @@ class MainWindow(Ui_MainWindow, QMainWindow):
         #         with open(filename, "w") as file:
         #             nexus_constructor.json.forwarder_json_writer.generate_forwarder_command(
         #                 file,
-        #                 self.instrument.nexus.entry,
+        #                 self.model.signals.entry,
         #                 provider_type=provider_type,
         #                 default_broker=default_broker,
         #             )
@@ -205,8 +200,8 @@ class MainWindow(Ui_MainWindow, QMainWindow):
     def open_nexus_file(self):
         raise NotImplementedError
         # filename = file_dialog(False, "Open Nexus File", NEXUS_FILE_TYPES)
-        # existing_file = self.instrument.nexus.nexus_file
-        # if self.instrument.nexus.open_file(filename):
+        # existing_file = self.model.signals.nexus_file
+        # if self.model.signals.open_file(filename):
         #     self._update_views()
         #     existing_file.close()
 
@@ -228,24 +223,24 @@ class MainWindow(Ui_MainWindow, QMainWindow):
         #             )
         #             return
         #
-        #         existing_file = self.instrument.nexus.nexus_file
-        #         if self.instrument.nexus.load_nexus_file(nexus_file):
+        #         existing_file = self.model.signals.nexus_file
+        #         if self.model.signals.load_nexus_file(nexus_file):
         #             self._update_views()
         #             existing_file.close()
 
     def _update_transformations_3d_view(self):
         self.sceneWidget.clear_all_transformations()
-        for component in self.instrument.get_component_list():
+        for component in self.model.entry.instrument.get_component_list():
             self.sceneWidget.add_transformation(component.name, component.transform)
 
     def _update_views(self):
         self.sceneWidget.clear_all_transformations()
         self.sceneWidget.clear_all_components()
-        self.component_tree_view_tab.set_up_model(self.instrument)
+        self.component_tree_view_tab.set_up_model(self.model)
         self._update_3d_view_with_component_shapes()
 
     def _update_3d_view_with_component_shapes(self):
-        for component in self.instrument.get_component_list():
+        for component in self.model.entry.instrument.get_component_list():
             shape, positions = component.shape
             self.sceneWidget.add_component(component.name, shape, positions)
             self.sceneWidget.add_transformation(component.name, component.transform)
@@ -253,7 +248,7 @@ class MainWindow(Ui_MainWindow, QMainWindow):
     def show_add_component_window(self, component: Component = None):
         self.add_component_window = QDialog()
         self.add_component_window.ui = AddComponentDialog(
-            self.instrument,
+            self.model,
             self.component_tree_view_tab.component_model,
             component,
             nx_classes=self.nx_classes,

--- a/nexus_constructor/model/entry.py
+++ b/nexus_constructor/model/entry.py
@@ -1,41 +1,5 @@
-from PySide2.QtCore import QObject, Signal
-
-from nexus_constructor.model.component import Component
 from nexus_constructor.model.group import Group
-
-
-def _convert_name_with_spaces(component_name: str) -> str:
-    return component_name.replace(" ", "_")
-
-
-class Nexus(QObject):
-    """
-    Used for storing the signals for updating the "file" - currently just needed to avoid changing the interface of Instrument
-    """
-
-    file_changed = Signal("QVariant")
-    file_opened = Signal("QVariant")
-    component_added = Signal(str, "QVariant", "QVariant")
-    component_removed = Signal(str)
-    transformation_changed = Signal()
-    show_entries_dialog = Signal("QVariant", "QVariant")
-
-
-class Instrument(Group):
-    def __init__(self):
-        super().__init__("instrument")
-        self.nx_class = "NXinstrument"
-        self.nexus = Nexus()
-
-        sample = Component("sample")
-        sample.nx_class = "NXsample"
-        self.component_list = [sample]
-
-    def get_component_list(self):
-        return self.component_list
-
-    def remove_component(self, component: Component):
-        self.component_list.remove(component)
+from nexus_constructor.model.instrument import Instrument
 
 
 class Entry(Group):

--- a/nexus_constructor/model/instrument.py
+++ b/nexus_constructor/model/instrument.py
@@ -1,0 +1,18 @@
+from nexus_constructor.model.component import Component
+from nexus_constructor.model.group import Group
+
+
+class Instrument(Group):
+    def __init__(self):
+        super().__init__("instrument")
+        self.nx_class = "NXinstrument"
+
+        sample = Component("sample")
+        sample.nx_class = "NXsample"
+        self.component_list = [sample]
+
+    def get_component_list(self):
+        return self.component_list
+
+    def remove_component(self, component: Component):
+        self.component_list.remove(component)

--- a/nexus_constructor/model/model.py
+++ b/nexus_constructor/model/model.py
@@ -1,5 +1,6 @@
 from PySide2.QtCore import QObject, Signal
 from typing import Dict, Any
+from nexus_constructor.model.entry import Entry
 
 
 class Signals(QObject):
@@ -16,7 +17,7 @@ class Signals(QObject):
 
 
 class Model:
-    def __init__(self, entry):
+    def __init__(self, entry: Entry):
         self.signals = Signals()
         self.entry = entry
 

--- a/nexus_constructor/model/model.py
+++ b/nexus_constructor/model/model.py
@@ -1,0 +1,24 @@
+from PySide2.QtCore import QObject, Signal
+from typing import Dict, Any
+
+
+class Signals(QObject):
+    """
+    Signals when model is updated, to trigger, for example, updating the 3D view
+    """
+
+    file_changed = Signal("QVariant")
+    file_opened = Signal("QVariant")
+    component_added = Signal(str, "QVariant", "QVariant")
+    component_removed = Signal(str)
+    transformation_changed = Signal()
+    show_entries_dialog = Signal("QVariant", "QVariant")
+
+
+class Model:
+    def __init__(self, entry):
+        self.signals = Signals()
+        self.entry = entry
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {"nexus_structure": {"children": [self.entry.as_dict()]}}

--- a/nexus_constructor/transformation_view.py
+++ b/nexus_constructor/transformation_view.py
@@ -4,7 +4,7 @@ from PySide2.QtWidgets import QGroupBox, QFrame, QWidget
 from nexus_constructor.component_tree_model import LinkTransformation
 from nexus_constructor.field_utils import find_field_type
 from nexus_constructor.model.component import Component
-from nexus_constructor.model.entry import Instrument
+from nexus_constructor.model.model import Model
 from nexus_constructor.model.transformation import Transformation
 from nexus_constructor.transformation_types import TransformationType
 from nexus_constructor.unit_utils import METRES, RADIANS
@@ -13,11 +13,9 @@ from ui.transformation import Ui_Transformation
 
 
 class EditTransformation(QGroupBox):
-    def __init__(
-        self, parent: QWidget, transformation: Transformation, instrument: Instrument
-    ):
+    def __init__(self, parent: QWidget, transformation: Transformation, model: Model):
         super().__init__(parent)
-        self.instrument = instrument
+        self.model = model
         self.transformation_frame = Ui_Transformation()
         self.transformation_frame.setupUi(self)
         self.transformation = transformation
@@ -81,14 +79,12 @@ class EditTransformation(QGroupBox):
             *[spinbox.value() for spinbox in self.transformation_frame.spinboxes[:-1]]
         )
         self.transformation.units = self.transformation_frame.magnitude_widget.units
-        self.instrument.nexus.transformation_changed.emit()
+        self.model.signals.transformation_changed.emit()
 
 
 class EditTranslation(EditTransformation):
-    def __init__(
-        self, parent: QWidget, transformation: Transformation, instrument: Instrument
-    ):
-        super().__init__(parent, transformation, instrument)
+    def __init__(self, parent: QWidget, transformation: Transformation, model: Model):
+        super().__init__(parent, transformation, model)
         self.transformation_frame.magnitude_widget.unit_validator.expected_dimensionality = (
             METRES
         )
@@ -98,10 +94,8 @@ class EditTranslation(EditTransformation):
 
 
 class EditRotation(EditTransformation):
-    def __init__(
-        self, parent: QWidget, transformation: Transformation, instrument: Instrument
-    ):
-        super().__init__(parent, transformation, instrument)
+    def __init__(self, parent: QWidget, transformation: Transformation, model: Model):
+        super().__init__(parent, transformation, model)
         self.transformation_frame.magnitude_widget.unit_validator.expected_dimensionality = (
             RADIANS
         )
@@ -123,12 +117,11 @@ def links_back_to_component(reference: Component, comparison: Component):
 
 
 class EditTransformationLink(QFrame):
-    def __init__(
-        self, parent: QWidget, link: LinkTransformation, instrument: Instrument
-    ):
+    def __init__(self, parent: QWidget, link: LinkTransformation, model: Model):
         super().__init__(parent)
         self.link = link
-        self.instrument = instrument
+        self.signals = model.signals
+        self.instrument = model.entry.instrument
         self.link_frame = Ui_Link()
         self.link_frame.setupUi(self)
         self.populate_combo_box()
@@ -179,4 +172,4 @@ class EditTransformationLink(QFrame):
         self.populate_combo_box()
 
     def saveChanges(self):
-        self.instrument.nexus.transformation_changed.emit()
+        self.signals.transformation_changed.emit()

--- a/nexus_constructor/treeview_utils.py
+++ b/nexus_constructor/treeview_utils.py
@@ -9,6 +9,7 @@ from nexus_constructor.component.link_transformation import LinkTransformation
 from nexus_constructor.component.transformations_list import TransformationsList
 from nexus_constructor.component_tree_model import ComponentTreeModel
 from nexus_constructor.model.component import Component
+from nexus_constructor.model.model import Model
 from nexus_constructor.model.transformation import Transformation
 from nexus_constructor.transformation_types import TransformationType
 from nexus_constructor.transformation_view import (
@@ -191,16 +192,16 @@ def fill_selection(option, painter):
     painter.fillRect(option.rect, colour)
 
 
-def get_link_transformation_frame(frame, instrument, value):
-    frame.transformation_frame = EditTransformationLink(frame, value, instrument)
+def get_link_transformation_frame(frame, model: Model, value):
+    frame.transformation_frame = EditTransformationLink(frame, value, model)
     frame.layout().addWidget(frame.transformation_frame, Qt.AlignTop)
 
 
-def get_transformation_frame(frame, instrument, value):
+def get_transformation_frame(frame, model: Model, value):
     if value.type == TransformationType.TRANSLATION:
-        frame.transformation_frame = EditTranslation(frame, value, instrument)
+        frame.transformation_frame = EditTranslation(frame, value, model)
     elif value.type == TransformationType.ROTATION:
-        frame.transformation_frame = EditRotation(frame, value, instrument)
+        frame.transformation_frame = EditRotation(frame, value, model)
     else:
         raise (RuntimeError('Transformation type "{}" is unknown.'.format(value.type)))
     frame.layout().addWidget(frame.transformation_frame, Qt.AlignTop)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,13 @@
 # import uuid
 from unittest.mock import Mock
-
 import h5py
 import pytest
 from PySide2.QtWidgets import QDialog
 
-# from nexus_constructor.instrument import Instrument
 # from nexus_constructor.nexus.nexus_wrapper import NexusWrapper
-from nexus_constructor.model.entry import Instrument
+from nexus_constructor.model.instrument import Instrument
+from nexus_constructor.model.entry import Entry
+from nexus_constructor.model.model import Model
 from nexus_constructor.pixel_options import PixelOptions
 from nexus_constructor.validators import PixelValidator
 from tests.chopper_test_helpers import chopper_details  # noqa: F401
@@ -30,6 +30,13 @@ def template(qtbot) -> QDialog:
 @pytest.fixture(scope="function")
 def instrument() -> Instrument:
     return Instrument()
+
+
+@pytest.fixture(scope="function")
+def model() -> Model:
+    entry = Entry()
+    entry.instrument = Instrument()
+    return Model(entry)
 
 
 @pytest.fixture(scope="function")

--- a/tests/ui_tests/test_main_window_utils.py
+++ b/tests/ui_tests/test_main_window_utils.py
@@ -6,6 +6,7 @@ from PySide2.QtWidgets import QToolBar, QWidget, QTreeView, QFrame, QVBoxLayout
 from nexus_constructor.component_tree_model import ComponentTreeModel
 from nexus_constructor.component_tree_view import ComponentEditorDelegate
 from nexus_constructor.model.dataset import DatasetMetadata
+from nexus_constructor.model.model import Model
 from nexus_constructor.model.transformation import Transformation
 from nexus_constructor.transformation_view import EditRotation, EditTranslation
 from nexus_constructor.treeview_utils import (
@@ -44,14 +45,14 @@ def trigger_method_mock():
 
 
 @pytest.fixture(scope="function")
-def component_model(instrument):
-    return ComponentTreeModel(instrument)
+def component_model(model: Model):
+    return ComponentTreeModel(model)
 
 
 @pytest.fixture(scope="function")
-def component_tree_view(template, instrument, component_model, qtbot):
+def component_tree_view(template, model, component_model, qtbot):
     component_tree_view = QTreeView(template)
-    component_delegate = ComponentEditorDelegate(component_tree_view, instrument)
+    component_delegate = ComponentEditorDelegate(component_tree_view, model)
     component_tree_view.setItemDelegate(component_delegate)
     component_tree_view.setModel(component_model)
     qtbot.addWidget(component_tree_view)

--- a/tests/ui_tests/test_ui_fields.py
+++ b/tests/ui_tests/test_ui_fields.py
@@ -18,14 +18,14 @@ from nexus_constructor.stream_fields_widget import (
 
 
 @pytest.fixture
-def stream_fields_widget(qtbot, instrument, template):
+def stream_fields_widget(qtbot, model, template):
     class DummyField:
         @property
         def name(self):
             return "test"
 
     add_component_dialog = AddComponentDialog(
-        instrument, ComponentTreeModel(instrument), nx_classes=NX_CLASS_DEFINITIONS
+        model, ComponentTreeModel(model), nx_classes=NX_CLASS_DEFINITIONS
     )
     add_component_dialog.setupUi(template)
     field = add_component_dialog.create_new_ui_field(DummyField())

--- a/tests/ui_tests/test_ui_transformation_view.py
+++ b/tests/ui_tests/test_ui_transformation_view.py
@@ -16,11 +16,6 @@ import pytest
 
 
 @pytest.fixture
-def instrument():
-    return Instrument()
-
-
-@pytest.fixture
 def component():
     return Component("Component", [])
 
@@ -41,7 +36,7 @@ def create_corresponding_value_dataset(value: Any):
 
 
 def test_UI_GIVEN_scalar_vector_WHEN_creating_translation_view_THEN_ui_is_filled_correctly(
-    qtbot, instrument, component
+    qtbot, model, component
 ):
 
     x = 1
@@ -51,7 +46,7 @@ def test_UI_GIVEN_scalar_vector_WHEN_creating_translation_view_THEN_ui_is_filled
     transform = component.add_translation(QVector3D(x, y, z), name="transform")
     transform.values = create_corresponding_value_dataset(value)
 
-    view = EditTranslation(parent=None, transformation=transform, instrument=instrument)
+    view = EditTranslation(parent=None, transformation=transform, model=model)
     qtbot.addWidget(view)
 
     assert view.transformation_frame.x_spinbox.value() == x
@@ -68,7 +63,7 @@ def test_UI_GIVEN_scalar_vector_WHEN_creating_translation_view_THEN_ui_is_filled
 
 
 def test_UI_GIVEN_scalar_angle_WHEN_creating_rotation_view_THEN_ui_is_filled_correctly(
-    qtbot, instrument, component
+    qtbot, model, component
 ):
     x = 1
     y = 2
@@ -78,7 +73,7 @@ def test_UI_GIVEN_scalar_angle_WHEN_creating_rotation_view_THEN_ui_is_filled_cor
     transform = component.add_rotation(angle=angle, axis=QVector3D(x, y, z))
     transform.values = create_corresponding_value_dataset(angle)
 
-    view = EditRotation(parent=None, transformation=transform, instrument=instrument)
+    view = EditRotation(parent=None, transformation=transform, model=model)
     qtbot.addWidget(view)
 
     assert view.transformation_frame.x_spinbox.value() == x
@@ -95,7 +90,7 @@ def test_UI_GIVEN_scalar_angle_WHEN_creating_rotation_view_THEN_ui_is_filled_cor
 
 
 def test_UI_GIVEN_array_dataset_as_magnitude_WHEN_creating_translation_THEN_ui_is_filled_correctly(
-    qtbot, file, component
+    qtbot, file, component, model
 ):
     array = np.array([1, 2, 3, 4])
 
@@ -105,7 +100,7 @@ def test_UI_GIVEN_array_dataset_as_magnitude_WHEN_creating_translation_THEN_ui_i
     transform = component.add_translation(QVector3D(x, y, z), name="test")
     transform.values = create_corresponding_value_dataset(array)
 
-    view = EditTranslation(parent=None, transformation=transform, instrument=instrument)
+    view = EditTranslation(parent=None, transformation=transform, model=model)
     qtbot.addWidget(view)
 
     assert view.transformation_frame.x_spinbox.value() == x
@@ -192,7 +187,7 @@ def test_UI_GIVEN_link_as_rotation_magnitude_WHEN_creating_rotation_view_THEN_ui
 
 
 def test_UI_GIVEN_vector_updated_WHEN_saving_view_changes_THEN_model_is_updated(
-    qtbot, component, instrument
+    qtbot, component, model
 ):
     x = 1
     y = 2
@@ -202,7 +197,7 @@ def test_UI_GIVEN_vector_updated_WHEN_saving_view_changes_THEN_model_is_updated(
     transform = component.add_rotation(angle=angle, axis=QVector3D(x, y, z))
     transform.values = create_corresponding_value_dataset(angle)
 
-    view = EditRotation(parent=None, transformation=transform, instrument=instrument)
+    view = EditRotation(parent=None, transformation=transform, model=model)
     qtbot.addWidget(view)
 
     new_x = 4
@@ -219,7 +214,7 @@ def test_UI_GIVEN_vector_updated_WHEN_saving_view_changes_THEN_model_is_updated(
 
 
 def test_UI_GIVEN_view_gains_focus_WHEN_transformation_view_exists_THEN_spinboxes_are_enabled(
-    qtbot, component
+    qtbot, component, model
 ):
     x = 1
     y = 2
@@ -229,7 +224,7 @@ def test_UI_GIVEN_view_gains_focus_WHEN_transformation_view_exists_THEN_spinboxe
     transform = component.add_rotation(angle=angle, axis=QVector3D(x, y, z))
     transform.values = create_corresponding_value_dataset(angle)
 
-    view = EditRotation(parent=None, transformation=transform, instrument=instrument)
+    view = EditRotation(parent=None, transformation=transform, model=model)
     qtbot.addWidget(view)
 
     view.enable()
@@ -241,7 +236,7 @@ def test_UI_GIVEN_view_gains_focus_WHEN_transformation_view_exists_THEN_spinboxe
 
 
 def test_UI_GIVEN_view_loses_focus_WHEN_transformation_view_exists_THEN_spinboxes_are_disabled(
-    qtbot, component
+    qtbot, component, model
 ):
     x = 1
     y = 2
@@ -251,7 +246,7 @@ def test_UI_GIVEN_view_loses_focus_WHEN_transformation_view_exists_THEN_spinboxe
     transform = component.add_rotation(angle=angle, axis=QVector3D(x, y, z))
     transform.values = create_corresponding_value_dataset(angle)
 
-    view = EditRotation(parent=None, transformation=transform, instrument=instrument)
+    view = EditRotation(parent=None, transformation=transform, model=model)
     qtbot.addWidget(view)
 
     view.disable()
@@ -263,7 +258,7 @@ def test_UI_GIVEN_view_loses_focus_WHEN_transformation_view_exists_THEN_spinboxe
 
 
 def test_UI_GIVEN_new_values_are_provided_WHEN_save_changes_is_called_THEN_transformation_changed_signal_is_called_to_update_3d_view(
-    qtbot, component, instrument
+    qtbot, component, model
 ):
     x = 1
     y = 2
@@ -273,20 +268,20 @@ def test_UI_GIVEN_new_values_are_provided_WHEN_save_changes_is_called_THEN_trans
     transform = component.add_rotation(angle=angle, axis=QVector3D(x, y, z))
     transform.values = create_corresponding_value_dataset(angle)
 
-    view = EditRotation(parent=None, transformation=transform, instrument=instrument)
-    instrument.nexus.transformation_changed = Mock()
+    view = EditRotation(parent=None, transformation=transform, model=model)
+    model.signals.transformation_changed = Mock()
     qtbot.addWidget(view)
 
     new_x = 4
 
     view.transformation_frame.x_spinbox.setValue(new_x)
     view.saveChanges()
-    instrument.nexus.transformation_changed.emit.assert_called_once()
+    model.signals.transformation_changed.emit.assert_called_once()
     assert transform.vector == QVector3D(new_x, y, z)
 
 
 def test_UI_GIVEN_scalar_value_WHEN_creating_new_transformation_THEN_ui_values_spinbox_is_disabled(
-    qtbot, component, instrument
+    qtbot, component, model
 ):
     x = 1
     y = 0
@@ -295,7 +290,7 @@ def test_UI_GIVEN_scalar_value_WHEN_creating_new_transformation_THEN_ui_values_s
     transform = component.add_translation(QVector3D(x, y, z), name="transform")
     transform.values = create_corresponding_value_dataset(value)
 
-    view = EditTranslation(parent=None, transformation=transform, instrument=instrument)
+    view = EditTranslation(parent=None, transformation=transform, model=model)
     qtbot.addWidget(view)
 
     assert not view.transformation_frame.value_spinbox.isEnabled()
@@ -303,7 +298,7 @@ def test_UI_GIVEN_scalar_value_WHEN_creating_new_transformation_THEN_ui_values_s
 
 @pytest.mark.parametrize("field_type", [item.value for item in FieldType][1:])
 def test_UI_GIVEN_change_to_non_scalar_value_WHEN_creating_new_transformation_THEN_ui_values_spinbox_is_enabled(
-    qtbot, component, instrument, field_type
+    qtbot, component, model, field_type
 ):
     x = 1
     y = 0
@@ -312,7 +307,7 @@ def test_UI_GIVEN_change_to_non_scalar_value_WHEN_creating_new_transformation_TH
     transform = component.add_translation(QVector3D(x, y, z), name="transform")
     transform.values = create_corresponding_value_dataset(value)
 
-    view = EditTranslation(parent=None, transformation=transform, instrument=instrument)
+    view = EditTranslation(parent=None, transformation=transform, model=model)
     view.transformation_frame.magnitude_widget.field_type = field_type
     qtbot.addWidget(view)
 
@@ -320,7 +315,7 @@ def test_UI_GIVEN_change_to_non_scalar_value_WHEN_creating_new_transformation_TH
 
 
 def test_UI_GIVEN_change_to_scalar_value_WHEN_creating_new_transformation_THEN_ui_values_spinbox_is_disabled(
-    qtbot, component, instrument
+    qtbot, component, model
 ):
     x = 1
     y = 0
@@ -330,7 +325,7 @@ def test_UI_GIVEN_change_to_scalar_value_WHEN_creating_new_transformation_THEN_u
     transform = component.add_translation(QVector3D(x, y, z), name="transform")
     transform.values = create_corresponding_value_dataset(value)
 
-    view = EditTranslation(parent=None, transformation=transform, instrument=instrument)
+    view = EditTranslation(parent=None, transformation=transform, model=model)
     print(view.transformation_frame.magnitude_widget.field_type)
     view.transformation_frame.magnitude_widget.field_type = (
         FieldType.scalar_dataset.value

--- a/ui/treeview_tab.py
+++ b/ui/treeview_tab.py
@@ -16,6 +16,7 @@ from nexus_constructor.treeview_utils import (
     set_button_states,
 )
 from nexus_constructor.transformation_types import TransformationType
+from nexus_constructor.model.model import Model
 
 
 class ComponentTreeViewTab(QWidget):
@@ -95,10 +96,10 @@ class ComponentTreeViewTab(QWidget):
         self.component_tool_bar.insertSeparator(self.zoom_action)
         self.componentsTabLayout.insertWidget(0, self.component_tool_bar)
 
-    def set_up_model(self, instrument):
-        self.component_model = ComponentTreeModel(instrument)
+    def set_up_model(self, model: Model):
+        self.component_model = ComponentTreeModel(model)
         self.component_delegate = ComponentEditorDelegate(
-            self.component_tree_view, instrument
+            self.component_tree_view, model
         )
         self.component_tree_view.setItemDelegate(self.component_delegate)
         self.component_tree_view.setModel(self.component_model)


### PR DESCRIPTION
Refactored so that the top level model object is `Model`.
Renamed the object containing signals from `Nexus` to `Signals` and this now lives in `Model` rather than `Instrument`.
In general we then pass around the top level `Model` object, rather than `Instrument`.
Updated the many affected tests to use a `model` fixture instead of `instrument` fixture, this accounts for the vast majority of changed lines of code.

**To test**
Please carefully review the non-test code changes then do a general, manual test of the interface. Cover as much as possible: create a component with fields with attributes, add a translation and a rotation, etc.
