### PR TITLE
Add as_dict methods to some model classes

### DIFF
--- a/nexus_constructor/model/attribute.py
+++ b/nexus_constructor/model/attribute.py
@@ -1,5 +1,5 @@
 import attr
-
+from typing import Dict, Any
 from nexus_constructor.model.value_type import ValueType
 
 
@@ -14,3 +14,7 @@ class FieldAttribute:
 
     name = attr.ib(type=str)
     values = attr.ib(type=ValueType)
+
+    @staticmethod
+    def as_dict() -> Dict[str, Any]:
+        return {}

--- a/nexus_constructor/model/component.py
+++ b/nexus_constructor/model/component.py
@@ -1,6 +1,5 @@
 import logging
-from typing import Tuple, Union, List
-
+from typing import Tuple, Union, List, Dict, Any, Optional
 import attr
 import numpy as np
 from PySide2.Qt3DCore import Qt3DCore
@@ -31,6 +30,8 @@ from nexus_constructor.pixel_data_to_nexus_utils import (
 )
 from nexus_constructor.transformation_types import TransformationType
 from nexus_constructor.ui_utils import show_warning_dialog
+
+TRANSFORMS_GROUP_NAME = "transformations"
 
 
 def _normalise(input_vector: QVector3D) -> Tuple[QVector3D, float]:
@@ -315,7 +316,9 @@ class Component(Group):
             "int64",
         )
 
-    def _create_transformation_vectors_for_pixel_offsets(self) -> List[QVector3D]:
+    def _create_transformation_vectors_for_pixel_offsets(
+        self,
+    ) -> Optional[List[QVector3D]]:
         """
         Construct a transformation (as a QVector3D) for each pixel offset
         """
@@ -338,6 +341,18 @@ class Component(Group):
                 x_offsets.flatten(), y_offsets.flatten(), z_offsets.flatten()
             )
         ]
+
+    def as_dict(self) -> Dict[str, Any]:
+        dictionary = super(Component, self).as_dict()
+        # Add transformations in a child group
+        dictionary["children"].append(
+            {
+                "type": "group",
+                "name": TRANSFORMS_GROUP_NAME,
+                "children": [transform.as_dict() for transform in self.transforms_list],
+            }
+        )
+        return dictionary
 
 
 def add_fields_to_component(component: Component, fields_widget: QListWidget):

--- a/nexus_constructor/model/dataset.py
+++ b/nexus_constructor/model/dataset.py
@@ -1,5 +1,5 @@
 import attr
-from typing import List
+from typing import List, Dict, Any
 
 from nexus_constructor.common_attrs import CommonAttrs
 from nexus_constructor.model.node import Node
@@ -25,3 +25,10 @@ class Dataset(Node):
     @nx_class.setter
     def nx_class(self, new_nx_class: str):
         self.set_attribute_value(CommonAttrs.NX_CLASS, new_nx_class)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "type": self.type,
+            "attributes": [attribute.as_dict() for attribute in self.attributes],
+        }

--- a/nexus_constructor/model/entry.py
+++ b/nexus_constructor/model/entry.py
@@ -1,5 +1,6 @@
 from nexus_constructor.model.group import Group
 from nexus_constructor.model.instrument import Instrument
+from typing import Dict, Any
 
 
 class Entry(Group):
@@ -14,3 +15,14 @@ class Entry(Group):
     @instrument.setter
     def instrument(self, instrument: Instrument):
         self["instrument"] = instrument
+
+    def as_dict(self) -> Dict[str, Any]:
+        dictionary = super(Entry, self).as_dict()
+        # sample lives in instrument component list for purposes of GUI
+        # but in the NeXus structure must live in the entry
+        try:
+            dictionary["children"].append(self.instrument.sample.as_dict())
+        except AttributeError:
+            # If instrument is not set then don't try to add sample to dictionary
+            pass
+        return dictionary

