### PR TITLE
771: Edited component loses transformations

### DIFF
--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -441,6 +441,9 @@ class AddComponentDialog(Ui_AddComponentDialog, QObject):
 
         self.signals.component_added.emit(self.nameLineEdit.text(), shape, positions)
 
+        if self.component_to_edit:
+            self.signals.transformation_changed.emit()
+
     def create_new_component(
         self,
         component_name: str,

--- a/tests/ui_tests/test_ui_add_component_window.py
+++ b/tests/ui_tests/test_ui_add_component_window.py
@@ -3010,3 +3010,23 @@ def test_UI_GIVEN_invalid_chopper_definition_WHEN_creating_component_with_no_sha
     with patch(CHOPPER_GEOMETRY_CREATOR_PATH) as chopper_creator:
         add_component_dialog.on_ok()
         chopper_creator.assert_not_called()
+
+
+def test_UI_GIVEN_previous_transformations_WHEN_editing_component_THEN_transformation_changed_signal_is_emitted(
+    edit_component_dialog,
+):
+
+    transformation_mock = Mock()
+    edit_component_dialog.signals.transformation_changed = transformation_mock
+    edit_component_dialog.on_ok()
+    transformation_mock.emit.assert_called_once()
+
+
+def test_UI_GIVEN_creating_component_WHEN_pressing_ok_THEN_transformation_changed_signal_isnt_emitted(
+    add_component_dialog,
+):
+
+    transformation_mock = Mock()
+    add_component_dialog.signals.transformation_changed = transformation_mock
+    add_component_dialog.on_ok()
+    transformation_mock.emit.assert_not_called()

--- a/tests/ui_tests/test_ui_add_component_window.py
+++ b/tests/ui_tests/test_ui_add_component_window.py
@@ -3023,10 +3023,13 @@ def test_UI_GIVEN_previous_transformations_WHEN_editing_component_THEN_transform
 
 
 def test_UI_GIVEN_creating_component_WHEN_pressing_ok_THEN_transformation_changed_signal_isnt_emitted(
-    add_component_dialog,
+    add_component_dialog, qtbot, template
 ):
 
     transformation_mock = Mock()
     add_component_dialog.signals.transformation_changed = transformation_mock
+
+    enter_component_name(qtbot, template, add_component_dialog, "component name")
+
     add_component_dialog.on_ok()
     transformation_mock.emit.assert_not_called()


### PR DESCRIPTION
### Issue

Closes #771

### Description of work

Should fix the issue of transformations disappearing when a component is edited. Also added some tests to check for the transformation changed signal being emitted.

### Acceptance Criteria 

1. Create a component
2. Add a transformation
3. Edit the component
4. Check that the transformations are preserved

### UI tests

n/a

### Nominate for Group Code Review

- [ ] Nominate for code review 
