### PR TITLE
814 Fix set_field_value by removing optional dtype and making dtype required

### DIFF
--- a/nexus_constructor/component_tree_model.py
+++ b/nexus_constructor/component_tree_model.py
@@ -8,7 +8,7 @@ from PySide2.QtWidgets import QMessageBox
 from nexus_constructor.component.link_transformation import LinkTransformation
 from nexus_constructor.component.transformations_list import TransformationsList
 from nexus_constructor.model.component import Component
-from nexus_constructor.model.dataset import Dataset, DatasetMetadata
+from nexus_constructor.model.dataset import Dataset
 from nexus_constructor.model.model import Model
 from nexus_constructor.model.transformation import Transformation
 from nexus_constructor.transformation_types import TransformationType
@@ -225,9 +225,7 @@ class ComponentTreeModel(QAbstractItemModel):
     def _create_new_transformation(
         parent_component, transformation_list, transformation_type
     ):
-        values = Dataset(
-            name="", dataset=DatasetMetadata(type="Double", size=[1]), values=""
-        )
+        values = Dataset(name="", type="Double", size=[1], values="")
         if transformation_type == TransformationType.TRANSLATION:
             new_transformation = parent_component.add_translation(
                 name=generate_unique_name(

--- a/nexus_constructor/field_attrs.py
+++ b/nexus_constructor/field_attrs.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Union, Any
+from typing import Union
 
 import numpy as np
 from PySide2.QtWidgets import (
@@ -16,25 +16,12 @@ from PySide2.QtWidgets import (
 
 from nexus_constructor.array_dataset_table_widget import ArrayDatasetTableWidget
 from nexus_constructor.common_attrs import CommonAttrs
-from nexus_constructor.model.dataset import Dataset
+from nexus_constructor.model.dataset import Dataset, _get_human_readable_type
 from nexus_constructor.ui_utils import validate_line_edit
 from nexus_constructor.validators import FieldValueValidator
 from nexus_constructor.model.value_type import VALUE_TYPE
 
 ATTRS_EXCLUDELIST = [CommonAttrs.UNITS]
-
-
-def _get_human_readable_type(new_value: Any):
-    if isinstance(new_value, str):
-        return "String"
-    elif isinstance(new_value, int):
-        return "Int"
-    elif isinstance(new_value, float):
-        return "Double"
-    else:
-        return next(
-            key for key, value in VALUE_TYPE.items() if value == new_value.dtype
-        )
 
 
 class FieldAttrsDialog(QDialog):

--- a/nexus_constructor/field_attrs.py
+++ b/nexus_constructor/field_attrs.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Union
+from typing import Union, Any
 
 import numpy as np
 from PySide2.QtWidgets import (
@@ -22,6 +22,19 @@ from nexus_constructor.validators import FieldValueValidator
 from nexus_constructor.model.value_type import VALUE_TYPE
 
 ATTRS_EXCLUDELIST = [CommonAttrs.UNITS]
+
+
+def _get_human_readable_type(new_value: Any):
+    if isinstance(new_value, str):
+        return "String"
+    elif isinstance(new_value, int):
+        return "Int"
+    elif isinstance(new_value, float):
+        return "Double"
+    else:
+        return next(
+            key for key, value in VALUE_TYPE.items() if value == new_value.dtype
+        )
 
 
 class FieldAttrsDialog(QDialog):

--- a/nexus_constructor/field_attrs.py
+++ b/nexus_constructor/field_attrs.py
@@ -16,7 +16,7 @@ from PySide2.QtWidgets import (
 
 from nexus_constructor.array_dataset_table_widget import ArrayDatasetTableWidget
 from nexus_constructor.common_attrs import CommonAttrs
-from nexus_constructor.model.dataset import Dataset, _get_human_readable_type
+from nexus_constructor.model.dataset import Dataset
 from nexus_constructor.ui_utils import validate_line_edit
 from nexus_constructor.validators import FieldValueValidator
 from nexus_constructor.model.value_type import VALUE_TYPE

--- a/nexus_constructor/field_utils.py
+++ b/nexus_constructor/field_utils.py
@@ -29,7 +29,7 @@ def update_existing_array_field(field: Dataset, new_ui_field: FieldWidget):
     :param new_ui_field: The new UI field to fill in with existing data
     """
     new_ui_field.field_type = FieldType.array_dataset.value
-    new_ui_field.dtype = field.dataset.type
+    new_ui_field.dtype = field.type
     new_ui_field.value = field.values
     new_ui_field.attrs = field
 
@@ -42,7 +42,7 @@ def update_existing_scalar_field(field: Dataset, new_ui_field: FieldWidget):
     """
     new_ui_field.field_type = FieldType.scalar_dataset.value
     new_ui_field.value = field.values
-    new_ui_field.dtype = field.dataset.type
+    new_ui_field.dtype = field.type
     new_ui_field.attrs = field
 
 

--- a/nexus_constructor/field_widget.py
+++ b/nexus_constructor/field_widget.py
@@ -20,7 +20,7 @@ from nexus_constructor.array_dataset_table_widget import ArrayDatasetTableWidget
 from nexus_constructor.common_attrs import CommonAttrs
 from nexus_constructor.field_attrs import FieldAttrsDialog
 from nexus_constructor.invalid_field_names import INVALID_FIELD_NAMES
-from nexus_constructor.model.dataset import Dataset, DatasetMetadata
+from nexus_constructor.model.dataset import Dataset
 from nexus_constructor.model.group import Group
 from nexus_constructor.model.link import Link
 from nexus_constructor.stream_fields_widget import StreamFieldsWidget
@@ -224,18 +224,12 @@ class FieldWidget(QFrame):
         dtype = self.value_type_combo.currentText()
         if self.field_type == FieldType.scalar_dataset:
             val = self.value_line_edit.text()
-            return_object = Dataset(
-                name=self.name,
-                dataset=DatasetMetadata(size=[1], type=dtype),
-                values=val,
-            )
+            return_object = Dataset(name=self.name, size=[1], type=dtype, values=val,)
         elif self.field_type == FieldType.array_dataset:
             # Squeeze the array so 1D arrays can exist. Should not affect dimensional arrays.
             array = np.squeeze(self.table_view.model.array)
             return_object = Dataset(
-                name=self.name,
-                dataset=DatasetMetadata(size=array.size, type=dtype),
-                values=array,
+                name=self.name, size=array.size, type=dtype, values=array,
             )
         elif self.field_type == FieldType.kafka_stream:
             return_object = self.streams_widget.get_stream_group()
@@ -247,13 +241,15 @@ class FieldWidget(QFrame):
 
         if self.field_type != FieldType.link:
             for attr_name, attr_tuple in self.attrs_dialog.get_attrs().items():
-                return_object.set_attribute_value(
+                return_object.attributes.set_attribute_value(
                     attribute_name=attr_name,
                     attribute_value=attr_tuple[0],
                     attribute_type=attr_tuple[1],
                 )
             if self.units and self.units is not None:
-                return_object.set_attribute_value(CommonAttrs.UNITS, self.units)
+                return_object.attributes.set_attribute_value(
+                    CommonAttrs.UNITS, self.units
+                )
         return return_object
 
     @value.setter

--- a/nexus_constructor/json/shape_reader.py
+++ b/nexus_constructor/json/shape_reader.py
@@ -233,7 +233,7 @@ class ShapeReader:
         cylindrical_geometry.set_field_value(
             CommonAttrs.VERTICES, np.vstack(vertices), vertices_dtype
         )
-        cylindrical_geometry[CommonAttrs.VERTICES].set_attribute_value(
+        cylindrical_geometry[CommonAttrs.VERTICES].attributes.set_attribute_value(
             CommonAttrs.UNITS, units
         )
         return cylindrical_geometry

--- a/nexus_constructor/json/transformation_reader.py
+++ b/nexus_constructor/json/transformation_reader.py
@@ -4,7 +4,7 @@ from PySide2.QtGui import QVector3D
 
 from nexus_constructor.common_attrs import CommonAttrs
 from nexus_constructor.model.component import Component
-from nexus_constructor.model.dataset import Dataset, DatasetMetadata
+from nexus_constructor.model.dataset import Dataset
 from nexus_constructor.model.value_type import VALUE_TYPE
 from nexus_constructor.transformation_types import TransformationType
 from nexus_constructor.json.load_from_json_utils import (
@@ -43,9 +43,7 @@ def _create_transformation_dataset(
     :param name: The transformation name.
     :return: A dataset containing the above information.
     """
-    return Dataset(
-        name, dataset=DatasetMetadata(size=[1], type=dtype), values=angle_or_magnitude,
-    )
+    return Dataset(name, size=[1], type=dtype, values=angle_or_magnitude,)
 
 
 class TransformationReader:

--- a/nexus_constructor/model/attributes.py
+++ b/nexus_constructor/model/attributes.py
@@ -1,7 +1,38 @@
+from typing import Any, Dict
 import attr
 import numpy as np
-from typing import Dict, Any
+
+from nexus_constructor.model.helpers import _get_item, _set_item
 from nexus_constructor.model.value_type import ValueType
+
+
+class Attributes(list):
+    """Abstract class used for common functionality between a group and dataset. """
+
+    def set_attribute_value(
+        self, attribute_name: str, attribute_value: Any, attribute_type: str = "String"
+    ):
+        _set_item(
+            self,
+            self,
+            attribute_name,
+            FieldAttribute(
+                name=attribute_name, values=attribute_value, type=attribute_type
+            ),
+        )
+
+    def get_attribute_value(self, attribute_name: str):
+        return _get_item(self, attribute_name).values
+
+    def contains_attribute(self, attribute_name):
+        result = _get_item(self, attribute_name)
+        return True if result is not None else False
+
+    def as_dict(self):
+        return_dict = {}
+        if self:
+            return_dict["attributes"] = [attribute.as_dict() for attribute in self]
+        return return_dict
 
 
 @attr.s(eq=False)

--- a/nexus_constructor/model/component.py
+++ b/nexus_constructor/model/component.py
@@ -91,7 +91,7 @@ class Component(Group):
 
     @description.setter
     def description(self, new_description: str):
-        self.set_field_value(CommonAttrs.DESCRIPTION, new_description)
+        self.set_field_value(CommonAttrs.DESCRIPTION, new_description, "String")
 
     @property
     def qtransform(self) -> QTransform:
@@ -314,10 +314,10 @@ class Component(Group):
         vertices = CylindricalGeometry.calculate_vertices(
             axis_direction, height, radius
         )
-        geometry.set_field_value(CommonAttrs.VERTICES, vertices)
+        geometry.set_field_value(CommonAttrs.VERTICES, vertices, "int")
 
         # # Specify 0th vertex is base centre, 1st is base edge, 2nd is top centre
-        geometry.set_field_value("cylinders", np.array([0, 1, 2]))
+        geometry.set_field_value("cylinders", np.array([0, 1, 2]), "int")
         geometry[CommonAttrs.VERTICES].set_attribute_value(CommonAttrs.UNITS, units)
 
         if isinstance(pixel_data, PixelMapping):

--- a/nexus_constructor/model/component.py
+++ b/nexus_constructor/model/component.py
@@ -233,7 +233,7 @@ class Component(Group):
             size=values.size,
             values=values,
         )
-        transform.type = transformation_type
+        transform.transform_type = transformation_type
         transform.ui_value = angle_or_magnitude
         transform.units = units
         transform.vector = vector

--- a/nexus_constructor/model/component.py
+++ b/nexus_constructor/model/component.py
@@ -17,7 +17,7 @@ from nexus_constructor.model.geometry import (
     OFFGeometry,
 )
 from nexus_constructor.model.group import Group, TRANSFORMS_GROUP_NAME
-from nexus_constructor.model.node import _generate_incremental_name
+from nexus_constructor.model.helpers import _generate_incremental_name
 from nexus_constructor.model.transformation import Transformation
 from nexus_constructor.pixel_data import PixelGrid, PixelMapping, PixelData
 from nexus_constructor.pixel_data_to_nexus_utils import (
@@ -168,7 +168,7 @@ class Component(Group):
         vector: QVector3D,
         name: str = None,
         depends_on: Transformation = None,
-        values: Dataset = Dataset(name="", values=0),
+        values: Dataset = Dataset(name="", values=0, type="Double", size="1"),
     ) -> Transformation:
         """
         Note, currently assumes translation is in metres
@@ -194,7 +194,7 @@ class Component(Group):
         angle: float,
         name: str = None,
         depends_on: Transformation = None,
-        values: Dataset = Dataset(name="", values=0),
+        values: Dataset = Dataset(name="", values=0, type="Double", size="1"),
     ) -> Transformation:
         """
         Note, currently assumes angle is in degrees

--- a/nexus_constructor/model/component.py
+++ b/nexus_constructor/model/component.py
@@ -168,7 +168,7 @@ class Component(Group):
         vector: QVector3D,
         name: str = None,
         depends_on: Transformation = None,
-        values: Dataset = Dataset("", None, []),
+        values: Dataset = Dataset(name="", values=0),
     ) -> Transformation:
         """
         Note, currently assumes translation is in metres
@@ -194,7 +194,7 @@ class Component(Group):
         angle: float,
         name: str = None,
         depends_on: Transformation = None,
-        values: Dataset = Dataset("", None, []),
+        values: Dataset = Dataset(name="", values=0),
     ) -> Transformation:
         """
         Note, currently assumes angle is in degrees

--- a/nexus_constructor/model/component.py
+++ b/nexus_constructor/model/component.py
@@ -227,14 +227,17 @@ class Component(Group):
         if name is None:
             name = _generate_incremental_name(transformation_type, self.transforms)
         transform = Transformation(
-            name=name, dataset=None, parent_node=self.get_transforms_group()
+            name=name,
+            parent_node=self.get_transforms_group(),
+            type=values.type,
+            size=values.size,
+            values=values,
         )
         transform.type = transformation_type
         transform.ui_value = angle_or_magnitude
         transform.units = units
         transform.vector = vector
         transform.depends_on = depends_on
-        transform.values = values
         transform._parent_component = self
 
         self.get_transforms_group()[name] = transform
@@ -318,7 +321,9 @@ class Component(Group):
 
         # # Specify 0th vertex is base centre, 1st is base edge, 2nd is top centre
         geometry.set_field_value("cylinders", np.array([0, 1, 2]), "int")
-        geometry[CommonAttrs.VERTICES].set_attribute_value(CommonAttrs.UNITS, units)
+        geometry[CommonAttrs.VERTICES].attributes.set_attribute_value(
+            CommonAttrs.UNITS, units
+        )
 
         if isinstance(pixel_data, PixelMapping):
             geometry.detector_number = get_detector_number_from_pixel_mapping(

--- a/nexus_constructor/model/dataset.py
+++ b/nexus_constructor/model/dataset.py
@@ -4,7 +4,22 @@ import numpy as np
 
 from nexus_constructor.common_attrs import CommonAttrs
 from nexus_constructor.model.node import Node
-from nexus_constructor.model.value_type import ValueType
+from nexus_constructor.model.value_type import ValueType, VALUE_TYPE
+
+
+def _get_human_readable_type(new_value: Any):
+    if isinstance(new_value, list):
+        new_value = new_value[0]
+    if isinstance(new_value, str):
+        return "String"
+    elif isinstance(new_value, int):
+        return "Int"
+    elif isinstance(new_value, float):
+        return "Double"
+    else:
+        return next(
+            key for key, value in VALUE_TYPE.items() if value == new_value.dtype
+        )
 
 
 @attr.s
@@ -12,12 +27,29 @@ class DatasetMetadata:
     type = attr.ib(type=str)
     size = attr.ib(factory=tuple)
 
+    def as_dict(self) -> Dict:
+        return {"size": self.size, "type": self.type}
+
+
+def create_metadata(ds: "Dataset") -> DatasetMetadata:
+    """
+    Attempts to infer size and type from the value passed at initialisation.
+    :param ds: the dataset to infer from
+    :return: a dataset metadata class containing the size and type of the dataset
+    """
+    return DatasetMetadata(
+        size=len(ds.values) if isinstance(ds.values, list) else "1",
+        type=_get_human_readable_type(ds.values),
+    )
+
 
 @attr.s
 class Dataset(Node):
-    dataset = attr.ib(type=DatasetMetadata, default={})
     values = attr.ib(factory=list, type=List[ValueType])
     type = attr.ib(type=str, default="dataset", init=False)
+    dataset = attr.ib(
+        type=DatasetMetadata, default=attr.Factory(create_metadata, takes_self=True)
+    )
 
     @property
     def nx_class(self):
@@ -34,4 +66,5 @@ class Dataset(Node):
             values = values.tolist()
         return_dict["type"] = self.type
         return_dict["values"] = values
+        return_dict["dataset"] = self.dataset.as_dict()
         return return_dict

--- a/nexus_constructor/model/dataset.py
+++ b/nexus_constructor/model/dataset.py
@@ -3,67 +3,35 @@ from typing import List, Dict, Any
 import numpy as np
 
 from nexus_constructor.common_attrs import CommonAttrs
-from nexus_constructor.model.node import Node
-from nexus_constructor.model.value_type import ValueType, VALUE_TYPE
-
-
-def _get_human_readable_type(new_value: Any):
-    if isinstance(new_value, list):
-        new_value = new_value[0]
-    if isinstance(new_value, str):
-        return "String"
-    elif isinstance(new_value, int):
-        return "Int"
-    elif isinstance(new_value, float):
-        return "Double"
-    else:
-        return next(
-            key for key, value in VALUE_TYPE.items() if value == new_value.dtype
-        )
+from nexus_constructor.model.attributes import Attributes
+from nexus_constructor.model.value_type import ValueType
 
 
 @attr.s
-class DatasetMetadata:
+class Dataset:
+    name = attr.ib(type=str)
+    values = attr.ib(type=List[ValueType])
     type = attr.ib(type=str)
     size = attr.ib(factory=tuple)
-
-    def as_dict(self) -> Dict:
-        return {"size": self.size, "type": self.type}
-
-
-def create_metadata(ds: "Dataset") -> DatasetMetadata:
-    """
-    Attempts to infer size and type from the value passed at initialisation.
-    :param ds: the dataset to infer from
-    :return: a dataset metadata class containing the size and type of the dataset
-    """
-    return DatasetMetadata(
-        size=len(ds.values) if isinstance(ds.values, list) else "1",
-        type=_get_human_readable_type(ds.values),
-    )
-
-
-@attr.s
-class Dataset(Node):
-    values = attr.ib(factory=list, type=List[ValueType])
-    dataset = attr.ib(
-        type=DatasetMetadata, default=attr.Factory(create_metadata, takes_self=True)
-    )
+    parent_node = attr.ib(type="Node", default=None)
+    attributes = attr.ib(type=Attributes, factory=Attributes, init=False)
 
     @property
     def nx_class(self):
-        return self.get_attribute_value(CommonAttrs.NX_CLASS)
+        return self.attributes.get_attribute_value(CommonAttrs.NX_CLASS)
 
     @nx_class.setter
     def nx_class(self, new_nx_class: str):
-        self.set_attribute_value(CommonAttrs.NX_CLASS, new_nx_class)
+        self.attributes.set_attribute_value(CommonAttrs.NX_CLASS, new_nx_class)
 
     def as_dict(self) -> Dict[str, Any]:
-        return_dict = super().as_dict()
+        return_dict = {}
+        if self.attributes:
+            return_dict["attributes"] = self.attributes.as_dict()
         values = self.values
         if isinstance(values, np.ndarray):
             values = values.tolist()
         return_dict["type"] = "dataset"
         return_dict["values"] = values
-        return_dict["dataset"] = self.dataset.as_dict()
+        return_dict["dataset"] = {"type": self.type, "size": self.size}
         return return_dict

--- a/nexus_constructor/model/dataset.py
+++ b/nexus_constructor/model/dataset.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from nexus_constructor.common_attrs import CommonAttrs
 from nexus_constructor.model.attributes import Attributes
+from nexus_constructor.model.helpers import get_absolute_path
 from nexus_constructor.model.value_type import ValueType
 
 
@@ -15,6 +16,10 @@ class Dataset:
     size = attr.ib(factory=tuple)
     parent_node = attr.ib(type="Node", default=None)
     attributes = attr.ib(type=Attributes, factory=Attributes, init=False)
+
+    @property
+    def absolute_path(self):
+        return get_absolute_path(self)
 
     @property
     def nx_class(self):

--- a/nexus_constructor/model/dataset.py
+++ b/nexus_constructor/model/dataset.py
@@ -30,8 +30,7 @@ class Dataset:
         self.attributes.set_attribute_value(CommonAttrs.NX_CLASS, new_nx_class)
 
     def as_dict(self) -> Dict[str, Any]:
-        return_dict = {}
-        return_dict["name"] = self.name
+        return_dict = {"name": self.name}
         if self.attributes:
             return_dict["attributes"] = self.attributes.as_dict()
         values = self.values

--- a/nexus_constructor/model/dataset.py
+++ b/nexus_constructor/model/dataset.py
@@ -46,7 +46,6 @@ def create_metadata(ds: "Dataset") -> DatasetMetadata:
 @attr.s
 class Dataset(Node):
     values = attr.ib(factory=list, type=List[ValueType])
-    type = attr.ib(type=str, default="dataset", init=False)
     dataset = attr.ib(
         type=DatasetMetadata, default=attr.Factory(create_metadata, takes_self=True)
     )
@@ -64,7 +63,7 @@ class Dataset(Node):
         values = self.values
         if isinstance(values, np.ndarray):
             values = values.tolist()
-        return_dict["type"] = self.type
+        return_dict["type"] = "dataset"
         return_dict["values"] = values
         return_dict["dataset"] = self.dataset.as_dict()
         return return_dict

--- a/nexus_constructor/model/dataset.py
+++ b/nexus_constructor/model/dataset.py
@@ -31,6 +31,7 @@ class Dataset:
 
     def as_dict(self) -> Dict[str, Any]:
         return_dict = {}
+        return_dict["name"] = self.name
         if self.attributes:
             return_dict["attributes"] = self.attributes.as_dict()
         values = self.values

--- a/nexus_constructor/model/entry.py
+++ b/nexus_constructor/model/entry.py
@@ -5,7 +5,7 @@ from typing import Dict, Any
 
 class Entry(Group):
     def __init__(self):
-        super().__init__("entry", None)
+        super().__init__(name="entry", parent_node=None)
         self.nx_class = "NXentry"
 
     @property

--- a/nexus_constructor/model/geometry.py
+++ b/nexus_constructor/model/geometry.py
@@ -122,7 +122,9 @@ class CylindricalGeometry(Group):
 
     @property
     def units(self) -> str:
-        return self[CommonAttrs.VERTICES].get_attribute_value(CommonAttrs.UNITS)
+        return self[CommonAttrs.VERTICES].attributes.get_attribute_value(
+            CommonAttrs.UNITS
+        )
 
     @property
     def height(self) -> float:
@@ -370,7 +372,9 @@ class OFFGeometryNexus(OFFGeometry, Group):
             [qvector3d_to_numpy_array(vertex) for vertex in new_vertices]
         )
         self.set_field_value(CommonAttrs.VERTICES, vertices, "int")
-        self[CommonAttrs.VERTICES].set_attribute_value(CommonAttrs.UNITS, "m")
+        self[CommonAttrs.VERTICES].attributes.set_attribute_value(
+            CommonAttrs.UNITS, "m"
+        )
 
 
 __half_side_length = 0.05

--- a/nexus_constructor/model/geometry.py
+++ b/nexus_constructor/model/geometry.py
@@ -118,7 +118,7 @@ class CylindricalGeometry(Group):
 
     @detector_number.setter
     def detector_number(self, pixel_ids: List[int]):
-        self.set_field_value("detector_number", pixel_ids)
+        self.set_field_value("detector_number", pixel_ids, "int")
 
     @property
     def units(self) -> str:
@@ -276,7 +276,7 @@ class OFFGeometryNexus(OFFGeometry, Group):
         Records the detector faces in the NXoff_geometry.
         :param detector_faces: The PixelMapping object containing IDs the user provided through the Add/Edit Component window.
         """
-        self.set_field_value("detector_faces", detector_faces)
+        self.set_field_value("detector_faces", detector_faces, "int")
 
     @property
     def winding_order(self) -> List[int]:
@@ -353,11 +353,11 @@ class OFFGeometryNexus(OFFGeometry, Group):
         winding_order = np.array(
             [index for new_face in new_faces for index in new_face]
         )
-        self.set_field_value("winding_order", winding_order)
+        self.set_field_value("winding_order", winding_order, "int")
         faces_length = [0]
         faces_length.extend([len(new_face) for new_face in new_faces[:-1]])
         faces_start_indices = np.cumsum(faces_length)
-        self.set_field_value("faces", faces_start_indices)
+        self.set_field_value("faces", faces_start_indices, "int")
 
     def record_vertices(self, new_vertices: List[QVector3D]):
         """
@@ -369,7 +369,7 @@ class OFFGeometryNexus(OFFGeometry, Group):
         vertices = np.array(
             [qvector3d_to_numpy_array(vertex) for vertex in new_vertices]
         )
-        self.set_field_value(CommonAttrs.VERTICES, vertices)
+        self.set_field_value(CommonAttrs.VERTICES, vertices, "int")
         self[CommonAttrs.VERTICES].set_attribute_value(CommonAttrs.UNITS, "m")
 
 

--- a/nexus_constructor/model/group.py
+++ b/nexus_constructor/model/group.py
@@ -73,6 +73,7 @@ class Group:
 
     def as_dict(self) -> Dict[str, Any]:
         return_dict = {}
+        return_dict["name"] = self.name
         if self.attributes:
             return_dict["attributes"] = self.attributes.as_dict()
         return_dict["type"] = "group"

--- a/nexus_constructor/model/group.py
+++ b/nexus_constructor/model/group.py
@@ -26,7 +26,6 @@ class Group(Node):
     """
 
     children = attr.ib(factory=list, init=False)
-    type = attr.ib(type=str, default="group", init=False)
     attributes = attr.ib(type=List[FieldAttribute], factory=list, init=False)
 
     def __getitem__(self, key: str):
@@ -69,7 +68,7 @@ class Group(Node):
 
     def as_dict(self) -> Dict[str, Any]:
         return_dict = super().as_dict()
-        return_dict["type"] = self.type
+        return_dict["type"] = "group"
         return_dict["children"] = (
             [
                 child.as_dict()

--- a/nexus_constructor/model/group.py
+++ b/nexus_constructor/model/group.py
@@ -56,7 +56,7 @@ class Group(Node):
     def nx_class(self, new_nx_class: str):
         self.set_attribute_value(CommonAttrs.NX_CLASS, new_nx_class)
 
-    def set_field_value(self, name: str, value: Any, dtype: str = None):
+    def set_field_value(self, name: str, value: Any, dtype: str):
         size = [1]
         if isinstance(value, (np.ndarray, np.generic)):
             size = value.size

--- a/nexus_constructor/model/group.py
+++ b/nexus_constructor/model/group.py
@@ -28,7 +28,6 @@ class Group:
 
     name = attr.ib(type=str)
     parent_node = attr.ib(type="Node", default=None)
-
     children = attr.ib(factory=list, init=False)
     attributes = attr.ib(type=Attributes, factory=Attributes, init=False)
 

--- a/nexus_constructor/model/group.py
+++ b/nexus_constructor/model/group.py
@@ -1,17 +1,18 @@
-from typing import List, Any, Union, Dict
+from typing import Any, Union, Dict
 import attr
 import numpy as np
 
 from nexus_constructor.common_attrs import CommonAttrs
-from nexus_constructor.model.attribute import FieldAttribute
-from nexus_constructor.model.dataset import DatasetMetadata, Dataset
-from nexus_constructor.model.link import Link
-from nexus_constructor.model.node import (
-    Node,
+from nexus_constructor.model.attributes import Attributes
+from nexus_constructor.model.dataset import Dataset
+from nexus_constructor.model.helpers import (
+    get_absolute_path,
     _get_item,
     _set_item,
     _remove_item,
 )
+from nexus_constructor.model.link import Link
+
 
 TRANSFORMS_GROUP_NAME = "transformations"
 
@@ -20,13 +21,16 @@ CHILD_EXCLUDELIST = [TRANSFORMS_GROUP_NAME]
 
 
 @attr.s
-class Group(Node):
+class Group:
     """
     Base class for any group which has a set of children and an nx_class attribute.
     """
 
+    name = attr.ib(type=str)
+    parent_node = attr.ib(type="Node", default=None)
+
     children = attr.ib(factory=list, init=False)
-    attributes = attr.ib(type=List[FieldAttribute], factory=list, init=False)
+    attributes = attr.ib(type=Attributes, factory=Attributes, init=False)
 
     def __getitem__(self, key: str):
         return _get_item(self.children, key)
@@ -48,26 +52,30 @@ class Group(Node):
         _remove_item(self.children, key)
 
     @property
+    def absolute_path(self):
+        return get_absolute_path(self)
+
+    @property
     def nx_class(self):
-        return self.get_attribute_value(CommonAttrs.NX_CLASS)
+        return self.attributes.get_attribute_value(CommonAttrs.NX_CLASS)
 
     @nx_class.setter
     def nx_class(self, new_nx_class: str):
-        self.set_attribute_value(CommonAttrs.NX_CLASS, new_nx_class)
+        self.attributes.set_attribute_value(CommonAttrs.NX_CLASS, new_nx_class)
 
     def set_field_value(self, name: str, value: Any, dtype: str):
         size = [1]
         if isinstance(value, (np.ndarray, np.generic)):
             size = value.size
-        self[name] = Dataset(
-            name=name, dataset=DatasetMetadata(size=size, type=dtype), values=value
-        )
+        self[name] = Dataset(name=name, size=size, type=dtype, values=value)
 
     def get_field_value(self, name: str):
         return self[name].values
 
     def as_dict(self) -> Dict[str, Any]:
-        return_dict = super().as_dict()
+        return_dict = {}
+        if self.attributes:
+            return_dict["attributes"] = self.attributes.as_dict()
         return_dict["type"] = "group"
         return_dict["children"] = (
             [

--- a/nexus_constructor/model/helpers.py
+++ b/nexus_constructor/model/helpers.py
@@ -1,6 +1,4 @@
-from typing import List, Any
-import attr
-from nexus_constructor.model.attribute import FieldAttribute
+from typing import List, Any, Union
 
 
 def __find_item_index(list_to_look_in: List[Any], item_name: str):
@@ -39,7 +37,10 @@ def _remove_item(list_to_remove_from: List[Any], item_name: str):
 
 
 def _set_item(
-    parent: "Node", list_to_look_in: List[Any], item_name: str, new_value: Any
+    parent: Union["Dataset", "Group"],  # noqa: F821
+    list_to_look_in: List[Any],
+    item_name: str,
+    new_value: Any,
 ):
     """
     Given an item name, either overwrite the current entry or just append the item to the list.
@@ -62,46 +63,6 @@ def get_absolute_path(node: Any):
         path = f"/{node.parent_node.name}{path}"
         node = node.parent_node
     return path
-
-
-@attr.s
-class Node:
-    """Abstract class used for common functionality between a group and dataset. """
-
-    name = attr.ib(type=str)
-    attributes = attr.ib(init=False, factory=list)
-    parent_node = attr.ib(type="Node", default=None)
-
-    @property
-    def absolute_path(self):
-        return get_absolute_path(self)
-
-    def set_attribute_value(
-        self, attribute_name: str, attribute_value: Any, attribute_type: str = "String"
-    ):
-        _set_item(
-            self,
-            self.attributes,
-            attribute_name,
-            FieldAttribute(
-                name=attribute_name, values=attribute_value, type=attribute_type
-            ),
-        )
-
-    def get_attribute_value(self, attribute_name: str):
-        return _get_item(self.attributes, attribute_name).values
-
-    def contains_attribute(self, attribute_name):
-        result = _get_item(self.attributes, attribute_name)
-        return True if result is not None else False
-
-    def as_dict(self):
-        return_dict = {"name": self.name}
-        if self.attributes:
-            return_dict["attributes"] = [
-                attribute.as_dict() for attribute in self.attributes
-            ]
-        return return_dict
 
 
 def _generate_incremental_name(base_name, transforms_list):

--- a/nexus_constructor/model/instrument.py
+++ b/nexus_constructor/model/instrument.py
@@ -8,7 +8,7 @@ INSTRUMENT_NAME = "instrument"
 
 class Instrument(Group):
     def __init__(self, parent_node=None):
-        super().__init__(INSTRUMENT_NAME, parent_node)
+        super().__init__(name=INSTRUMENT_NAME, parent_node=parent_node)
         self.nx_class = "NXinstrument"
 
         self.sample = Component(SAMPLE_NAME, parent_node=self)

--- a/nexus_constructor/model/link.py
+++ b/nexus_constructor/model/link.py
@@ -5,7 +5,6 @@ import attr
 class Link:
     name = attr.ib(type=str)
     target = attr.ib(type=str)
-    type = attr.ib(type=str, default="link", init=False)
 
     def as_dict(self):
-        return {"name": self.name, "target": self.target, "type": self.type}
+        return {"name": self.name, "target": self.target, "type": "link"}

--- a/nexus_constructor/model/transformation.py
+++ b/nexus_constructor/model/transformation.py
@@ -153,7 +153,7 @@ class Transformation(Dataset):
     def as_dict(self) -> Dict[str, Any]:
         return_dict = {
             "name": self.name,
-            "type": self.type,
+            "type": "dataset",
             "attributes": [
                 attribute.as_dict()
                 for attribute in self.attributes

--- a/nexus_constructor/model/transformation.py
+++ b/nexus_constructor/model/transformation.py
@@ -53,13 +53,13 @@ class Transformation(Dataset):
     def ui_value(self) -> float:
         try:
             if isinstance(self.values, Dataset):
-                if np.isscalar(self.values):
+                if np.isscalar(self.values.values):
                     self.ui_value = float(self.values.values)
                     return float(self.values.values)
                 else:
                     self.ui_value = float(self.values.values[0])
                     return float(self.values.values[0])
-        except ValueError:
+        except (ValueError, TypeError):
             pass
 
         if self._ui_value is None:

--- a/nexus_constructor/model/transformation.py
+++ b/nexus_constructor/model/transformation.py
@@ -30,11 +30,11 @@ class Transformation(Dataset):
         return [] if self._parent_component is None else [self._parent_component]
 
     @property
-    def type(self) -> str:
+    def transform_type(self) -> str:
         return self.attributes.get_attribute_value(CommonAttrs.TRANSFORMATION_TYPE)
 
-    @type.setter
-    def type(self, new_type):
+    @transform_type.setter
+    def transform_type(self, new_type):
         self.attributes.set_attribute_value(CommonAttrs.TRANSFORMATION_TYPE, new_type)
 
     @property
@@ -86,13 +86,15 @@ class Transformation(Dataset):
         Get a Qt3DCore.QTransform describing the transformation
         """
         transform = Qt3DCore.QTransform()
-        if self.type == TransformationType.ROTATION:
+        if self.transform_type == TransformationType.ROTATION:
             quaternion = transform.fromAxisAndAngle(self.vector, self.ui_value)
             transform.setRotation(quaternion)
-        elif self.type == TransformationType.TRANSLATION:
+        elif self.transform_type == TransformationType.TRANSLATION:
             transform.setTranslation(self.vector.normalized() * self.ui_value)
         else:
-            raise (RuntimeError(f'Unknown transformation of type "{self.type}".'))
+            raise (
+                RuntimeError(f'Unknown transformation of type "{self.transform_type}".')
+            )
         return transform.matrix()
 
     @property

--- a/nexus_constructor/model/transformation.py
+++ b/nexus_constructor/model/transformation.py
@@ -31,15 +31,15 @@ class Transformation(Dataset):
 
     @property
     def type(self) -> str:
-        return self.get_attribute_value(CommonAttrs.TRANSFORMATION_TYPE)
+        return self.attributes.get_attribute_value(CommonAttrs.TRANSFORMATION_TYPE)
 
     @type.setter
     def type(self, new_type):
-        self.set_attribute_value(CommonAttrs.TRANSFORMATION_TYPE, new_type)
+        self.attributes.set_attribute_value(CommonAttrs.TRANSFORMATION_TYPE, new_type)
 
     @property
     def vector(self) -> QVector3D:
-        vector = self.get_attribute_value(CommonAttrs.VECTOR)
+        vector = self.attributes.get_attribute_value(CommonAttrs.VECTOR)
         return (
             QVector3D(vector[0], vector[1], vector[2]) if vector is not None else None
         )
@@ -47,18 +47,18 @@ class Transformation(Dataset):
     @vector.setter
     def vector(self, new_vector: QVector3D):
         vector_as_np_array = np.array([new_vector.x(), new_vector.y(), new_vector.z()])
-        self.set_attribute_value(CommonAttrs.VECTOR, vector_as_np_array)
+        self.attributes.set_attribute_value(CommonAttrs.VECTOR, vector_as_np_array)
 
     @property
     def ui_value(self) -> float:
         try:
-            if isinstance(self.dataset, Dataset):
-                if np.isscalar(self.dataset.values):
-                    self.ui_value = float(self.dataset.values)
-                    return float(self.dataset.values)
+            if isinstance(self.values, Dataset):
+                if np.isscalar(self.values):
+                    self.ui_value = float(self.values.values)
+                    return float(self.values.values)
                 else:
-                    self.ui_value = float(self.dataset.values[0])
-                    return float(self.dataset.values[0])
+                    self.ui_value = float(self.values.values[0])
+                    return float(self.values.values[0])
         except ValueError:
             pass
 
@@ -97,15 +97,15 @@ class Transformation(Dataset):
 
     @property
     def units(self):
-        return self.get_attribute_value(CommonAttrs.UNITS)
+        return self.attributes.get_attribute_value(CommonAttrs.UNITS)
 
     @units.setter
     def units(self, new_units):
-        self.set_attribute_value(CommonAttrs.UNITS, new_units)
+        self.attributes.set_attribute_value(CommonAttrs.UNITS, new_units)
 
     @property
     def depends_on(self) -> "Transformation":
-        return self.get_attribute_value(CommonAttrs.DEPENDS_ON)
+        return self.attributes.get_attribute_value(CommonAttrs.DEPENDS_ON)
 
     @depends_on.setter
     def depends_on(self, new_depends_on: "Transformation"):
@@ -115,7 +115,7 @@ class Transformation(Dataset):
                 self.depends_on.deregister_dependent(self)
         except AttributeError:
             pass
-        self.set_attribute_value(CommonAttrs.DEPENDS_ON, new_depends_on)
+        self.attributes.set_attribute_value(CommonAttrs.DEPENDS_ON, new_depends_on)
         if new_depends_on is not None:
             new_depends_on.register_dependent(self)
 

--- a/nexus_constructor/treeview_utils.py
+++ b/nexus_constructor/treeview_utils.py
@@ -200,12 +200,16 @@ def get_link_transformation_frame(frame, model: Model, value):
 
 
 def get_transformation_frame(frame, model: Model, value):
-    if value.type == TransformationType.TRANSLATION:
+    if value.transform_type == TransformationType.TRANSLATION:
         frame.transformation_frame = EditTranslation(frame, value, model)
-    elif value.type == TransformationType.ROTATION:
+    elif value.transform_type == TransformationType.ROTATION:
         frame.transformation_frame = EditRotation(frame, value, model)
     else:
-        raise (RuntimeError('Transformation type "{}" is unknown.'.format(value.type)))
+        raise (
+            RuntimeError(
+                'Transformation type "{}" is unknown.'.format(value.transform_type)
+            )
+        )
     frame.layout().addWidget(frame.transformation_frame, Qt.AlignTop)
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,6 +1,6 @@
 from typing import Any
 from nexus_constructor.model.component import Component
-from nexus_constructor.model.dataset import Dataset, DatasetMetadata
+from nexus_constructor.model.dataset import Dataset
 
 
 def add_component_to_file(
@@ -11,9 +11,7 @@ def add_component_to_file(
     component = Component(name=component_name)
     component.set_field_value(
         name=field_name,
-        value=Dataset(
-            name=field_name, dataset=DatasetMetadata(type="Double"), values=field_value
-        ),
+        value=Dataset(name=field_name, type="Double", size="1", values=field_value),
         dtype="Double",
     )
     return component

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -14,5 +14,6 @@ def add_component_to_file(
         value=Dataset(
             name=field_name, dataset=DatasetMetadata(type="Double"), values=field_value
         ),
+        dtype="Double",
     )
     return component

--- a/tests/json/test_load_from_json.py
+++ b/tests/json/test_load_from_json.py
@@ -5,7 +5,6 @@ from mock import patch, mock_open
 
 from nexus_constructor.json.load_from_json import JSONReader, _retrieve_children_list
 from nexus_constructor.model.component import Component
-from nexus_constructor.model.dataset import DatasetMetadata
 from nexus_constructor.model.transformation import Transformation
 
 
@@ -218,7 +217,8 @@ def test_GIVEN_json_with_missing_value_WHEN_loading_from_json_THEN_json_loader_r
 def component_with_transformation() -> Component:
     transformation = Transformation(
         name="Transformation",
-        dataset=DatasetMetadata(type=None),
+        type="Double",
+        size="[1]",
         values="",
         parent_component=None,
     )

--- a/tests/model/test_attribute.py
+++ b/tests/model/test_attribute.py
@@ -1,6 +1,6 @@
 import pytest
 
-from nexus_constructor.model.node import FieldAttribute
+from nexus_constructor.model.attributes import FieldAttribute
 import numpy as np
 
 NAME = "field1"

--- a/tests/model/test_attribute.py
+++ b/tests/model/test_attribute.py
@@ -1,6 +1,6 @@
 import pytest
 
-from nexus_constructor.model.attribute import FieldAttribute
+from nexus_constructor.model.node import FieldAttribute
 import numpy as np
 
 NAME = "field1"

--- a/tests/model/test_dataset.py
+++ b/tests/model/test_dataset.py
@@ -1,10 +1,11 @@
-from nexus_constructor.model.dataset import Dataset, DatasetMetadata
+from nexus_constructor.model.dataset import Dataset
 
 
 def test_dataset_as_dict_contains_expected_keys():
-    test_dataset_metadata = DatasetMetadata("String", (0,))
     input_name = "test_dataset"
-    test_dataset = Dataset(input_name, test_dataset_metadata, "the_value")
+    test_dataset = Dataset(
+        name=input_name, size="[1]", type="String", values="the_value"
+    )
     dictionary_output = test_dataset.as_dict()
     for expected_key in ("name", "type"):
         assert expected_key in dictionary_output.keys()

--- a/tests/model/test_model_component.py
+++ b/tests/model/test_model_component.py
@@ -45,8 +45,8 @@ def test_component_set_field_with_numpy_array_correctly_sets_field_value():
     field_dataset = comp["field1"]
     assert field_dataset.name == field_name
     assert np.array_equal(field_dataset.values, field_value)
-    assert field_dataset.dataset.size == 2
-    assert field_dataset.dataset.type == dtype
+    assert field_dataset.size == 2
+    assert field_dataset.type == dtype
 
 
 def test_component_set_field_with_scalar_value_correctly_sets_field_value():
@@ -61,8 +61,8 @@ def test_component_set_field_with_scalar_value_correctly_sets_field_value():
 
     assert field_dataset.name == field_name
     assert field_dataset.values == data
-    assert field_dataset.dataset.size == [1]
-    assert field_dataset.dataset.type == dtype
+    assert field_dataset.size == [1]
+    assert field_dataset.type == dtype
 
 
 def test_component_as_dict_contains_transformations():

--- a/tests/model/test_node_helpers.py
+++ b/tests/model/test_node_helpers.py
@@ -1,5 +1,6 @@
 from nexus_constructor.model.component import Component
-from nexus_constructor.model.node import _get_item, _remove_item, _set_item, Attributes
+from nexus_constructor.model.group import Group
+from nexus_constructor.model.helpers import _get_item, _remove_item, _set_item
 
 
 def test_get_item_returns_correct_component_when_given_component_is_in_list():
@@ -77,14 +78,14 @@ def test_set_item_with_existing_component_in_overwrites_if_name_is_same():
 
 def test_get_absolute_path_works_with_no_parent():
     name = "test"
-    node = Attributes(name=name, parent_node=None)
+    node = Group(name=name, parent_node=None)
 
     assert node.absolute_path == f"/{name}"
 
 
 def test_get_absolute_path_works_if_component_with_parents():
     name1 = "thing1"
-    node1 = Attributes(name=name1, parent_node=None)
+    node1 = Group(name=name1, parent_node=None)
     name2 = "thing2"
-    node2 = Attributes(name=name2, parent_node=node1)
+    node2 = Group(name=name2, parent_node=node1)
     assert node2.absolute_path == f"/{name1}/{name2}"

--- a/tests/model/test_node_helpers.py
+++ b/tests/model/test_node_helpers.py
@@ -1,5 +1,5 @@
 from nexus_constructor.model.component import Component
-from nexus_constructor.model.node import _get_item, _remove_item, _set_item, Node
+from nexus_constructor.model.node import _get_item, _remove_item, _set_item, Attributes
 
 
 def test_get_item_returns_correct_component_when_given_component_is_in_list():
@@ -77,14 +77,14 @@ def test_set_item_with_existing_component_in_overwrites_if_name_is_same():
 
 def test_get_absolute_path_works_with_no_parent():
     name = "test"
-    node = Node(name=name, parent_node=None)
+    node = Attributes(name=name, parent_node=None)
 
     assert node.absolute_path == f"/{name}"
 
 
 def test_get_absolute_path_works_if_component_with_parents():
     name1 = "thing1"
-    node1 = Node(name=name1, parent_node=None)
+    node1 = Attributes(name=name1, parent_node=None)
     name2 = "thing2"
-    node2 = Node(name=name2, parent_node=node1)
+    node2 = Attributes(name=name2, parent_node=node1)
     assert node2.absolute_path == f"/{name1}/{name2}"

--- a/tests/test_component_fields.py
+++ b/tests/test_component_fields.py
@@ -1,7 +1,7 @@
 from nexus_constructor.model.component import add_fields_to_component, Component
 import numpy as np
 
-from nexus_constructor.model.dataset import Dataset, DatasetMetadata
+from nexus_constructor.model.dataset import Dataset
 
 
 class DummyListWidget:
@@ -36,7 +36,8 @@ def test_GIVEN_single_scalar_field_and_float_WHEN_adding_fields_to_component_THE
 
     field_value = Dataset(
         name=field_name,
-        dataset=DatasetMetadata(size=field_value_raw.size, type=field_dtype),
+        size=field_value_raw.size,
+        type=field_dtype,
         values=field_value_raw,
     )
 
@@ -58,11 +59,7 @@ def test_GIVEN_single_scalar_field_and_string_WHEN_adding_fields_to_component_TH
     field_name = "test_field"
     field_value_raw = np.string_(b"some_value")
 
-    field_value = Dataset(
-        name=field_name,
-        dataset=DatasetMetadata(size=[1], type=str),
-        values=field_value_raw,
-    )
+    field_value = Dataset(name=field_name, size=[1], type=str, values=field_value_raw,)
 
     field = DummyField(field_name, field_value, str)
     list_widget = DummyListWidget()

--- a/tests/test_component_tree_model.py
+++ b/tests/test_component_tree_model.py
@@ -6,7 +6,7 @@ from nexus_constructor.component_tree_model import (
 from nexus_constructor.model.model import Model
 from nexus_constructor.model.entry import Entry
 from nexus_constructor.model.component import Component
-from nexus_constructor.model.dataset import Dataset, DatasetMetadata
+from nexus_constructor.model.dataset import Dataset
 from nexus_constructor.model.entry import Instrument
 import pytest
 from PySide2.QtCore import QModelIndex, Qt
@@ -25,9 +25,8 @@ def _add_component_to_file(
     component = Component(component_name)
     component.set_field_value(
         field_name,
-        Dataset(
-            name=field_name, dataset=DatasetMetadata(type="Double"), values=field_value
-        ),
+        Dataset(name=field_name, type="Double", size="[1]", values=field_value),
+        dtype="Double",
     )
 
     return component

--- a/tests/test_disk_chopper_checker.py
+++ b/tests/test_disk_chopper_checker.py
@@ -18,7 +18,7 @@ from nexus_constructor.geometry.disk_chopper.disk_chopper_checker import (
     _units_are_valid,
     UNITS_REQUIRED,
 )
-from nexus_constructor.model.dataset import Dataset, DatasetMetadata
+from nexus_constructor.model.dataset import Dataset
 from tests.chopper_test_helpers import (  # noqa: F401
     N_SLITS,
     DEGREES_EDGES_ARR,
@@ -36,12 +36,8 @@ IMPROPER_UNITS = {
 
 def create_dataset(name: str, dtype: str, val: Any):
     if np.isscalar(val):
-        return Dataset(
-            name=name, dataset=DatasetMetadata(size=[1], type=dtype), values=str(val)
-        )
-    return Dataset(
-        name=name, dataset=DatasetMetadata(size=val.size, type=dtype), values=val
-    )
+        return Dataset(name=name, size=[1], type=dtype, values=str(val))
+    return Dataset(name=name, size=val.size, type=dtype, values=val)
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_remove_from_dependee_chain.py
+++ b/tests/test_remove_from_dependee_chain.py
@@ -1,15 +1,12 @@
 from nexus_constructor.model.component import Component
 from PySide2.QtGui import QVector3D
 
-from nexus_constructor.model.dataset import DatasetMetadata, Dataset
+from nexus_constructor.model.dataset import Dataset
 from nexus_constructor.model.instrument import Instrument
 import pytest
 
 values = Dataset(
-    name="scalar_value",
-    dataset=DatasetMetadata(type="Double", size=[1]),
-    values=90.0,
-    parent_node=None,
+    name="scalar_value", type="Double", size=[1], values=90.0, parent_node=None,
 )
 
 

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -28,13 +28,13 @@ def create_transform(
     ui_value=42.0,
     vector=QVector3D(1.0, 0.0, 0.0),
     type="Translation",
-    values=Dataset(name="", values=0, type="double", size=[1]),
+    values=Dataset(name="", values=None, type="double", size=[1]),
 ):
 
     translation = Transformation(
         name=name,
         parent_node=None,
-        values="test",
+        values=values,
         type="str",
         parent_component=None,
         size=[1],
@@ -43,7 +43,6 @@ def create_transform(
     translation.vector = vector
     translation.transform_type = type
     translation.ui_value = ui_value
-    translation.values = values
 
     return translation
 

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -28,7 +28,7 @@ def create_transform(
     ui_value=42.0,
     vector=QVector3D(1.0, 0.0, 0.0),
     type="Translation",
-    values=Dataset("", None, []),
+    values=Dataset(name="", values=0),
 ):
 
     translation = Transformation(

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -16,7 +16,7 @@ def _add_transform_to_file(
     name: str, value: Any, vector: QVector3D, transform_type: str
 ):
     transform = Transformation(name=name, type="Double", size="[1]", values=42)
-    transform.type = transform_type
+    transform.transform_type = transform_type
     transform.vector = vector
     transform.values = value
 
@@ -41,7 +41,7 @@ def create_transform(
     )
 
     translation.vector = vector
-    translation.type = type
+    translation.transform_type = type
     translation.ui_value = ui_value
     translation.values = values
 
@@ -74,7 +74,7 @@ def test_can_get_transform_properties():
         transform.vector == test_vector
     ), "Expected the transform vector to match what was in the NeXus file"
     assert (
-        transform.type == test_type
+        transform.transform_type == test_type
     ), "Expected the transform type to match what was in the NeXus file"
     assert (
         transform.values == test_values
@@ -115,7 +115,7 @@ def test_can_set_transform_properties():
     transform.name = test_name
     transform.ui_value = test_ui_value
     transform.vector = test_vector
-    transform.type = test_type
+    transform.transform_type = test_type
     transform.values = test_values
 
     assert (
@@ -128,7 +128,7 @@ def test_can_set_transform_properties():
         transform.vector == test_vector
     ), "Expected the transform vector to match what was in the NeXus file"
     assert (
-        transform.type == test_type
+        transform.transform_type == test_type
     ), "Expected the transform type to match what was in the NeXus file"
     assert (
         transform.values == test_values

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -2,7 +2,7 @@ import numpy as np
 from PySide2.QtGui import QVector3D
 
 from nexus_constructor.model.component import Component
-from nexus_constructor.model.dataset import Dataset, DatasetMetadata
+from nexus_constructor.model.dataset import Dataset
 from nexus_constructor.model.transformation import Transformation
 from typing import Any
 from tests.helpers import add_component_to_file  # noqa:F401
@@ -15,7 +15,7 @@ translation_type = "Translation"
 def _add_transform_to_file(
     name: str, value: Any, vector: QVector3D, transform_type: str
 ):
-    transform = Transformation(name=name, dataset=DatasetMetadata(type="Double"))
+    transform = Transformation(name=name, type="Double", size="[1]", values=42)
     transform.type = transform_type
     transform.vector = vector
     transform.values = value
@@ -28,18 +28,16 @@ def create_transform(
     ui_value=42.0,
     vector=QVector3D(1.0, 0.0, 0.0),
     type="Translation",
-    values=Dataset(name="", values=0),
+    values=Dataset(name="", values=0, type="double", size=[1]),
 ):
 
     translation = Transformation(
         name=name,
-        dataset=Dataset(
-            name="dataset",
-            dataset=DatasetMetadata([1], "str"),
-            values="test",
-            parent_node=None,
-        ),
         parent_node=None,
+        values="test",
+        type="str",
+        parent_component=None,
+        size=[1],
     )
 
     translation.vector = vector

--- a/tests/ui_tests/test_main_window_utils.py
+++ b/tests/ui_tests/test_main_window_utils.py
@@ -578,7 +578,7 @@ def test_GIVEN_translation_is_added_WHEN_adding_transformation_THEN_translation_
     sample_component = sample_component_index.internalPointer()
 
     assert len(sample_component.transforms) == 1
-    assert sample_component.transforms[0].type == "Translation"
+    assert sample_component.transforms[0].transform_type == "Translation"
 
 
 def test_GIVEN_rotation_is_added_WHEN_adding_transformation_THEN_rotation_is_added_to_component(
@@ -592,7 +592,7 @@ def test_GIVEN_rotation_is_added_WHEN_adding_transformation_THEN_rotation_is_add
     sample_component = sample_component_index.internalPointer()
 
     assert len(sample_component.transforms) == 1
-    assert sample_component.transforms[0].type == "Rotation"
+    assert sample_component.transforms[0].transform_type == "Rotation"
 
 
 def test_GIVEN_unknown_transformation_type_WHEN_adding_transformation_THEN_raises_value_error(
@@ -607,10 +607,8 @@ def test_GIVEN_unknown_transformation_type_WHEN_adding_transformation_THEN_raise
 
 
 def create_transformation(trans_type: TransformationType):
-    t = Transformation(
-        name="transformation", type="Double", size=[1], values=8
-    )
-    t.type = trans_type
+    t = Transformation(name="transformation", type="Double", size=[1], values=8)
+    t.transform_type = trans_type
     t.vector = QVector3D(1, 0, 0)
     return t
 

--- a/tests/ui_tests/test_main_window_utils.py
+++ b/tests/ui_tests/test_main_window_utils.py
@@ -5,7 +5,6 @@ from PySide2.QtGui import QVector3D
 from PySide2.QtWidgets import QToolBar, QWidget, QTreeView, QFrame, QVBoxLayout
 from nexus_constructor.component_tree_model import ComponentTreeModel
 from nexus_constructor.component_tree_view import ComponentEditorDelegate
-from nexus_constructor.model.dataset import DatasetMetadata
 from nexus_constructor.model.model import Model
 from nexus_constructor.model.transformation import Transformation
 from nexus_constructor.transformation_view import EditRotation, EditTranslation
@@ -609,7 +608,7 @@ def test_GIVEN_unknown_transformation_type_WHEN_adding_transformation_THEN_raise
 
 def create_transformation(trans_type: TransformationType):
     t = Transformation(
-        name="transformation", dataset=DatasetMetadata(type="Double"), values=8
+        name="transformation", type="Double", size=[1], values=8
     )
     t.type = trans_type
     t.vector = QVector3D(1, 0, 0)

--- a/tests/ui_tests/test_ui_add_component_window.py
+++ b/tests/ui_tests/test_ui_add_component_window.py
@@ -1794,7 +1794,7 @@ def test_UI_GIVEN_component_with_array_field_WHEN_editing_component_THEN_field_a
 
     field_name = "array"
     field_value = np.array([1, 2, 3, 4, 5])
-    component.set_field_value(field_name, field_value)
+    component.set_field_value(field_name, field_value, "int")
     dialog = AddComponentDialog(
         model,
         treeview_model,
@@ -1855,11 +1855,11 @@ def test_UI_GIVEN_component_with_multiple_fields_WHEN_editing_component_THEN_all
 
     field_name1 = "array"
     field_value1 = np.array([1, 2, 3, 4, 5])
-    component.set_field_value(field_name1, field_value1)
+    component.set_field_value(field_name1, field_value1, "int")
 
     field_name2 = "scalar"
     field_value2 = 1
-    component.set_field_value(field_name2, field_value2)
+    component.set_field_value(field_name2, field_value2, "int")
 
     dialog = AddComponentDialog(
         model,

--- a/tests/ui_tests/test_ui_field_attrs.py
+++ b/tests/ui_tests/test_ui_field_attrs.py
@@ -7,7 +7,7 @@ from PySide2.QtWidgets import QListWidget
 from nexus_constructor.field_attrs import FieldAttrsDialog, FieldAttrFrame
 import numpy as np
 
-from nexus_constructor.model.dataset import Dataset
+from nexus_constructor.model.dataset import Dataset, DatasetMetadata
 from tests.ui_tests.ui_test_utils import show_and_close_window
 
 
@@ -39,7 +39,7 @@ def test_GIVEN_existing_field_with_attr_WHEN_editing_component_THEN_both_field_a
     qtbot, attr_val, field_attributes_dialog
 ):
     attr_key = "testattr"
-    ds = Dataset("test", [])
+    ds = Dataset(name="test", dataset=DatasetMetadata("1", "String"))
     ds.set_attribute_value(attr_key, attr_val)
 
     field_attributes_dialog.fill_existing_attrs(ds)
@@ -54,7 +54,7 @@ def test_GIVEN_existing_field_with_attr_which_is_in_excludelist_WHEN_editing_com
     attr_key = "units"
     attr_val = "m"
 
-    ds = Dataset("test", [])
+    ds = Dataset(name="test", dataset=DatasetMetadata("1", "String"))
     ds.set_attribute_value(attr_key, attr_val)
 
     field_attributes_dialog.fill_existing_attrs(ds)

--- a/tests/ui_tests/test_ui_field_attrs.py
+++ b/tests/ui_tests/test_ui_field_attrs.py
@@ -7,7 +7,7 @@ from PySide2.QtWidgets import QListWidget
 from nexus_constructor.field_attrs import FieldAttrsDialog, FieldAttrFrame
 import numpy as np
 
-from nexus_constructor.model.dataset import Dataset, DatasetMetadata
+from nexus_constructor.model.dataset import Dataset
 from tests.ui_tests.ui_test_utils import show_and_close_window
 
 
@@ -39,8 +39,8 @@ def test_GIVEN_existing_field_with_attr_WHEN_editing_component_THEN_both_field_a
     qtbot, attr_val, field_attributes_dialog
 ):
     attr_key = "testattr"
-    ds = Dataset(name="test", dataset=DatasetMetadata("1", "String"))
-    ds.set_attribute_value(attr_key, attr_val)
+    ds = Dataset(name="test", size="1", type="String", values="")
+    ds.attributes.set_attribute_value(attr_key, attr_val)
 
     field_attributes_dialog.fill_existing_attrs(ds)
 
@@ -54,8 +54,8 @@ def test_GIVEN_existing_field_with_attr_which_is_in_excludelist_WHEN_editing_com
     attr_key = "units"
     attr_val = "m"
 
-    ds = Dataset(name="test", dataset=DatasetMetadata("1", "String"))
-    ds.set_attribute_value(attr_key, attr_val)
+    ds = Dataset(name="test", size="1", type="String", values="")
+    ds.attributes.set_attribute_value(attr_key, attr_val)
 
     field_attributes_dialog.fill_existing_attrs(ds)
 

--- a/tests/ui_tests/test_ui_fields.py
+++ b/tests/ui_tests/test_ui_fields.py
@@ -47,8 +47,8 @@ def test_ui_field_GIVEN_field_has_units_filled_in_ui_WHEN_getting_field_group_TH
     field.units = units
     group = field.value
 
-    assert group.contains_attribute("units")
-    assert group.get_attribute_value("units") == units
+    assert group.attributes.contains_attribute("units")
+    assert group.attributes.get_attribute_value("units") == units
 
 
 def test_ui_field_GIVEN_field_does_not_have_units_filled_in_ui_WHEN_getting_field_group_THEN_units_are_not_saved(
@@ -63,7 +63,7 @@ def test_ui_field_GIVEN_field_does_not_have_units_filled_in_ui_WHEN_getting_fiel
 
     group = field.value
 
-    assert not group.contains_attribute("units")
+    assert not group.attributes.contains_attribute("units")
 
 
 def test_ui_stream_field_GIVEN_f142_is_selected_WHEN_combo_is_changed_THEN_value_units_edit_is_shown(

--- a/tests/ui_tests/test_ui_transformation_view.py
+++ b/tests/ui_tests/test_ui_transformation_view.py
@@ -4,9 +4,12 @@ import h5py
 from PySide2.QtGui import QVector3D
 from mock import Mock
 
-from nexus_constructor.field_attrs import _get_human_readable_type
 from nexus_constructor.model.component import Component
-from nexus_constructor.model.dataset import Dataset, DatasetMetadata
+from nexus_constructor.model.dataset import (
+    Dataset,
+    DatasetMetadata,
+    _get_human_readable_type,
+)
 from nexus_constructor.model.entry import Instrument
 from nexus_constructor.transformation_view import EditRotation, EditTranslation
 from nexus_constructor.validators import FieldType

--- a/tests/ui_tests/test_ui_transformation_view.py
+++ b/tests/ui_tests/test_ui_transformation_view.py
@@ -7,8 +7,7 @@ from mock import Mock
 from nexus_constructor.model.component import Component
 from nexus_constructor.model.dataset import (
     Dataset,
-    DatasetMetadata,
-    _get_human_readable_type,
+
 )
 from nexus_constructor.model.entry import Instrument
 from nexus_constructor.transformation_view import EditRotation, EditTranslation
@@ -34,7 +33,7 @@ def create_corresponding_value_dataset(value: Any):
         size = len(value)
 
     return Dataset(
-        name=name, dataset=DatasetMetadata(type=type, size=[size]), values=value,
+        name=name, type=type, size=[size], values=value,
     )
 
 

--- a/tests/ui_tests/test_ui_transformation_view.py
+++ b/tests/ui_tests/test_ui_transformation_view.py
@@ -4,11 +4,9 @@ import h5py
 from PySide2.QtGui import QVector3D
 from mock import Mock
 
+from nexus_constructor.field_attrs import _get_human_readable_type
 from nexus_constructor.model.component import Component
-from nexus_constructor.model.dataset import (
-    Dataset,
-
-)
+from nexus_constructor.model.dataset import Dataset
 from nexus_constructor.model.entry import Instrument
 from nexus_constructor.transformation_view import EditRotation, EditTranslation
 from nexus_constructor.validators import FieldType
@@ -32,9 +30,7 @@ def create_corresponding_value_dataset(value: Any):
     else:
         size = len(value)
 
-    return Dataset(
-        name=name, type=type, size=[size], values=value,
-    )
+    return Dataset(name=name, type=type, size=[size], values=value,)
 
 
 def test_UI_GIVEN_scalar_vector_WHEN_creating_translation_view_THEN_ui_is_filled_correctly(


### PR DESCRIPTION
### Issue

Closes #814 

### Description of work

Makes `dtype` a required argument for `set_field_value()` and replaces any instances where it was used without the argument and provides one. 

### Acceptance Criteria 

- Everything still works and tests still pass.
- Dtypes that have been set are of the correct type

### UI tests

Some changed to provide the dtype arg if not already doing so. 

### Nominate for Group Code Review

- [ ] Nominate for code review 
