### PR TITLE
changing datatype check to check for integers and not floats

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: stable
+    rev: 19.10b0
     hooks:
     - id: black
       language_version: python3

--- a/nexus_constructor/json/shape_reader.py
+++ b/nexus_constructor/json/shape_reader.py
@@ -220,7 +220,7 @@ class ShapeReader:
             return
 
         vertices_dtype = self._find_and_validate_data_type(
-            vertices_dataset, INT_TYPES, CommonAttrs.VERTICES
+            vertices_dataset, FLOAT_TYPES, CommonAttrs.VERTICES
         )
         vertices = self._find_and_validate_values_list(
             vertices_dataset, FLOAT_TYPES, CommonAttrs.VERTICES

--- a/nexus_constructor/json/shape_reader.py
+++ b/nexus_constructor/json/shape_reader.py
@@ -41,9 +41,7 @@ from nexus_constructor.unit_utils import (
 )
 
 
-def _convert_vertices_to_qvector3d(
-    vertices: List[List[float]],
-) -> List[QVector3D]:
+def _convert_vertices_to_qvector3d(vertices: List[List[float]],) -> List[QVector3D]:
     """
     Converts a list of vertices to QVector3D
     :param vertices: The list of vertices.

--- a/nexus_constructor/json/shape_reader.py
+++ b/nexus_constructor/json/shape_reader.py
@@ -41,7 +41,9 @@ from nexus_constructor.unit_utils import (
 )
 
 
-def _convert_vertices_to_qvector3d(vertices: List[List[float]],) -> List[QVector3D]:
+def _convert_vertices_to_qvector3d(
+    vertices: List[List[float]],
+) -> List[QVector3D]:
     """
     Converts a list of vertices to QVector3D
     :param vertices: The list of vertices.
@@ -220,7 +222,7 @@ class ShapeReader:
             return
 
         vertices_dtype = self._find_and_validate_data_type(
-            vertices_dataset, FLOAT_TYPES, CommonAttrs.VERTICES
+            vertices_dataset, INT_TYPES, CommonAttrs.VERTICES
         )
         vertices = self._find_and_validate_values_list(
             vertices_dataset, FLOAT_TYPES, CommonAttrs.VERTICES

--- a/nexus_constructor/model/component.py
+++ b/nexus_constructor/model/component.py
@@ -343,7 +343,7 @@ class Component(Group):
         vertices = CylindricalGeometry.calculate_vertices(
             axis_direction, height, radius
         )
-        geometry.set_field_value(CommonAttrs.VERTICES, vertices, ValueTypes.INT)
+        geometry.set_field_value(CommonAttrs.VERTICES, vertices, ValueTypes.FLOAT)
 
         # # Specify 0th vertex is base centre, 1st is base edge, 2nd is top centre
         geometry.set_field_value(CYLINDERS, np.array([0, 1, 2]), ValueTypes.INT)


### PR DESCRIPTION
### Issue

https://github.com/ess-dmsc/nexus-constructor/issues/839

### Description of work

Erroneous warning message pops up due to datatype check done for float type rather than integer for vertices.

### Acceptance Criteria 

Test if the erroneous warning message still persists.
