### PR TITLE
Fix coverage reporting

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -106,7 +106,7 @@ return {
             stage("Setup") {
                   bat """
                   python -m pip install --user --upgrade -r requirements-dev.txt
-                  python -m pip install codecov==2.0.15
+                  python -m pip install codecov==2.1.8
                 """
             } // stage
             stage("Run tests") {


### PR DESCRIPTION
### Issue

None

### Description of work
Just updates the version of codecov to the latest. This was causing coverage to be omitted as the AWS URL used for submitting coverage reports has changed between versions.
### Acceptance Criteria 

Coverage badge shows up

### UI tests

N/A

### Nominate for Group Code Review

- [ ] Nominate for code review 