--- a/nexus_constructor/model/group.py
+++ b/nexus_constructor/model/group.py
@@ -1,5 +1,4 @@
-from typing import List, Any, Union
-
+from typing import List, Any, Union, Dict
 import attr
 import numpy as np
 
@@ -50,3 +49,11 @@ class Group(Node):
 
     def get_field_value(self, name: str):
         return self[name].values
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "type": self.type,
+            "attributes": [attribute.as_dict() for attribute in self.attributes],
+            "children": [child.as_dict() for child in self.children],
+        }

--- a/nexus_constructor/model/instrument.py
+++ b/nexus_constructor/model/instrument.py
@@ -1,13 +1,17 @@
 from nexus_constructor.model.component import Component
 from nexus_constructor.model.group import Group
+from typing import Dict, Any
+
+SAMPLE_NAME = "sample"
+INSTRUMENT_NAME = "instrument"
 
 
 class Instrument(Group):
     def __init__(self):
-        super().__init__("instrument")
+        super().__init__(INSTRUMENT_NAME)
         self.nx_class = "NXinstrument"
 
-        self.sample = Component("sample")
+        self.sample = Component(SAMPLE_NAME)
         self.sample.nx_class = "NXsample"
         self.component_list = [self.sample]
 
@@ -16,3 +20,15 @@ class Instrument(Group):
 
     def remove_component(self, component: Component):
         self.component_list.remove(component)
+
+    def as_dict(self) -> Dict[str, Any]:
+        dictionary = super(Instrument, self).as_dict()
+        # Put components (other than sample) in children
+        dictionary["children"].extend(
+            [
+                component.as_dict()
+                for component in self.component_list
+                if component.name != SAMPLE_NAME
+            ]
+        )
+        return dictionary

--- a/nexus_constructor/model/instrument.py
+++ b/nexus_constructor/model/instrument.py
@@ -7,9 +7,9 @@ class Instrument(Group):
         super().__init__("instrument")
         self.nx_class = "NXinstrument"
 
-        sample = Component("sample")
-        sample.nx_class = "NXsample"
-        self.component_list = [sample]
+        self.sample = Component("sample")
+        self.sample.nx_class = "NXsample"
+        self.component_list = [self.sample]
 
     def get_component_list(self):
         return self.component_list

--- a/nexus_constructor/model/node.py
+++ b/nexus_constructor/model/node.py
@@ -1,5 +1,4 @@
 from typing import List, Any
-
 import attr
 
 from nexus_constructor.model.attribute import FieldAttribute

--- a/tests/model/test_component.py
+++ b/tests/model/test_component.py
@@ -1,0 +1,24 @@
+from nexus_constructor.model.component import Component, TRANSFORMS_GROUP_NAME
+from nexus_constructor.model.transformation import Transformation
+from nexus_constructor.model.dataset import DatasetMetadata
+
+
+def test_component_as_dict_contains_transformations():
+    zeroth_transform_name = "test_transform_A"
+    first_transform_name = "test_transform_B"
+    metadata = DatasetMetadata("String", (0,))
+    test_component = Component(
+        "test_component",
+        [
+            Transformation(zeroth_transform_name, metadata),
+            Transformation(first_transform_name, metadata),
+        ],
+    )
+    dictionary_output = test_component.as_dict()
+
+    assert dictionary_output["children"][0]["name"] == TRANSFORMS_GROUP_NAME
+    child_names = [
+        child["name"] for child in dictionary_output["children"][0]["children"]
+    ]
+    assert zeroth_transform_name in child_names
+    assert first_transform_name in child_names

--- a/tests/model/test_dataset.py
+++ b/tests/model/test_dataset.py
@@ -1,0 +1,12 @@
+from nexus_constructor.model.dataset import Dataset, DatasetMetadata
+
+
+def test_dataset_as_dict_contains_expected_keys():
+    test_dataset_metadata = DatasetMetadata("String", (0,))
+    input_name = "test_dataset"
+    test_dataset = Dataset(input_name, test_dataset_metadata, "the_value")
+    dictionary_output = test_dataset.as_dict()
+    for expected_key in ("name", "type", "attributes"):
+        assert expected_key in dictionary_output.keys()
+
+    assert dictionary_output["name"] == input_name

