### PR TITLE
782: Load from JSON prototype

### DIFF
--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -11,7 +11,7 @@ from nexusutils.nexusbuilder import NexusBuilder
 
 from nexus_constructor.add_component_window import AddComponentDialog
 from nexus_constructor.model.component import Component
-from nexus_constructor.ui_utils import file_dialog
+from nexus_constructor.ui_utils import file_dialog, show_warning_dialog
 from nexus_constructor.model.model import Model
 from ui.main_window import Ui_MainWindow
 
@@ -207,27 +207,26 @@ class MainWindow(Ui_MainWindow, QMainWindow):
         #     existing_file.close()
 
     def open_json_file(self):
-        raise NotImplementedError
-        # filename = file_dialog(False, "Open File Writer JSON File", JSON_FILE_TYPES)
-        # if filename:
-        #     with open(filename, "r") as json_file:
-        #         json_data = json_file.read()
-        #
-        #         try:
-        #             nexus_file = json_to_nexus(json_data)
-        #         except Exception as exception:
-        #             show_warning_dialog(
-        #                 "Provided file not recognised as valid JSON",
-        #                 "Invalid JSON",
-        #                 f"{exception}",
-        #                 parent=self,
-        #             )
-        #             return
-        #
-        #         existing_file = self.model.signals.nexus_file
-        #         if self.model.signals.load_nexus_file(nexus_file):
-        #             self._update_views()
-        #             existing_file.close()
+        filename = file_dialog(False, "Open File Writer JSON File", JSON_FILE_TYPES)
+        if filename:
+            with open(filename, "r") as json_file:
+                json_data = json_file.read()
+
+                try:
+                    json.loads(json_data)
+                except ValueError as exception:
+                    show_warning_dialog(
+                        "Provided file not recognised as valid JSON",
+                        "Invalid JSON",
+                        f"{exception}",
+                        parent=self,
+                    )
+                    return
+
+                existing_file = self.model.signals.nexus_file
+                if self.model.signals.load_nexus_file(nexus_file):
+                    self._update_views()
+                    existing_file.close()
 
     def _update_transformations_3d_view(self):
         self.sceneWidget.clear_all_transformations()

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -213,7 +213,7 @@ class MainWindow(Ui_MainWindow, QMainWindow):
                 json_data = json_file.read()
 
                 try:
-                    json_file = json.loads(json_data)
+                    json.loads(json_data)
                 except ValueError as exception:
                     show_warning_dialog(
                         "Provided file not recognised as valid JSON",
@@ -223,7 +223,7 @@ class MainWindow(Ui_MainWindow, QMainWindow):
                     )
                     return
 
-                if self.model.load_json_file(json_file):
+                if self.model.load_json_file(json_data):
                     self._update_views()
 
     def _update_transformations_3d_view(self):

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -223,10 +223,8 @@ class MainWindow(Ui_MainWindow, QMainWindow):
                     )
                     return
 
-                existing_file = self.model.signals.nexus_file
-                if self.model.signals.load_nexus_file(nexus_file):
+                if self.model.signals.load_json_file(json_data):
                     self._update_views()
-                    existing_file.close()
 
     def _update_transformations_3d_view(self):
         self.sceneWidget.clear_all_transformations()

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -213,7 +213,7 @@ class MainWindow(Ui_MainWindow, QMainWindow):
                 json_data = json_file.read()
 
                 try:
-                    json.loads(json_data)
+                    json_file = json.loads(json_data)
                 except ValueError as exception:
                     show_warning_dialog(
                         "Provided file not recognised as valid JSON",
@@ -223,7 +223,7 @@ class MainWindow(Ui_MainWindow, QMainWindow):
                     )
                     return
 
-                if self.model.signals.load_json_file(json_data):
+                if self.model.load_json_file(json_file):
                     self._update_views()
 
     def _update_transformations_3d_view(self):

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -11,6 +11,7 @@ from nexusutils.nexusbuilder import NexusBuilder
 
 from nexus_constructor.add_component_window import AddComponentDialog
 from nexus_constructor.model.component import Component
+from nexus_constructor.model.load_from_json import JSONReader
 from nexus_constructor.ui_utils import file_dialog, show_warning_dialog
 from nexus_constructor.model.model import Model
 from ui.main_window import Ui_MainWindow
@@ -209,22 +210,10 @@ class MainWindow(Ui_MainWindow, QMainWindow):
     def open_json_file(self):
         filename = file_dialog(False, "Open File Writer JSON File", JSON_FILE_TYPES)
         if filename:
-            with open(filename, "r") as json_file:
-                json_data = json_file.read()
-
-                try:
-                    json.loads(json_data)
-                except ValueError as exception:
-                    show_warning_dialog(
-                        "Provided file not recognised as valid JSON",
-                        "Invalid JSON",
-                        f"{exception}",
-                        parent=self,
-                    )
-                    return
-
-                if self.model.load_json_file(json_data):
-                    self._update_views()
+            reader = JSONReader()
+            if reader.load_model_from_json(filename):
+                self.model.entry = reader.entry
+                self._update_views()
 
     def _update_transformations_3d_view(self):
         self.sceneWidget.clear_all_transformations()

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -12,7 +12,7 @@ from nexusutils.nexusbuilder import NexusBuilder
 from nexus_constructor.add_component_window import AddComponentDialog
 from nexus_constructor.model.component import Component
 from nexus_constructor.model.load_from_json import JSONReader
-from nexus_constructor.ui_utils import file_dialog, show_warning_dialog
+from nexus_constructor.ui_utils import file_dialog
 from nexus_constructor.model.model import Model
 from ui.main_window import Ui_MainWindow
 
@@ -210,7 +210,7 @@ class MainWindow(Ui_MainWindow, QMainWindow):
     def open_json_file(self):
         filename = file_dialog(False, "Open File Writer JSON File", JSON_FILE_TYPES)
         if filename:
-            reader = JSONReader()
+            reader = JSONReader(self)
             if reader.load_model_from_json(filename):
                 self.model.entry = reader.entry
                 self._update_views()

--- a/nexus_constructor/model/instrument.py
+++ b/nexus_constructor/model/instrument.py
@@ -18,6 +18,9 @@ class Instrument(Group):
     def get_component_list(self):
         return self.component_list
 
+    def add_component(self, component: Component):
+        self.component_list.append(component)
+
     def remove_component(self, component: Component):
         self.component_list.remove(component)
 

--- a/nexus_constructor/model/load_from_json.py
+++ b/nexus_constructor/model/load_from_json.py
@@ -1,5 +1,4 @@
 import json
-import logging
 from typing import Union
 
 from PySide2.QtWidgets import QWidget
@@ -96,10 +95,10 @@ class JSONReader:
 
             nx_class = _read_nx_class(json_object.get("attributes"))
 
-            if not self._validate_nx_class(nx_class):
+            if nx_class == "NXinstrument":
                 return
 
-            if name == "NXinstrument":
+            if not self._validate_nx_class(nx_class):
                 return
 
             if nx_class == "NXsample":
@@ -111,14 +110,10 @@ class JSONReader:
 
             transformations = _read_transformations(json_object.get("children"))
 
-            if not transformations:
-                self.warnings.append(
-                    "Unable to find transformations entry for component."
-                )
-
-            for transformation in transformations:
-                # todo: transformation reading
-                pass
+            if transformations:
+                for transformation in transformations:
+                    # todo: transformation reading
+                    pass
 
     def _validate_nx_class(self, nx_class: str) -> bool:
 

--- a/nexus_constructor/model/load_from_json.py
+++ b/nexus_constructor/model/load_from_json.py
@@ -97,7 +97,9 @@ class JSONReader:
 
             if self.warnings:
                 show_warning_dialog(
-                    "\n".join(self.warnings), "Warnings encountered loading JSON", parent=self.parent,
+                    "\n".join(self.warnings),
+                    "Warnings encountered loading JSON",
+                    parent=self.parent,
                 )
                 return True
 
