### PR TITLE
updating to 5.15.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ ess-streaming-data-types
 
 
 # PySide2 has had some issues with new versions and packaging so we will pin it
-PySide2==5.13.0
+PySide2==5.15.0


### PR DESCRIPTION
### Issue

Closes #596 

### Description of work

Previously when testing 5.14.0 it fixed the scaling issue but was segfaulting when components were being deleted. This has now been fixed in 5.15.0 (although i am unsure of the issue number that was closed for pyside2)

This also now means the NC can be run on python 3.8, which ships with ubuntu 20.04 by default now.

Creating this PR to see if it now works on MacOS.

### Acceptance Criteria 

No functional changes

### UI tests

*How you have updated the UI tests document to fit your changes*

### Nominate for Group Code Review

- [ ] Nominate for code review 