--- a/tests/model/test_entry.py
+++ b/tests/model/test_entry.py
@@ -1,0 +1,12 @@
+from nexus_constructor.model.entry import Entry
+from nexus_constructor.model.instrument import Instrument
+
+
+def test_entry_as_dict_contains_sample_and_instrument():
+    test_entry = Entry()
+    test_entry.instrument = Instrument()
+    dictionary_output = test_entry.as_dict()
+
+    child_names = [child["name"] for child in dictionary_output["children"]]
+    assert "sample" in child_names
+    assert "instrument" in child_names

--- a/tests/model/test_entry.py
+++ b/tests/model/test_entry.py
@@ -1,5 +1,5 @@
 from nexus_constructor.model.entry import Entry
-from nexus_constructor.model.instrument import Instrument
+from nexus_constructor.model.instrument import Instrument, SAMPLE_NAME, INSTRUMENT_NAME
 
 
 def test_entry_as_dict_contains_sample_and_instrument():
@@ -8,5 +8,5 @@ def test_entry_as_dict_contains_sample_and_instrument():
     dictionary_output = test_entry.as_dict()
 
     child_names = [child["name"] for child in dictionary_output["children"]]
-    assert "sample" in child_names
-    assert "instrument" in child_names
+    assert SAMPLE_NAME in child_names
+    assert INSTRUMENT_NAME in child_names

--- a/tests/model/test_group.py
+++ b/tests/model/test_group.py
@@ -4,8 +4,17 @@ from nexus_constructor.model.group import Group
 
 
 def test_get_field_value_throws_if_field_does_not_exist():
-
     group = Group("test_group")
 
     with pytest.raises(AttributeError):
         group.get_field_value("nonexistentfield")
+
+
+def test_group_as_dict_contains_expected_keys():
+    input_name = "test_group"
+    test_group = Group("test_group")
+    dictionary_output = test_group.as_dict()
+    for expected_key in ("name", "type", "attributes", "children"):
+        assert expected_key in dictionary_output.keys()
+
+    assert dictionary_output["name"] == input_name

--- a/tests/model/test_instrument.py
+++ b/tests/model/test_instrument.py
@@ -1,0 +1,26 @@
+from nexus_constructor.model.instrument import Instrument, SAMPLE_NAME
+from nexus_constructor.model.component import Component
+
+
+def test_instrument_as_dict_does_not_contain_sample():
+    test_instrument = Instrument()
+    dictionary_output = test_instrument.as_dict()
+
+    child_names = [child["name"] for child in dictionary_output["children"]]
+    assert (
+        SAMPLE_NAME not in child_names
+    ), "Sample component should be in NXentry not in NXinstrument"
+
+
+def test_instrument_as_dict_contains_components():
+    test_instrument = Instrument()
+    component_list = test_instrument.get_component_list()
+    zeroth_test_component_name = "Component_A"
+    first_test_component_name = "Component_B"
+    component_list.append(Component(zeroth_test_component_name, []))
+    component_list.append(Component(first_test_component_name, []))
+    dictionary_output = test_instrument.as_dict()
+
+    child_names = [child["name"] for child in dictionary_output["children"]]
+    assert zeroth_test_component_name in child_names
+    assert first_test_component_name in child_names


### PR DESCRIPTION
### Issue

Closes #768 

### Description of work

Implements `as_dict()` for JSON serialisation for:
- `Group`
- `Dataset`
- `Entry`
- `Instrument`
- `Component`

`Attribute.as_dict()` is not properly implemented, but returns an empty dictionary so that it doesn't throw an error when you try to output a JSON file from the interface.

### Acceptance Criteria 

Review code changes, test adding components, fields and transformations and see what the output looks like.