@@ -138,7 +140,7 @@ class JSONReader:
 
     def _validate_nx_class(self, name: str, nx_class: str) -> bool:
         """
-        Validates the NXclass by checking if it was found, and if it matches known NXclasses.
+        Validates the NXclass by checking if it was found, and if it matches known NXclasses for components.
         :param nx_class: The NXclass string obtained from the dictionary.
         :return: True if the NXclass is valid, False otherwise.
         """
@@ -147,9 +149,6 @@ class JSONReader:
             return False
 
         if nx_class not in COMPONENT_TYPES:
-            self.warnings.append(
-                f"NXclass value {nx_class} for component {name} does not match any known classes."
-            )
             return False
 
         return True

--- a/nexus_constructor/model/load_from_json.py
+++ b/nexus_constructor/model/load_from_json.py
@@ -97,7 +97,7 @@ class JSONReader:
 
             if self.warnings:
                 show_warning_dialog(
-                    "\n".join(self.warnings), "Invalid JSON", parent=self.parent,
+                    "\n".join(self.warnings), "Warnings encountered loading JSON", parent=self.parent,
                 )
                 return False
 

--- a/nexus_constructor/model/load_from_json.py
+++ b/nexus_constructor/model/load_from_json.py
@@ -31,7 +31,7 @@ def _read_nx_class(entry: Union[list, dict]) -> str:
     """
     Attempts to determine the NXclass of a component in a list/dictionary.
     :param entry: A dictionary of list of a dictionary containing NXclass information.
-    :return:
+    :return: The NXclass if it can be found, otherwise an emtpy string is returned.
     """
     if isinstance(entry, list):
         for item in entry:

--- a/nexus_constructor/model/load_from_json.py
+++ b/nexus_constructor/model/load_from_json.py
@@ -93,7 +93,9 @@ class JSONReader:
                 return False
 
             for child in children_list:
-                self._read_json_object(child)
+                self._read_json_object(
+                    child, json_dict["nexus_structure"]["children"][0].get("name")
+                )
 
             if self.warnings:
                 show_warning_dialog(
@@ -105,7 +107,7 @@ class JSONReader:
 
             return True
 
-    def _read_json_object(self, json_object: dict):
+    def _read_json_object(self, json_object: dict, parent_name: str = None):
         """
         Tries to create a component based on the contents of the JSON file.
         :param json_object:  A component from the JSON dictionary.
@@ -119,7 +121,7 @@ class JSONReader:
             if nx_class == NX_INSTRUMENT:
                 return all(
                     [
-                        self._read_json_object(child)
+                        self._read_json_object(child, name)
                         for child in json_object.get("children")
                     ]
                 )
@@ -136,7 +138,9 @@ class JSONReader:
                 self.entry.instrument.add_component(component)
 
         else:
-            self.warnings.append("Unable to find object name.")
+            self.warnings.append(
+                f"Unable to find object name for child of {parent_name}."
+            )
 
     def _validate_nx_class(self, name: str, nx_class: str) -> bool:
         """

--- a/nexus_constructor/model/load_from_json.py
+++ b/nexus_constructor/model/load_from_json.py
@@ -116,8 +116,10 @@ class JSONReader:
 
             if nx_class == NX_INSTRUMENT:
                 return all(
-                    self._read_json_object(child)
-                    for child in json_object.get("children")
+                    [
+                        self._read_json_object(child)
+                        for child in json_object.get("children")
+                    ]
                 )
 
             if not self._validate_nx_class(name, nx_class):

--- a/nexus_constructor/model/load_from_json.py
+++ b/nexus_constructor/model/load_from_json.py
@@ -1,0 +1,93 @@
+import json
+import logging
+
+from nexus_constructor.model.component import Component
+from nexus_constructor.model.entry import Entry
+from nexus_constructor.model.instrument import Instrument
+from nexus_constructor.ui_utils import show_warning_dialog
+
+IGNORE = ["entry", "instrument", "transformations", "NX_class"]
+
+
+def _read_nx_class(entry: list):
+
+    for item in entry:
+        if item.get("name") == "NX_class":
+            return item.get("values")
+
+    return None
+
+
+def _read_transformations(entry: list):
+
+    for item in entry:
+        if item.get("name") == "transformations":
+            return item.get("children")
+
+    return None
+
+
+class JSONReader:
+    def __init__(self):
+
+        self.entry = Entry()
+        self.entry.instrument = Instrument()
+
+    def load_model_from_json(self, filename: str):
+
+        with open(filename, "r") as json_file:
+            json_data = json_file.read()
+
+            try:
+                json_dict = json.loads(json_data)
+            except ValueError as exception:
+                show_warning_dialog(
+                    "Provided file not recognised as valid JSON",
+                    "Invalid JSON",
+                    f"{exception}",
+                    parent=self,
+                )
+                return False
+
+            try:
+                children_list = json_dict["nexus_structure"]["children"][0]["children"]
+            except KeyError:
+                return False
+
+            return all(self.read_json_object(child) for child in children_list)
+
+    def read_json_object(self, json_entry: dict):
+
+        name = json_entry.get("name")
+
+        if name == "instrument":
+            return True
+
+        elif name and name not in IGNORE:
+
+            nx_class = _read_nx_class(json_entry.get("attributes"))
+
+            if nx_class is None:
+                logging.warning("Unable to determine NXclass.")
+                return False
+
+            elif nx_class == "NX_sample":
+                component = self.entry.instrument.sample
+                component.name = name
+            else:
+                component = Component(name)
+                self.entry.instrument.add_component(component)
+
+            transformations = _read_transformations(json_entry.get("children"))
+
+            if transformations is None:
+                logging.warning("Unable to find transformations entry for component.")
+                return False
+            else:
+                for transformation in transformations:
+                    # todo: transformation reading
+                    pass
+
+            return True
+
+        return False

--- a/nexus_constructor/model/load_from_json.py
+++ b/nexus_constructor/model/load_from_json.py
@@ -127,6 +127,7 @@ class JSONReader:
                 component.name = name
             else:
                 component = Component(name)
+                component.nx_class = nx_class
                 self.entry.instrument.add_component(component)
 
         else:

--- a/nexus_constructor/model/load_from_json.py
+++ b/nexus_constructor/model/load_from_json.py
@@ -28,14 +28,16 @@ def _read_transformations(entry: list):
 
 
 class JSONReader:
-    def __init__(self):
+    def __init__(self, parent):
 
         self.entry = Entry()
         self.entry.instrument = Instrument()
+        self.parent = parent
 
     def load_model_from_json(self, filename: str):
 
         with open(filename, "r") as json_file:
+
             json_data = json_file.read()
 
             try:
@@ -45,7 +47,7 @@ class JSONReader:
                     "Provided file not recognised as valid JSON",
                     "Invalid JSON",
                     f"{exception}",
-                    parent=self,
+                    self.parent,
                 )
                 return False
 
@@ -54,9 +56,9 @@ class JSONReader:
             except KeyError:
                 return False
 
-            return all(self.read_json_object(child) for child in children_list)
+            return all(self._read_json_object(child) for child in children_list)
 
-    def read_json_object(self, json_entry: dict):
+    def _read_json_object(self, json_entry: dict):
 
         name = json_entry.get("name")
 

--- a/nexus_constructor/model/load_from_json.py
+++ b/nexus_constructor/model/load_from_json.py
@@ -37,6 +37,19 @@ def _retrieve_children_list(json_dict: dict) -> list:
         return []
 
 
+def _validate_nx_class(nx_class: str) -> bool:
+
+    if not nx_class:
+        logging.warning("Unable to determine NXclass.")
+        return False
+
+    if nx_class not in COMPONENT_TYPES:
+        logging.warning("NXclass does not match any known classes.")
+        return False
+
+    return True
+
+
 class JSONReader:
     def __init__(self, parent: QWidget):
 
