### PR TITLE
#769: Storing attribute type information + adding asdict method for attrs

### DIFF
--- a/nexus_constructor/field_attrs.py
+++ b/nexus_constructor/field_attrs.py
@@ -19,7 +19,7 @@ from nexus_constructor.common_attrs import CommonAttrs
 from nexus_constructor.model.dataset import Dataset
 from nexus_constructor.ui_utils import validate_line_edit
 from nexus_constructor.validators import FieldValueValidator
-from nexus_constructor.model.value_type import VALUE_TYPE, ValueType
+from nexus_constructor.model.value_type import VALUE_TYPE
 
 ATTRS_BLACKLIST = [CommonAttrs.UNITS]
 
@@ -141,8 +141,12 @@ class FieldAttrFrame(QFrame):
         )
 
     @property
-    def dtype(self) -> ValueType:
+    def dtype(self) -> str:
         return self.attr_dtype_combo.currentText()
+
+    @dtype.setter
+    def dtype(self, new_dtype: str):
+        self.attr_dtype_combo.setCurrentText(new_dtype)
 
     @property
     def is_scalar(self):

--- a/nexus_constructor/field_attrs.py
+++ b/nexus_constructor/field_attrs.py
@@ -57,7 +57,7 @@ class FieldAttrsDialog(QDialog):
     def fill_existing_attrs(self, existing_dataset: Dataset):
         for attr in existing_dataset.attributes:
             if attr.name not in ATTRS_BLACKLIST:
-                frame = FieldAttrFrame(attr.name, attr.values)
+                frame = FieldAttrFrame(attr)
                 self._add_attr(existing_frame=frame)
 
     def __add_attr(self):
@@ -87,7 +87,7 @@ class FieldAttrsDialog(QDialog):
 
 
 class FieldAttrFrame(QFrame):
-    def __init__(self, name=None, value=None, parent=None):
+    def __init__(self, attr=None, parent=None):
         super().__init__(parent)
         self.setMinimumHeight(40)
         self.setLayout(QHBoxLayout())
@@ -104,7 +104,7 @@ class FieldAttrFrame(QFrame):
         self.attr_dtype_combo.addItems([*VALUE_TYPE.keys()])
         self.attr_dtype_combo.currentTextChanged.connect(self.dtype_changed)
         self.dtype_changed(self.attr_dtype_combo.currentText())
-        self.dialog = ArrayDatasetTableWidget(self.dtype)
+        self.dialog = ArrayDatasetTableWidget(VALUE_TYPE[self.dtype])
 
         self.layout().addWidget(self.attr_name_lineedit)
         self.layout().addWidget(self.array_or_scalar_combo)
@@ -114,9 +114,10 @@ class FieldAttrFrame(QFrame):
 
         self.type_changed("Scalar")
 
-        if name is not None and value is not None:
-            self.name = name
-            self.value = value
+        if attr is not None:
+            self.name = attr.name
+            self.value = attr.values
+            self.dtype = attr.type
 
     def type_changed(self, item: str):
         self.attr_value_lineedit.setVisible(item == "Scalar")
@@ -141,7 +142,7 @@ class FieldAttrFrame(QFrame):
 
     @property
     def dtype(self) -> ValueType:
-        return VALUE_TYPE[self.attr_dtype_combo.currentText()]
+        return self.attr_dtype_combo.currentText()
 
     @property
     def is_scalar(self):

--- a/nexus_constructor/field_attrs.py
+++ b/nexus_constructor/field_attrs.py
@@ -82,7 +82,7 @@ class FieldAttrsDialog(QDialog):
         for index in range(self.list_widget.count()):
             item = self.list_widget.item(index)
             widget = self.list_widget.itemWidget(item)
-            attrs_dict[widget.name] = widget.value
+            attrs_dict[widget.name] = (widget.value, widget.dtype)
         return attrs_dict
 
 

--- a/nexus_constructor/field_widget.py
+++ b/nexus_constructor/field_widget.py
@@ -243,8 +243,12 @@ class FieldWidget(QFrame):
             return None
 
         if self.field_type != FieldType.link:
