### PR TITLE
Close edit or attrs window when the parent dialog is closed

### DIFF
--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -2,7 +2,7 @@ import logging
 from collections import OrderedDict
 from functools import partial
 
-from PySide2.QtCore import QUrl, Signal, QObject
+from PySide2.QtCore import QUrl, Signal, QObject, Qt
 from PySide2.QtGui import QVector3D
 from PySide2.QtWidgets import QListWidgetItem, QListWidget
 
@@ -222,6 +222,7 @@ class AddComponentDialog(Ui_AddComponentDialog, QObject):
         self.noShapeRadioButton.clicked.connect(self.set_pixel_related_changes)
 
         self.change_pixel_options_visibility()
+        parent_dialog.setAttribute(Qt.WA_DeleteOnClose)
 
     def set_pixel_related_changes(self):
         """

--- a/nexus_constructor/field_widget.py
+++ b/nexus_constructor/field_widget.py
@@ -86,7 +86,9 @@ class FieldWidget(QFrame):
             possible_field_names = []
 
         self.edit_dialog = QDialog(parent=self)
+        self.parent().parent().destroyed.connect(self.edit_dialog.close)
         self.attrs_dialog = FieldAttrsDialog(parent=self)
+        self.parent().parent().destroyed.connect(self.attrs_dialog.close)
 
         self.field_name_edit = FieldNameLineEdit(possible_field_names)
         self.hide_name_field = hide_name_field

--- a/nexus_constructor/field_widget.py
+++ b/nexus_constructor/field_widget.py
@@ -86,9 +86,10 @@ class FieldWidget(QFrame):
             possible_field_names = []
 
         self.edit_dialog = QDialog(parent=self)
-        self.parent().parent().destroyed.connect(self.edit_dialog.close)
         self.attrs_dialog = FieldAttrsDialog(parent=self)
-        self.parent().parent().destroyed.connect(self.attrs_dialog.close)
+        if self.parent() is not None and self.parent().parent() is not None:
+            self.parent().parent().destroyed.connect(self.edit_dialog.close)
+            self.parent().parent().destroyed.connect(self.attrs_dialog.close)
 
         self.field_name_edit = FieldNameLineEdit(possible_field_names)
         self.hide_name_field = hide_name_field


### PR DESCRIPTION
### Issue

Closes #783 

### Description of work

Previously a user could close the add/edit component window and if they had an edit field window or edit attrs for a field window it would persist. This change closes the child dialogs when the edit component window is closed. 

### Acceptance Criteria 

Follow steps on ticket and make sure the edit field window closes when the parent dialog is closed. 

### UI tests

None added

### Nominate for Group Code Review

- [ ] Nominate for code review 