@@ -80,12 +93,7 @@ class JSONReader:
 
             nx_class = _read_nx_class(json_object.get("attributes"))
 
-            if nx_class is None:
-                logging.warning("Unable to determine NXclass.")
-                return False
-
-            if nx_class not in COMPONENT_TYPES:
-                logging.warning("NXclass does not match any known classes.")
+            if not _validate_nx_class(nx_class):
                 return False
 
             if nx_class == "NXsample":

--- a/nexus_constructor/model/load_from_json.py
+++ b/nexus_constructor/model/load_from_json.py
@@ -9,16 +9,30 @@ from nexus_constructor.model.entry import Entry
 from nexus_constructor.model.instrument import Instrument
 from nexus_constructor.ui_utils import show_warning_dialog
 
+NX_CLASS = "NX_class"
+NX_INSTRUMENT = "NXInstrument"
+NX_SAMPLE = "NXsample"
+
 
 def _find_nx_class(entry: dict) -> str:
-    if entry.get("name") == "NX_class":
+    """
+    Attempts to find the NXclass of a component in the dictionary.
+    :param entry: The dictionary containing the NXclass information for a given component.
+    :return: The NXclass if it was able to find it, otherwise an empty string is returned.
+    """
+    if entry.get("name") == NX_CLASS:
         return entry.get("values")
-    if entry.get("NX_class"):
-        return entry.get("NX_class")
+    if entry.get(NX_CLASS):
+        return entry.get(NX_CLASS)
     return ""
 
 
 def _read_nx_class(entry: Union[list, dict]) -> str:
+    """
+    Attempts to determine the NXclass of a component in a list/dictionary.
+    :param entry: A dictionary of list of a dictionary containing NXclass information.
+    :return:
+    """
     if isinstance(entry, list):
         for item in entry:
             return _find_nx_class(item)
@@ -26,15 +40,12 @@ def _read_nx_class(entry: Union[list, dict]) -> str:
         return _find_nx_class(entry)
 
 
-def _read_transformations(entry: list):
-    for item in entry:
-        if item.get("name") == "transformations":
-            return item.get("children")
-
-    return None
-
-
 def _retrieve_children_list(json_dict: dict) -> list:
+    """
+    Attempts to retrieve the children from the JSON dictionary.
+    :param json_dict: The JSON dictionary loaded by the user.
+    :return: The children value is returned if it was found, otherwise an empty list is returned.
+    """
     try:
         return json_dict["nexus_structure"]["children"][0]["children"]
     except (KeyError, IndexError, TypeError):
@@ -50,7 +61,11 @@ class JSONReader:
         self.warnings = []
 
     def load_model_from_json(self, filename: str) -> bool:
-
+        """
+        Tries to load a model from a JSON file.
+        :param filename: The filename of the JSON file.
+        :return: True if the model was loaded without problems, False otherwise.
+        """
         with open(filename, "r") as json_file:
 
             json_data = json_file.read()
@@ -88,41 +103,45 @@ class JSONReader:
             return True
 
     def _read_json_object(self, json_object: dict):
-
+        """
+        Tries to create a component based on the contents of the JSON file.
+        :param json_object:  A component from the JSON dictionary.
+        """
         name = json_object.get("name")
 
         if name:
 
             nx_class = _read_nx_class(json_object.get("attributes"))
 
-            if nx_class == "NXinstrument":
+            if nx_class == NX_INSTRUMENT:
                 return
 
-            if not self._validate_nx_class(nx_class):
+            if not self._validate_nx_class(name, nx_class):
                 return
 
-            if nx_class == "NXsample":
+            if nx_class == NX_SAMPLE:
                 component = self.entry.instrument.sample
                 component.name = name
             else:
                 component = Component(name)
                 self.entry.instrument.add_component(component)
+        else:
+            self.warnings.append("Unable to find object name.")
 
-            transformations = _read_transformations(json_object.get("children"))
-
-            if transformations:
-                for transformation in transformations:
-                    # todo: transformation reading
-                    pass
-
-    def _validate_nx_class(self, nx_class: str) -> bool:
-
+    def _validate_nx_class(self, name: str, nx_class: str) -> bool:
+        """
+        Validates the NXclass by checking if it was found, and if it matches known NXclasses.
+        :param nx_class: The NXclass string obtained from the dictionary.
+        :return: True if the NXclass is valid, False otherwise.
+        """
         if not nx_class:
-            self.warnings.append("Unable to determine NXclass.")
+            self.warnings.append(f"Unable to determine NXclass of component {name}.")
             return False
 
         if nx_class not in COMPONENT_TYPES:
-            self.warnings.append("NXclass does not match any known classes.")
+            self.warnings.append(
+                f"NXclass value {nx_class} for component {name} does not match any known classes."
+            )
             return False
 
         return True

--- a/nexus_constructor/model/load_from_json.py
+++ b/nexus_constructor/model/load_from_json.py
@@ -10,7 +10,7 @@ from nexus_constructor.model.instrument import Instrument
 from nexus_constructor.ui_utils import show_warning_dialog
 
 NX_CLASS = "NX_class"
-NX_INSTRUMENT = "NXInstrument"
+NX_INSTRUMENT = "NXinstrument"
 NX_SAMPLE = "NXsample"
 
 
@@ -114,7 +114,10 @@ class JSONReader:
             nx_class = _read_nx_class(json_object.get("attributes"))
 
             if nx_class == NX_INSTRUMENT:
-                return
+                return all(
+                    self._read_json_object(child)
+                    for child in json_object.get("children")
+                )
 
             if not self._validate_nx_class(name, nx_class):
                 return
@@ -125,6 +128,7 @@ class JSONReader:
             else:
                 component = Component(name)
                 self.entry.instrument.add_component(component)
+
         else:
             self.warnings.append("Unable to find object name.")
 

--- a/nexus_constructor/model/load_from_json.py
+++ b/nexus_constructor/model/load_from_json.py
@@ -9,7 +9,7 @@ from nexus_constructor.model.entry import Entry
 from nexus_constructor.model.instrument import Instrument
 from nexus_constructor.ui_utils import show_warning_dialog
 
-IGNORE = ["entry", "instrument", "transformations", "NX_class"]
+IGNORE = ["entry", "transformations", "NX_class"]
 
 
 def _read_nx_class(entry: list) -> str:

--- a/nexus_constructor/model/load_from_json.py
+++ b/nexus_constructor/model/load_from_json.py
@@ -99,7 +99,7 @@ class JSONReader:
                 show_warning_dialog(
                     "\n".join(self.warnings), "Warnings encountered loading JSON", parent=self.parent,
                 )
-                return False
+                return True
 
             return True
 

--- a/nexus_constructor/model/load_from_json.py
+++ b/nexus_constructor/model/load_from_json.py
@@ -1,6 +1,8 @@
 import json
 import logging
 
+from PySide2.QtWidgets import QWidget
+
 from nexus_constructor.model.component import Component
 from nexus_constructor.model.entry import Entry
 from nexus_constructor.model.instrument import Instrument
@@ -9,17 +11,15 @@ from nexus_constructor.ui_utils import show_warning_dialog
 IGNORE = ["entry", "instrument", "transformations", "NX_class"]
 
 
-def _read_nx_class(entry: list):
-
+def _read_nx_class(entry: list) -> str:
     for item in entry:
         if item.get("name") == "NX_class":
             return item.get("values")
 
-    return None
+    return ""
 
 
 def _read_transformations(entry: list):
-
     for item in entry:
         if item.get("name") == "transformations":
             return item.get("children")
@@ -27,14 +27,21 @@ def _read_transformations(entry: list):
     return None
 
 