-            for attr_name, attr_value in self.attrs_dialog.get_attrs().items():
-                return_object.set_attribute_value(attr_name, attr_value)
+            for attr_name, attr_tuple in self.attrs_dialog.get_attrs().items():
+                return_object.set_attribute_value(
+                    attribute_name=attr_name,
+                    attribute_value=attr_tuple[0],
+                    attribute_type=attr_tuple[1],
+                )
             if self.units and self.units is not None:
                 return_object.set_attribute_value(CommonAttrs.UNITS, self.units)
         return return_object

--- a/nexus_constructor/model/attribute.py
+++ b/nexus_constructor/model/attribute.py
@@ -24,6 +24,5 @@ class FieldAttribute:
             return self.values == other_attribute.values
         return np.array_equal(self.values, other_attribute.values)
 
-    @staticmethod
-    def as_dict() -> Dict[str, Any]:
-        return {}
+    def as_dict(self) -> Dict[str, Any]:
+        return {"name": self.name, "type": self.type, "values": self.values}

--- a/nexus_constructor/model/attribute.py
+++ b/nexus_constructor/model/attribute.py
@@ -14,8 +14,8 @@ class FieldAttribute:
     """
 
     name = attr.ib(type=str)
-    type = attr.ib(type=str)
     values = attr.ib(type=ValueType, cmp=False)
+    type = attr.ib(type=str, default="String")
 
     def __eq__(self, other_attribute):
         if not self.name == other_attribute.name:

--- a/nexus_constructor/model/attribute.py
+++ b/nexus_constructor/model/attribute.py
@@ -14,6 +14,7 @@ class FieldAttribute:
     """
 
     name = attr.ib(type=str)
+    type = attr.ib(type=str)
     values = attr.ib(type=ValueType, cmp=False)
 
     def __eq__(self, other_attribute):

--- a/nexus_constructor/model/node.py
+++ b/nexus_constructor/model/node.py
@@ -60,11 +60,15 @@ class Node:
     name = attr.ib(type=str)
     attributes = attr.ib(init=False, factory=list)
 
-    def set_attribute_value(self, attribute_name: str, attribute_value: Any):
+    def set_attribute_value(
+        self, attribute_name: str, attribute_value: Any, attribute_type: str = "String"
+    ):
         _set_item(
             self.attributes,
             attribute_name,
-            FieldAttribute(attribute_name, attribute_value),
+            FieldAttribute(
+                name=attribute_name, values=attribute_value, type=attribute_type
+            ),
         )
 
     def get_attribute_value(self, attribute_name: str):

--- a/tests/ui_tests/test_ui_field_attrs.py
+++ b/tests/ui_tests/test_ui_field_attrs.py
@@ -45,7 +45,7 @@ def test_GIVEN_existing_field_with_attr_WHEN_editing_component_THEN_both_field_a
     field_attributes_dialog.fill_existing_attrs(ds)
 
     assert len(field_attributes_dialog.get_attrs()) == 1
-    assert field_attributes_dialog.get_attrs()[attr_key][0] == attr_val
+    assert field_attributes_dialog.get_attrs()[attr_key][0] == str(attr_val)
 
 
 def test_GIVEN_existing_field_with_attr_which_is_in_blacklist_WHEN_editing_component_THEN_attr_is_not_filled_in(

--- a/tests/ui_tests/test_ui_field_attrs.py
+++ b/tests/ui_tests/test_ui_field_attrs.py
@@ -45,7 +45,7 @@ def test_GIVEN_existing_field_with_attr_WHEN_editing_component_THEN_both_field_a
     field_attributes_dialog.fill_existing_attrs(ds)
 
     assert len(field_attributes_dialog.get_attrs()) == 1
-    assert field_attributes_dialog.get_attrs()[attr_key] == attr_val
+    assert field_attributes_dialog.get_attrs()[attr_key][0] == attr_val
 
 
 def test_GIVEN_existing_field_with_attr_which_is_in_blacklist_WHEN_editing_component_THEN_attr_is_not_filled_in(


### PR DESCRIPTION
### Issue

Closes #769 

### Description of work

Storing type information (UI already supported this)
Adding as_dict method for serialisation 

### Acceptance Criteria 

type info is stores + persists
attributes are serialised correctly

### UI tests

Some modified to suit changes

### Nominate for Group Code Review

- [ ] Nominate for code review 
