### PR TITLE
773: Remove no shape cube when component is edited

### DIFF
--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -489,8 +489,7 @@ class AddComponentDialog(Ui_AddComponentDialog, QObject):
         :return: The geometry object.
         """
         # remove the previous object from the qt3d view
-        if not isinstance(self.component_to_edit.shape[0], NoShapeGeometry):
-            self.parent().sceneWidget.delete_component(self.component_to_edit.name)
+        self.parent().sceneWidget.delete_component(self.component_to_edit.name)
 
         # remove previous fields
         self.component_to_edit.children = []

--- a/tests/ui_tests/test_ui_add_component_window.py
+++ b/tests/ui_tests/test_ui_add_component_window.py
@@ -3005,8 +3005,6 @@ def test_UI_GIVEN_invalid_chopper_definition_WHEN_creating_component_with_no_sha
     add_component_dialog.fieldsListWidget.setCurrentRow(0)
     systematic_button_press(qtbot, template, add_component_dialog.removeFieldPushButton)
 
-    add_component_dialog.on_ok()
-
     with patch(CHOPPER_GEOMETRY_CREATOR_PATH) as chopper_creator:
         add_component_dialog.on_ok()
         chopper_creator.assert_not_called()
@@ -3032,4 +3030,14 @@ def test_UI_GIVEN_creating_component_WHEN_pressing_ok_THEN_transformation_change
     enter_component_name(qtbot, template, add_component_dialog, "component name")
 
     add_component_dialog.on_ok()
+
     transformation_mock.emit.assert_not_called()
+
+
+def test_UI_GIVEN_component_is_changed_WHEN_editing_component_THEN_delete_component_is_called(
+    parent_mock, edit_component_dialog, component_with_cylindrical_geometry
+):
+    edit_component_dialog.on_ok()
+    parent_mock.sceneWidget.delete_component.assert_called_once_with(
+        component_with_cylindrical_geometry.name
+    )


### PR DESCRIPTION
### Issue

Closes #773 

### Description of work

Calls `delete_component` in the instrument view whenever a component is edited. It previously did not do this if the component had a `NoShapeGeometry`.

### Acceptance Criteria 

Create a faulty chopper, edit it so that it's now valid, and check that the cube in the instrument view has been replaced. Do the same with a No Shape component that's edited and set to Cylinder/Mesh.

### UI tests

n/a

### Nominate for Group Code Review

- [ ] Nominate for code review 
