### PR TITLE
Fix for JSON loading warning dialog immediately closing after being shown

### DIFF
--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -207,7 +207,7 @@ class MainWindow(Ui_MainWindow, QMainWindow):
             success = reader.load_model_from_json(filename)
             if reader.warnings:
                 show_warning_dialog(
-                    "\n".join(reader.warnings), "Warnings encountered loading JSON"
+                    "\n".join(reader.warnings), "Warnings encountered loading JSON", parent=self
                 )
             if success:
                 self.model.entry = reader.entry

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -207,7 +207,9 @@ class MainWindow(Ui_MainWindow, QMainWindow):
             success = reader.load_model_from_json(filename)
             if reader.warnings:
                 show_warning_dialog(
-                    "\n".join(reader.warnings), "Warnings encountered loading JSON", parent=self
+                    "\n".join(reader.warnings),
+                    "Warnings encountered loading JSON",
+                    parent=self,
                 )
             if success:
                 self.model.entry = reader.entry


### PR DESCRIPTION
### Issue

Closes #809 

### Description of work

Sets the parent for the modal dialog that shows the JSON loading errors when a file is invalid. Previously (on windows at least) this would be shown and then immediately closed. 

### Acceptance Criteria 

Load an invalid JSON file and check the warning message is shown and persists until a user exits the dialog. 

### UI tests

None added

### Nominate for Group Code Review

- [ ] Nominate for code review 