+def _retrieve_children_list(json_dict: dict) -> list:
+    try:
+        return json_dict["nexus_structure"]["children"][0]["children"]
+    except (KeyError, IndexError):
+        return []
+
+
 class JSONReader:
-    def __init__(self, parent):
+    def __init__(self, parent: QWidget):
 
         self.entry = Entry()
         self.entry.instrument = Instrument()
         self.parent = parent
 
-    def load_model_from_json(self, filename: str):
+    def load_model_from_json(self, filename: str) -> bool:
 
         with open(filename, "r") as json_file:
 
@@ -51,23 +58,24 @@ class JSONReader:
                 )
                 return False
 
-            try:
-                children_list = json_dict["nexus_structure"]["children"][0]["children"]
-            except KeyError:
+            children_list = _retrieve_children_list(json_dict)
+
+            if not children_list:
+                logging.info("Unable to locate components in JSON file.")
                 return False
 
             return all(self._read_json_object(child) for child in children_list)
 
-    def _read_json_object(self, json_entry: dict):
+    def _read_json_object(self, json_object: dict) -> bool:
 
-        name = json_entry.get("name")
+        name = json_object.get("name")
 
         if name == "instrument":
             return True
 
         elif name and name not in IGNORE:
 
-            nx_class = _read_nx_class(json_entry.get("attributes"))
+            nx_class = _read_nx_class(json_object.get("attributes"))
 
             if nx_class is None:
                 logging.warning("Unable to determine NXclass.")
@@ -80,15 +88,15 @@ class JSONReader:
                 component = Component(name)
                 self.entry.instrument.add_component(component)
 
-            transformations = _read_transformations(json_entry.get("children"))
+            transformations = _read_transformations(json_object.get("children"))
 
-            if transformations is None:
-                logging.warning("Unable to find transformations entry for component.")
+            if not transformations:
+                logging.info("Unable to find transformations entry for component.")
                 return False
-            else:
-                for transformation in transformations:
-                    # todo: transformation reading
-                    pass
+
+            for transformation in transformations:
+                # todo: transformation reading
+                pass
 
             return True
 

--- a/nexus_constructor/model/model.py
+++ b/nexus_constructor/model/model.py
@@ -1,6 +1,5 @@
 from PySide2.QtCore import QObject, Signal
 from typing import Dict, Any
-
 from nexus_constructor.model.entry import Entry
 
 
@@ -21,7 +20,6 @@ class Model:
     def __init__(self, entry: Entry):
         self.signals = Signals()
         self.entry = entry
-        self.temp_entry = None
 
     def as_dict(self) -> Dict[str, Any]:
         return {"nexus_structure": {"children": [self.entry.as_dict()]}}

--- a/nexus_constructor/model/model.py
+++ b/nexus_constructor/model/model.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 from PySide2.QtCore import QObject, Signal
 from typing import Dict, Any
@@ -13,8 +14,17 @@ ignore = ["entry", "instrument", "transformations", "NX_class"]
 def _parse_nx_class(entry: list):
 
     for item in entry:
-        if item.get("NX_class"):
+        if item.get("name") == "NX_class":
             return item.get("values")
+
+    return None
+
+
+def _parse_transformations(entry: list):
+
+    for item in entry:
+        if item.get("name") == "transformations":
+            return item.get("children")
 
     return None
 
@@ -72,6 +82,7 @@ class Model:
             nx_class = _parse_nx_class(json_entry.get("attributes"))
 
             if nx_class is None:
+                logging.warning("Unable to determine NXclass.")
                 return False
 
             elif nx_class == "NX_sample":
@@ -81,7 +92,15 @@ class Model:
                 component = Component(name)
                 self.temp_entry.instrument.add_component(component)
 
-            # todo: recover transformations
+            transformations = _parse_transformations(json_entry.get("children"))
+
+            if transformations is None:
+                logging.warning("Unable to find transformations entry for component.")
+                return False
+            else:
+                for transformation in transformations:
+                    # todo: transformation reading
+                    pass
 
             return True
 

--- a/nexus_constructor/model/model.py
+++ b/nexus_constructor/model/model.py
@@ -6,6 +6,8 @@ from typing import Dict, Any
 from nexus_constructor.model.entry import Entry
 from nexus_constructor.model.instrument import Instrument
 
+ignore = ["entry", "instrument"]
+
 
 class Signals(QObject):
     """
@@ -44,15 +46,4 @@ class Model:
             return False
 
     def parse_json(self, json_entry: dict):
-
-        name = json_entry.get("name")
-
-        if name == "nexus_structure":
-            self.parse_json(json_entry.get("children"))
-        elif name == "entry":
-            print(json_entry)
-        elif name == "instrument":
-            print(json_entry)
-        elif name == "transformations":
-            for child in json_entry.get("children"):
-                self.parse_json(child)
+        pass

--- a/nexus_constructor/model/model.py
+++ b/nexus_constructor/model/model.py
@@ -14,6 +14,7 @@ class Signals(QObject):
     component_removed = Signal(str)
     transformation_changed = Signal()
     show_entries_dialog = Signal("QVariant", "QVariant")
+    load_json_file = Signal(str)
 
 
 class Model:

--- a/nexus_constructor/model/model.py
+++ b/nexus_constructor/model/model.py
@@ -1,6 +1,7 @@
 from PySide2.QtCore import QObject, Signal
 from typing import Dict, Any
 from nexus_constructor.model.entry import Entry
+from nexus_constructor.model.instrument import Instrument
 
 
 class Signals(QObject):
@@ -14,7 +15,11 @@ class Signals(QObject):
     component_removed = Signal(str)
     transformation_changed = Signal()
     show_entries_dialog = Signal("QVariant", "QVariant")
-    load_json_file = Signal(str)
+
+
+def as_instrument(dct):
+    if dct["name"] == "instrument":
+        return Instrument()
 
 
 class Model:
@@ -24,3 +29,6 @@ class Model:
 
     def as_dict(self) -> Dict[str, Any]:
         return {"nexus_structure": {"children": [self.entry.as_dict()]}}
+
+    def load_json_file(self, json_file: dict):
+        return False

--- a/nexus_constructor/model/model.py
+++ b/nexus_constructor/model/model.py
@@ -1,5 +1,8 @@
+import json
+
 from PySide2.QtCore import QObject, Signal
 from typing import Dict, Any
+
 from nexus_constructor.model.entry import Entry
 from nexus_constructor.model.instrument import Instrument
 
@@ -17,18 +20,39 @@ class Signals(QObject):
     show_entries_dialog = Signal("QVariant", "QVariant")
 
 
-def as_instrument(dct):
-    if dct["name"] == "instrument":
-        return Instrument()
-
-
 class Model:
     def __init__(self, entry: Entry):
         self.signals = Signals()
         self.entry = entry
+        self.temp_entry = None
 
     def as_dict(self) -> Dict[str, Any]:
         return {"nexus_structure": {"children": [self.entry.as_dict()]}}
 
-    def load_json_file(self, json_file: dict):
-        return False
+    def load_json_file(self, json_data: str):
+
+        self.temp_entry = Entry()
+        self.entry.instrument = Instrument()
+
+        entry = json.loads(json_data, object_hook=self.parse_json)
+
+        if entry is not None:
+            self.entry = self.temp_entry
+            self.temp_entry = None
+            return True
+        else:
+            return False
+
+    def parse_json(self, json_entry: dict):
+
+        name = json_entry.get("name")
+
+        if name == "nexus_structure":
+            self.parse_json(json_entry.get("children"))
+        elif name == "entry":
+            print(json_entry)
+        elif name == "instrument":
+            print(json_entry)
+        elif name == "transformations":
+            for child in json_entry.get("children"):
+                self.parse_json(child)

--- a/nexus_constructor/model/model.py
+++ b/nexus_constructor/model/model.py
@@ -3,10 +3,20 @@ import json
 from PySide2.QtCore import QObject, Signal
 from typing import Dict, Any
 
+from nexus_constructor.model.component import Component
 from nexus_constructor.model.entry import Entry
 from nexus_constructor.model.instrument import Instrument
 
-ignore = ["entry", "instrument"]
+ignore = ["entry", "instrument", "transformations", "NX_class"]
+
+
+def _parse_nx_class(entry: list):
+
+    for item in entry:
+        if item.get("NX_class"):
+            return item.get("values")
+
+    return None
 
 
 class Signals(QObject):
@@ -34,11 +44,16 @@ class Model:
     def load_json_file(self, json_data: str):
 
         self.temp_entry = Entry()
-        self.entry.instrument = Instrument()
+        self.temp_entry.instrument = Instrument()
 
-        entry = json.loads(json_data, object_hook=self.parse_json)
+        json_dict = json.loads(json_data)
 
-        if entry is not None:
+        try:
+            children_list = json_dict["nexus_structure"]["children"][0]["children"]
+        except KeyError:
+            return False
+
+        if all(self.parse_json(child) for child in children_list):
             self.entry = self.temp_entry
             self.temp_entry = None
             return True
@@ -46,4 +61,28 @@ class Model:
             return False
 
     def parse_json(self, json_entry: dict):
-        pass
+
+        name = json_entry.get("name")
+
+        if name == "instrument":
+            return True
+
+        elif name and name not in ignore:
+
+            nx_class = _parse_nx_class(json_entry.get("attributes"))
+
+            if nx_class is None:
+                return False
+
+            elif nx_class == "NX_sample":
+                component = self.temp_entry.instrument.sample
+                component.name = name
+            else:
+                component = Component(name)
+                self.temp_entry.instrument.add_component(component)
+
+            # todo: recover transformations
+
+            return True
+
+        return False

--- a/tests/ui_tests/test_load_from_json.py
+++ b/tests/ui_tests/test_load_from_json.py
@@ -30,12 +30,10 @@ def test_GIVEN_json_with_missing_value_WHEN_loading_from_json_THEN_json_loader_r
               {
                 "name": "instrument",
                 "type": "group",
-                "attributes": [
+                "attributes":
                   {
-                    "name":  "NX_class",
-                    "values":  "NXinstrument"
-                  }
-                ],
+                    "NX_class":  "NXinstrument"
+                  },
                 "children": []
               },
               {
@@ -66,11 +64,11 @@ def test_GIVEN_json_with_missing_value_WHEN_loading_from_json_THEN_json_loader_r
         assert not json_reader.load_model_from_json("")
 
 
-def test_GIVEN_unable_to_find_children_field_WHEN_loading_from_json_THEN_json_loader_returns_false(json_reader):
+def test_GIVEN_unable_to_find_nexus_structure_field_WHEN_loading_from_json_THEN_json_loader_returns_false(json_reader):
 
     json_string = """
     {
-      "nexus_structure": {
+      "crumpet": {
         "children": [
           {
             "name": "entry",
@@ -81,16 +79,14 @@ def test_GIVEN_unable_to_find_children_field_WHEN_loading_from_json_THEN_json_lo
                 "values":  "NXentry"
               }
             ],
-            "crumpet": [
+            "children": [
               {
                 "name": "instrument",
                 "type": "group",
-                "attributes": [
+                "attributes":
                   {
-                    "name":  "NX_class",
-                    "values":  "NXinstrument"
-                  }
-                ],
+                    "NX_class":  "NXinstrument"
+                  },
                 "children": []
               },
               {
@@ -121,3 +117,165 @@ def test_GIVEN_unable_to_find_children_field_WHEN_loading_from_json_THEN_json_lo
         assert not json_reader.load_model_from_json("")
 
     assert not _retrieve_children_list(json.loads(json_string))
+
+
+def test_GIVEN_unable_to_find_first_children_field_WHEN_loading_from_json_THEN_json_loader_returns_false(json_reader):
+
+    json_string = """
+    {
+      "nexus_structure": {
+        "crumpet": [
+          {
+            "name": "entry",
+            "type": "group",
+            "attributes": [
+              {
+                "name":  "NX_class",
+                "values":  "NXentry"
+              }
+            ],
+            "children": [
+              {
+                "name": "instrument",
+                "type": "group",
+                "attributes":
+                  {
+                    "NX_class":  "NXinstrument"
+                  },
+                "children": []
+              },
+              {
+                "name": "sample",
+                "type": "group",
+                "attributes": [
+                  {
+                    "name":  "NX_class",
+                    "values":  "NXsample"
+                  }
+                ],
+                "children": [
+                  {
+                    "type": "group",
+                    "name": "transformations",
+                    "children": []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+    """
+
+    with patch('nexus_constructor.model.load_from_json.open', mock_open(read_data=json_string), create=True):
+        assert not json_reader.load_model_from_json("")
+
+    assert not _retrieve_children_list(json.loads(json_string))
+
+
+def test_GIVEN_unable_to_find_second_children_field_WHEN_loading_from_json_THEN_json_loader_returns_false(json_reader):
+
+    json_string = """
+    {
+      "nexus_structure": {
+        "children": [
+          {
+            "name": "entry",
+            "type": "group",
+            "attributes": [
+              {
+                "name":  "NX_class",
+                "values":  "NXentry"
+              }
+            ],
+            "crumpet": [
+              {
+                "name": "instrument",
+                "type": "group",
+                "attributes":
+                  {
+                    "NX_class":  "NXinstrument"
+                  },
+                "children": []
+              },
+              {
+                "name": "sample",
+                "type": "group",
+                "attributes": [
+                  {
+                    "name":  "NX_class",
+                    "values":  "NXsample"
+                  }
+                ],
+                "children": [
+                  {
+                    "type": "group",
+                    "name": "transformations",
+                    "children": []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+    """
+
+    with patch('nexus_constructor.model.load_from_json.open', mock_open(read_data=json_string), create=True):
+        assert not json_reader.load_model_from_json("")
+
+    assert not _retrieve_children_list(json.loads(json_string))
+
+
+def test_GIVEN_no_nx_class_for_component_WHEN_loading_from_json_THEN_json_loader_returns_false(json_reader):
+
+    json_string = """
+    {
+      "nexus_structure": {
+        "children": [
+          {
+            "name": "entry",
+            "type": "group",
+            "attributes": [
+              {
+                "name":  "NX_class",
+                "values":  "NXentry"
+              }
+            ],
+            "children": [
+              {
+                "name": "instrument",
+                "type": "group",
+                "attributes":
+                  {
+                    "NX_class":  "NXinstrument"
+                  },
+                "children": []
+              },
+              {
+                "name": "sample",
+                "type": "group",
+                "attributes": [
+                  {
+                    "name":  "NX_class"
+                  }
+                ],
+                "children": [
+                  {
+                    "type": "group",
+                    "name": "transformations",
+                    "children": []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+    """
+
+    with patch('nexus_constructor.model.load_from_json.open', mock_open(read_data=json_string), create=True):
+        assert not json_reader.load_model_from_json("")

--- a/tests/ui_tests/test_load_from_json.py
+++ b/tests/ui_tests/test_load_from_json.py
@@ -66,6 +66,92 @@ def nexus_json_dictionary() -> dict:
     return json.loads(json_string)
 
 
+@pytest.fixture(scope="function")
+def json_dict_with_component():
+
+    json_string = """
+    {
+        "nexus_structure": {
+            "children": [
+                {
+                    "name": "entry",
+                    "type": "group",
+                    "attributes": [
+                        {
+                            "name": "NX_class",
+                            "type": "String",
+                            "values": "NXentry"
+                        }
+                    ],
+                    "children": [
+                        {
+                            "name": "instrument",
+                            "type": "group",
+                            "attributes": [
+                                {
+                                    "name": "NX_class",
+                                    "type": "String",
+                                    "values": "NXinstrument"
+                                }
+                            ],
+                            "children": [
+                                {
+                                    "name": "componentname",
+                                    "type": "group",
+                                    "attributes": [
+                                        {
+                                            "name": "NX_class",
+                                            "type": "String",
+                                            "values": "NXaperture"
+                                        },
+                                        {
+                                            "name": "has_link",
+                                            "type": "String",
+                                            "values": false
+                                        }
+                                    ],
+                                    "children": [
+                                        {
+                                            "name": "description",
+                                            "type": "dataset",
+                                            "attributes": []
+                                        },
+                                        {
+                                            "type": "group",
+                                            "name": "transformations",
+                                            "children": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "sample",
+                            "type": "group",
+                            "attributes": [
+                                {
+                                    "name": "NX_class",
+                                    "type": "String",
+                                    "values": "NXsample"
+                                }
+                            ],
+                            "children": [
+                                {
+                                    "type": "group",
+                                    "name": "transformations",
+                                    "children": []
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+    """
+    return json.loads(json_string)
+
+
 def test_GIVEN_json_with_missing_value_WHEN_loading_from_json_THEN_json_loader_returns_false(
     json_reader,
 ):
@@ -203,4 +289,16 @@ def test_GIVEN_no_nx_instrument_class_WHEN_loading_from_json_THEN_read_json_obje
     assert not json_reader._read_json_object(nx_instrument)
 
 
-# todo: component name test
+def test_GIVEN_component_with_name_WHEN_loading_from_json_THEN_new_model_contains_component_with_json_name(
+    json_dict_with_component, json_reader
+):
+
+    component_name = "ComponentName"
+    json_dict_with_component["nexus_structure"]["children"][0]["children"][0][
+        "children"
+    ][0]["name"] = component_name
+    json_reader._read_json_object(
+        json_dict_with_component["nexus_structure"]["children"][0]["children"][0]
+    )
+
+    assert json_reader.entry.instrument.component_list[1].name == component_name

--- a/tests/ui_tests/test_load_from_json.py
+++ b/tests/ui_tests/test_load_from_json.py
@@ -61,4 +61,58 @@ def test_GIVEN_json_with_missing_value_WHEN_loading_from_json_THEN_json_loader_r
     """
 
     with patch('nexus_constructor.model.load_from_json.open', mock_open(read_data=json_string), create=True):
-        assert not json_reader.load_model_from_json("filename")
+        assert not json_reader.load_model_from_json("")
+
+def test_GIVEN_unable_to_find_children_field_WHEN_loading_from_json_THEN_json_loader_returns_false(json_reader):
+
+    json_string = """
+    {
+      "nexus_structure": {
+        "children": [
+          {
+            "name": "entry",
+            "type": "group",
+            "attributes": [
+              {
+                "name":  "NX_class",
+                "values":  "NXentry"
+              }
+            ],
+            "crumpet": [
+              {
+                "name": "instrument",
+                "type": "group",
+                "attributes": [
+                  {
+                    "name":  "NX_class",
+                    "values":  "NXinstrument"
+                  }
+                ],
+                "children": []
+              },
+              {
+                "name": "sample",
+                "type": "group",
+                "attributes": [
+                  {
+                    "name":  "NX_class",
+                    "values":  "NXsample"
+                  }
+                ],
+                "children": [
+                  {
+                    "type": "group",
+                    "name": "transformations",
+                    "children": []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+    """
+
+    with patch('nexus_constructor.model.load_from_json.open', mock_open(read_data=json_string), create=True):
+        assert not json_reader.load_model_from_json("")

--- a/tests/ui_tests/test_load_from_json.py
+++ b/tests/ui_tests/test_load_from_json.py
@@ -7,7 +7,6 @@ from nexus_constructor.model.load_from_json import (
     JSONReader,
     _retrieve_children_list,
     _read_nx_class,
-    _validate_nx_class,
 )
 
 
@@ -170,9 +169,9 @@ def test_GIVEN_nx_class_in_different_formats_WHEN_reading_class_information_THEN
 
 @pytest.mark.parametrize("nx_class", ["", "notannxclass"])
 def test_GIVEN_invalid_nx_class_WHEN_obtained_nx_class_value_THEN_validate_nx_class_returns_false(
-    nx_class,
+    nx_class, json_reader
 ):
-    assert not _validate_nx_class(nx_class)
+    assert not json_reader._validate_nx_class(nx_class)
 
 
 def test_GIVEN_json_with_sample_WHEN_loading_from_json_THEN_new_model_contains_new_sample_name(
@@ -190,3 +189,15 @@ def test_GIVEN_json_with_sample_WHEN_loading_from_json_THEN_new_model_contains_n
         json_reader._read_json_object(child)
 
     assert json_reader.entry.instrument.sample.name == sample_name
+
+
+def test_GIVEN_no_nx_instrument_class_WHEN_loading_from_json_THEN_read_json_object_returns_false(
+    nexus_json_dictionary, json_reader
+):
+
+    nx_instrument = nexus_json_dictionary["nexus_structure"]["children"][0]["children"][
+        0
+    ]
+    nx_instrument["attributes"]["NX_class"] = None
+
+    assert not json_reader._read_json_object(nx_instrument)

--- a/tests/ui_tests/test_load_from_json.py
+++ b/tests/ui_tests/test_load_from_json.py
@@ -11,6 +11,57 @@ def json_reader(template):
     return JSONReader(template)
 
 
+@pytest.fixture(scope="function")
+def nexus_json_dictionary():
+    json_string = """
+    {
+      "nexus_structure": {
+        "children": [
+          {
+            "name": "entry",
+            "type": "group",
+            "attributes": [
+              {
+                "name":  "NX_class",
+                "values":  "NXentry"
+              }
+            ],
+            "children": [
+              {
+                "name": "instrument",
+                "type": "group",
+                "attributes":
+                  {
+                    "NX_class":  "NXinstrument"
+                  },
+                "children": []
+              },
+              {
+                "name": "sample",
+                "type": "group",
+                "attributes": [
+                  {
+                    "name":  "NX_class",
+                    "values":  "NXsample"
+                  }
+                ],
+                "children": [
+                  {
+                    "type": "group",
+                    "name": "transformations",
+                    "children": []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+    """
+    return json.loads(json_string)
+
+
 def test_GIVEN_json_with_missing_value_WHEN_loading_from_json_THEN_json_loader_returns_false(json_reader):
 
     json_string = """

--- a/tests/ui_tests/test_load_from_json.py
+++ b/tests/ui_tests/test_load_from_json.py
@@ -1,0 +1,64 @@
+import pytest
+from mock import patch, mock_open
+
+from nexus_constructor.model.load_from_json import JSONReader
+
+
+@pytest.fixture(scope="function")
+def json_reader(template):
+    return JSONReader(template)
+
+
+def test_GIVEN_invalid_json_WHEN_loading_from_json_THEN_json_loader_returns_false(json_reader):
+
+    json_string = """
+    {
+      "nexus_structure": {
+        "children": [
+          {
+            "name":,
+            "type": "group",
+            "attributes": [
+              {
+                "name":  "NX_class",
+                "values":  "NXentry"
+              }
+            ],
+            "children": [
+              {
+                "name": "instrument",
+                "type": "group",
+                "attributes": [
+                  {
+                    "name":  "NX_class",
+                    "values":  "NXinstrument"
+                  }
+                ],
+                "children": []
+              },
+              {
+                "name": "wedgie",
+                "type": "group",
+                "attributes": [
+                  {
+                    "name":  "NX_class",
+                    "values":  "NXsample"
+                  }
+                ],
+                "children": [
+                  {
+                    "type": "group",
+                    "name": "transformations",
+                    "children": []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+    """
+
+    with patch('nexus_constructor.model.load_from_json.open', mock_open(read_data=json_string), create=True):
+        assert not json_reader.load_model_from_json("filename")

--- a/tests/ui_tests/test_load_from_json.py
+++ b/tests/ui_tests/test_load_from_json.py
@@ -171,7 +171,7 @@ def test_GIVEN_nx_class_in_different_formats_WHEN_reading_class_information_THEN
 def test_GIVEN_invalid_nx_class_WHEN_obtained_nx_class_value_THEN_validate_nx_class_returns_false(
     nx_class, json_reader
 ):
-    assert not json_reader._validate_nx_class(nx_class)
+    assert not json_reader._validate_nx_class("name", nx_class)
 
 
 def test_GIVEN_json_with_sample_WHEN_loading_from_json_THEN_new_model_contains_new_sample_name(
@@ -201,5 +201,6 @@ def test_GIVEN_no_nx_instrument_class_WHEN_loading_from_json_THEN_read_json_obje
     nx_instrument["attributes"]["NX_class"] = None
 
     assert not json_reader._read_json_object(nx_instrument)
+
 
 # todo: component name test

--- a/tests/ui_tests/test_load_from_json.py
+++ b/tests/ui_tests/test_load_from_json.py
@@ -302,3 +302,17 @@ def test_GIVEN_component_with_name_WHEN_loading_from_json_THEN_new_model_contain
     )
 
     assert json_reader.entry.instrument.component_list[1].name == component_name
+
+
+def test_GIVEN_component_with_nx_class_WHEN_loading_from_json_THEN_new_model_contains_component_with_nx_class(
+    json_dict_with_component, json_reader
+):
+    component_class = "NXcrystal"
+    json_dict_with_component["nexus_structure"]["children"][0]["children"][0][
+        "children"
+    ][0]["attributes"][0]["values"] = component_class
+    json_reader._read_json_object(
+        json_dict_with_component["nexus_structure"]["children"][0]["children"][0]
+    )
+
+    assert json_reader.entry.instrument.component_list[1].nx_class == component_class

--- a/tests/ui_tests/test_load_from_json.py
+++ b/tests/ui_tests/test_load_from_json.py
@@ -1,7 +1,9 @@
+import json
+
 import pytest
 from mock import patch, mock_open
 
-from nexus_constructor.model.load_from_json import JSONReader
+from nexus_constructor.model.load_from_json import JSONReader, _retrieve_children_list
 
 
 @pytest.fixture(scope="function")
@@ -63,6 +65,7 @@ def test_GIVEN_json_with_missing_value_WHEN_loading_from_json_THEN_json_loader_r
     with patch('nexus_constructor.model.load_from_json.open', mock_open(read_data=json_string), create=True):
         assert not json_reader.load_model_from_json("")
 
+
 def test_GIVEN_unable_to_find_children_field_WHEN_loading_from_json_THEN_json_loader_returns_false(json_reader):
 
     json_string = """
@@ -116,3 +119,5 @@ def test_GIVEN_unable_to_find_children_field_WHEN_loading_from_json_THEN_json_lo
 
     with patch('nexus_constructor.model.load_from_json.open', mock_open(read_data=json_string), create=True):
         assert not json_reader.load_model_from_json("")
+
+    assert not _retrieve_children_list(json.loads(json_string))

--- a/tests/ui_tests/test_load_from_json.py
+++ b/tests/ui_tests/test_load_from_json.py
@@ -3,16 +3,20 @@ import json
 import pytest
 from mock import patch, mock_open
 
-from nexus_constructor.model.load_from_json import JSONReader, _retrieve_children_list
+from nexus_constructor.model.load_from_json import (
+    JSONReader,
+    _retrieve_children_list,
+    _read_nx_class,
+)
 
 
 @pytest.fixture(scope="function")
-def json_reader(template):
+def json_reader(template) -> JSONReader:
     return JSONReader(template)
 
 
 @pytest.fixture(scope="function")
-def nexus_json_dictionary():
+def nexus_json_dictionary() -> dict:
     json_string = """
     {
       "nexus_structure": {
@@ -62,7 +66,9 @@ def nexus_json_dictionary():
     return json.loads(json_string)
 
 
-def test_GIVEN_json_with_missing_value_WHEN_loading_from_json_THEN_json_loader_returns_false(json_reader):
+def test_GIVEN_json_with_missing_value_WHEN_loading_from_json_THEN_json_loader_returns_false(
+    json_reader,
+):
 
     json_string = """
     {
@@ -111,222 +117,40 @@ def test_GIVEN_json_with_missing_value_WHEN_loading_from_json_THEN_json_loader_r
     }
     """
 
-    with patch('nexus_constructor.model.load_from_json.open', mock_open(read_data=json_string), create=True):
+    with patch(
+        "nexus_constructor.model.load_from_json.open",
+        mock_open(read_data=json_string),
+        create=True,
+    ):
         assert not json_reader.load_model_from_json("")
 
 
-def test_GIVEN_unable_to_find_nexus_structure_field_WHEN_loading_from_json_THEN_json_loader_returns_false(json_reader):
+def test_GIVEN_unable_to_find_nexus_structure_field_WHEN_loading_from_json_THEN_json_loader_returns_false(
+    nexus_json_dictionary,
+):
 
-    json_string = """
-    {
-      "crumpet": {
-        "children": [
-          {
-            "name": "entry",
-            "type": "group",
-            "attributes": [
-              {
-                "name":  "NX_class",
-                "values":  "NXentry"
-              }
-            ],
-            "children": [
-              {
-                "name": "instrument",
-                "type": "group",
-                "attributes":
-                  {
-                    "NX_class":  "NXinstrument"
-                  },
-                "children": []
-              },
-              {
-                "name": "sample",
-                "type": "group",
-                "attributes": [
-                  {
-                    "name":  "NX_class",
-                    "values":  "NXsample"
-                  }
-                ],
-                "children": [
-                  {
-                    "type": "group",
-                    "name": "transformations",
-                    "children": []
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    }
-    """
-
-    with patch('nexus_constructor.model.load_from_json.open', mock_open(read_data=json_string), create=True):
-        assert not json_reader.load_model_from_json("")
-
-    assert not _retrieve_children_list(json.loads(json_string))
+    del nexus_json_dictionary["nexus_structure"]
+    assert not _retrieve_children_list(nexus_json_dictionary)
 
 
-def test_GIVEN_unable_to_find_first_children_field_WHEN_loading_from_json_THEN_json_loader_returns_false(json_reader):
+def test_GIVEN_unable_to_find_first_children_field_WHEN_loading_from_json_THEN_json_loader_returns_false(
+    nexus_json_dictionary,
+):
 
-    json_string = """
-    {
-      "nexus_structure": {
-        "crumpet": [
-          {
-            "name": "entry",
-            "type": "group",
-            "attributes": [
-              {
-                "name":  "NX_class",
-                "values":  "NXentry"
-              }
-            ],
-            "children": [
-              {
-                "name": "instrument",
-                "type": "group",
-                "attributes":
-                  {
-                    "NX_class":  "NXinstrument"
-                  },
-                "children": []
-              },
-              {
-                "name": "sample",
-                "type": "group",
-                "attributes": [
-                  {
-                    "name":  "NX_class",
-                    "values":  "NXsample"
-                  }
-                ],
-                "children": [
-                  {
-                    "type": "group",
-                    "name": "transformations",
-                    "children": []
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    }
-    """
-
-    with patch('nexus_constructor.model.load_from_json.open', mock_open(read_data=json_string), create=True):
-        assert not json_reader.load_model_from_json("")
-
-    assert not _retrieve_children_list(json.loads(json_string))
+    del nexus_json_dictionary["nexus_structure"]["children"]
+    assert not _retrieve_children_list(nexus_json_dictionary)
 
 
-def test_GIVEN_unable_to_find_second_children_field_WHEN_loading_from_json_THEN_json_loader_returns_false(json_reader):
+def test_GIVEN_unable_to_find_second_children_field_WHEN_loading_from_json_THEN_json_loader_returns_false(
+    nexus_json_dictionary,
+):
 
-    json_string = """
-    {
-      "nexus_structure": {
-        "children": [
-          {
-            "name": "entry",
-            "type": "group",
-            "attributes": [
-              {
-                "name":  "NX_class",
-                "values":  "NXentry"
-              }
-            ],
-            "crumpet": [
-              {
-                "name": "instrument",
-                "type": "group",
-                "attributes":
-                  {
-                    "NX_class":  "NXinstrument"
-                  },
-                "children": []
-              },
-              {
-                "name": "sample",
-                "type": "group",
-                "attributes": [
-                  {
-                    "name":  "NX_class",
-                    "values":  "NXsample"
-                  }
-                ],
-                "children": [
-                  {
-                    "type": "group",
-                    "name": "transformations",
-                    "children": []
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    }
-    """
-
-    with patch('nexus_constructor.model.load_from_json.open', mock_open(read_data=json_string), create=True):
-        assert not json_reader.load_model_from_json("")
-
-    assert not _retrieve_children_list(json.loads(json_string))
+    del nexus_json_dictionary["nexus_structure"]["children"][0]["children"]
+    assert not _retrieve_children_list(nexus_json_dictionary)
 
 
-def test_GIVEN_no_nx_class_for_component_WHEN_loading_from_json_THEN_json_loader_returns_false(json_reader):
-
-    json_string = """
-    {
-      "nexus_structure": {
-        "children": [
-          {
-            "name": "entry",
-            "type": "group",
-            "attributes": [
-              {
-                "name":  "NX_class",
-                "values":  "NXentry"
-              }
-            ],
-            "children": [
-              {
-                "name": "instrument",
-                "type": "group",
-                "attributes":
-                  {
-                    "NX_class":  "NXinstrument"
-                  },
-                "children": []
-              },
-              {
-                "name": "sample",
-                "type": "group",
-                "attributes": [
-                  {
-                    "name":  "NX_class"
-                  }
-                ],
-                "children": [
-                  {
-                    "type": "group",
-                    "name": "transformations",
-                    "children": []
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    }
-    """
-
-    with patch('nexus_constructor.model.load_from_json.open', mock_open(read_data=json_string), create=True):
-        assert not json_reader.load_model_from_json("")
+@pytest.mark.parametrize("class_attribute", [[{"name": "NX_class"}], [{"name": "123"}]])
+def test_GIVEN_no_nx_class_values_for_component_WHEN_loading_from_json_THEN_json_loader_returns_false(
+    class_attribute,
+):
+    assert not _read_nx_class(class_attribute)

--- a/tests/ui_tests/test_load_from_json.py
+++ b/tests/ui_tests/test_load_from_json.py
@@ -161,7 +161,7 @@ def test_GIVEN_no_nx_class_values_for_component_WHEN_loading_from_json_THEN_json
     "class_attribute",
     [[{"name": "NX_class", "values": "NXmonitor"}], [{"NX_class": "NXmonitor"}]],
 )
-def test_GIVEN_nx_class_in_different_formations_WHEN_reading_class_information_THEN_read_nx_class_recognises_both_formats(
+def test_GIVEN_nx_class_in_different_formats_WHEN_reading_class_information_THEN_read_nx_class_recognises_both_formats(
     class_attribute,
 ):
 

--- a/tests/ui_tests/test_load_from_json.py
+++ b/tests/ui_tests/test_load_from_json.py
@@ -7,6 +7,7 @@ from nexus_constructor.model.load_from_json import (
     JSONReader,
     _retrieve_children_list,
     _read_nx_class,
+    _validate_nx_class,
 )
 
 
@@ -154,3 +155,21 @@ def test_GIVEN_no_nx_class_values_for_component_WHEN_loading_from_json_THEN_json
     class_attribute,
 ):
     assert not _read_nx_class(class_attribute)
+
+
+@pytest.mark.parametrize(
+    "class_attribute",
+    [[{"name": "NX_class", "values": "NXmonitor"}], [{"NX_class": "NXmonitor"}]],
+)
+def test_GIVEN_nx_class_in_different_formations_WHEN_reading_class_information_THEN_read_nx_class_recognises_both_formats(
+    class_attribute,
+):
+
+    assert _read_nx_class(class_attribute) == "NXmonitor"
+
+
+@pytest.mark.parametrize("nx_class", ["", "notannxclass"])
+def test_GIVEN_invalid_nx_class_WHEN_obtained_nx_class_value_THEN_validate_nx_class_returns_false(
+    nx_class,
+):
+    assert not _validate_nx_class(nx_class)

--- a/tests/ui_tests/test_load_from_json.py
+++ b/tests/ui_tests/test_load_from_json.py
@@ -9,7 +9,7 @@ def json_reader(template):
     return JSONReader(template)
 
 
-def test_GIVEN_invalid_json_WHEN_loading_from_json_THEN_json_loader_returns_false(json_reader):
+def test_GIVEN_json_with_missing_value_WHEN_loading_from_json_THEN_json_loader_returns_false(json_reader):
 
     json_string = """
     {
@@ -37,7 +37,7 @@ def test_GIVEN_invalid_json_WHEN_loading_from_json_THEN_json_loader_returns_fals
                 "children": []
               },
               {
-                "name": "wedgie",
+                "name": "sample",
                 "type": "group",
                 "attributes": [
                   {

--- a/tests/ui_tests/test_load_from_json.py
+++ b/tests/ui_tests/test_load_from_json.py
@@ -122,7 +122,7 @@ def test_GIVEN_json_with_missing_value_WHEN_loading_from_json_THEN_json_loader_r
         mock_open(read_data=json_string),
         create=True,
     ):
-        assert not json_reader.load_model_from_json("")
+        assert not json_reader.load_model_from_json("filename")
 
 
 def test_GIVEN_unable_to_find_nexus_structure_field_WHEN_loading_from_json_THEN_json_loader_returns_false(

--- a/tests/ui_tests/test_load_from_json.py
+++ b/tests/ui_tests/test_load_from_json.py
@@ -173,3 +173,20 @@ def test_GIVEN_invalid_nx_class_WHEN_obtained_nx_class_value_THEN_validate_nx_cl
     nx_class,
 ):
     assert not _validate_nx_class(nx_class)
+
+
+def test_GIVEN_json_with_sample_WHEN_loading_from_json_THEN_new_model_contains_new_sample_name(
+    nexus_json_dictionary, json_reader
+):
+
+    sample_name = "NewSampleName"
+    nexus_json_dictionary["nexus_structure"]["children"][0]["children"][1][
+        "name"
+    ] = sample_name
+
+    children_list = _retrieve_children_list(nexus_json_dictionary)
+
+    for child in children_list:
+        json_reader._read_json_object(child)
+
+    assert json_reader.entry.instrument.sample.name == sample_name

--- a/tests/ui_tests/test_load_from_json.py
+++ b/tests/ui_tests/test_load_from_json.py
@@ -201,3 +201,5 @@ def test_GIVEN_no_nx_instrument_class_WHEN_loading_from_json_THEN_read_json_obje
     nx_instrument["attributes"]["NX_class"] = None
 
     assert not json_reader._read_json_object(nx_instrument)
+
+# todo: component name test


### PR DESCRIPTION
### Issue

Closes #782

### Description of work

Allows basic reading of JSON files. Currently only capable of discovering the names and nxclasses of components.

### Acceptance Criteria 

Check that the tests pass. Create a file with a sample and component and check that loading the file recovers the sample name and component name + class.

### UI tests

n/a

### Nominate for Group Code Review

- [ ] Nominate for code review 
