### PR TITLE
ECDC-2435: Enable live update of transformations

### DIFF
--- a/nexus_constructor/component_tree_view.py
+++ b/nexus_constructor/component_tree_view.py
@@ -93,7 +93,7 @@ class ComponentEditorDelegate(QStyledItemDelegate):
     def setModelData(
         self, editorWidget: QWidget, model: QAbstractItemModel, index: QModelIndex
     ):
-        editorWidget.transformation_frame.saveChanges()
+        editorWidget.transformation_frame.save_all_changes()
 
     def sizeHint(self, option: QStyleOptionViewItem, index: QModelIndex) -> QSize:
         model = index.model()

--- a/nexus_constructor/transformation_view.py
+++ b/nexus_constructor/transformation_view.py
@@ -11,7 +11,7 @@ from nexus_constructor.model.model import Model
 from nexus_constructor.model.transformation import Transformation
 from nexus_constructor.unit_utils import METRES, RADIANS
 from ui.link import Ui_Link
-from ui.transformation import Ui_Transformation
+from ui.transformation import UiTransformation
 
 if TYPE_CHECKING:
     from nexus_constructor.model.value_type import ValueType  # noqa: F401
@@ -21,8 +21,7 @@ class EditTransformation(QGroupBox):
     def __init__(self, parent: QWidget, transformation: Transformation, model: Model):
         super().__init__(parent)
         self.model = model
-        self.transformation_frame = Ui_Transformation()
-        self.transformation_frame.setupUi(self)
+        self.transformation_frame = UiTransformation(self)
         self.transformation = transformation
         current_vector = self.transformation.vector
         self._fill_in_existing_fields(current_vector)

--- a/nexus_constructor/transformation_view.py
+++ b/nexus_constructor/transformation_view.py
@@ -71,7 +71,6 @@ class EditTransformation(QGroupBox):
         self.transformation.ui_value = self.transformation_frame.value_spinbox.value()
         self.transformation.values = self.transformation_frame.magnitude_widget.value
         self.transformation.units = self.transformation_frame.magnitude_widget.units
-        self.model.signals.transformation_changed.emit()
 
     def check_field_type(self):
         if self.transformation_frame.magnitude_widget.field_type_is_scalar():
@@ -87,12 +86,10 @@ class EditTransformation(QGroupBox):
         self.transformation.vector = QVector3D(
             *[spinbox.value() for spinbox in self.transformation_frame.spinboxes[:-1]]
         )
-        self.model.signals.transformation_changed.emit()
 
     def save_transformation_name(self):
         if self.transformation_frame.name_line_edit.text() != self.transformation.name:
             self.transformation.name = self.transformation_frame.name_line_edit.text()
-            self.model.signals.transformation_changed.emit()
 
     def save_all_changes(self):
         self.save_transformation_name()

--- a/nexus_constructor/transformation_view.py
+++ b/nexus_constructor/transformation_view.py
@@ -71,6 +71,7 @@ class EditTransformation(QGroupBox):
         self.transformation.ui_value = self.transformation_frame.value_spinbox.value()
         self.transformation.values = self.transformation_frame.magnitude_widget.value
         self.transformation.units = self.transformation_frame.magnitude_widget.units
+        self.model.signals.transformation_changed.emit()
 
     def check_field_type(self):
         if self.transformation_frame.magnitude_widget.field_type_is_scalar():
@@ -86,10 +87,12 @@ class EditTransformation(QGroupBox):
         self.transformation.vector = QVector3D(
             *[spinbox.value() for spinbox in self.transformation_frame.spinboxes[:-1]]
         )
+        self.model.signals.transformation_changed.emit()
 
     def save_transformation_name(self):
         if self.transformation_frame.name_line_edit.text() != self.transformation.name:
             self.transformation.name = self.transformation_frame.name_line_edit.text()
+            self.model.signals.transformation_changed.emit()
 
     def save_all_changes(self):
         self.save_transformation_name()

--- a/nexus_constructor/transformation_view.py
+++ b/nexus_constructor/transformation_view.py
@@ -79,10 +79,13 @@ class EditTransformation(QGroupBox):
 
         self.transformation.ui_value = self.transformation_frame.value_spinbox.value()
         self.transformation.values = self.transformation_frame.magnitude_widget.value
+        self.transformation.units = self.transformation_frame.magnitude_widget.units
+        self.model.signals.transformation_changed.emit()
+
+    def save_transformation_vector(self):
         self.transformation.vector = QVector3D(
             *[spinbox.value() for spinbox in self.transformation_frame.spinboxes[:-1]]
         )
-        self.transformation.units = self.transformation_frame.magnitude_widget.units
         self.model.signals.transformation_changed.emit()
 
     def save_transformation_name(self):
@@ -105,6 +108,9 @@ class EditTranslation(EditTransformation):
             self.save_transformation_name
         )
 
+        for box in self.transformation_frame.spinboxes[:-1]:
+            box.textChanged.connect(self.save_transformation_vector)
+
 
 class EditRotation(EditTransformation):
     def __init__(self, parent: QWidget, transformation: Transformation, model: Model):
@@ -119,6 +125,9 @@ class EditRotation(EditTransformation):
         self.transformation_frame.name_line_edit.textChanged.connect(
             self.save_transformation_name
         )
+
+        for box in self.transformation_frame.spinboxes[:-1]:
+            box.textChanged.connect(self.save_transformation_vector)
 
 
 def links_back_to_component(reference: Component, comparison: Component):

--- a/nexus_constructor/transformation_view.py
+++ b/nexus_constructor/transformation_view.py
@@ -66,8 +66,14 @@ class EditTransformation(QGroupBox):
         ]:
             ui_element.setEnabled(True)
 
-    def saveChanges(self):
+    def save_value(self):
+        self.check_field_type()
+        self.transformation.ui_value = self.transformation_frame.value_spinbox.value()
+        self.transformation.values = self.transformation_frame.magnitude_widget.value
+        self.transformation.units = self.transformation_frame.magnitude_widget.units
+        self.model.signals.transformation_changed.emit()
 
+    def check_field_type(self):
         if self.transformation_frame.magnitude_widget.field_type_is_scalar():
             try:
                 value_3d_view: "ValueType" = (
@@ -76,11 +82,6 @@ class EditTransformation(QGroupBox):
                 self.transformation_frame.value_spinbox.setValue(float(value_3d_view))
             except ValueError:
                 pass
-
-        self.transformation.ui_value = self.transformation_frame.value_spinbox.value()
-        self.transformation.values = self.transformation_frame.magnitude_widget.value
-        self.transformation.units = self.transformation_frame.magnitude_widget.units
-        self.model.signals.transformation_changed.emit()
 
     def save_transformation_vector(self):
         self.transformation.vector = QVector3D(
@@ -92,6 +93,11 @@ class EditTransformation(QGroupBox):
         if self.transformation_frame.name_line_edit.text() != self.transformation.name:
             self.transformation.name = self.transformation_frame.name_line_edit.text()
             self.model.signals.transformation_changed.emit()
+
+    def save_all_changes(self):
+        self.save_transformation_name()
+        self.save_transformation_vector()
+        self.save_value()
 
 
 class EditTranslation(EditTransformation):
@@ -111,6 +117,10 @@ class EditTranslation(EditTransformation):
         for box in self.transformation_frame.spinboxes[:-1]:
             box.textChanged.connect(self.save_transformation_vector)
 
+        self.transformation_frame.magnitude_widget.value_line_edit.textChanged.connect(
+            self.save_value
+        )
+
 
 class EditRotation(EditTransformation):
     def __init__(self, parent: QWidget, transformation: Transformation, model: Model):
@@ -128,6 +138,10 @@ class EditRotation(EditTransformation):
 
         for box in self.transformation_frame.spinboxes[:-1]:
             box.textChanged.connect(self.save_transformation_vector)
+
+        self.transformation_frame.magnitude_widget.value_line_edit.textChanged.connect(
+            self.save_value
+        )
 
 
 def links_back_to_component(reference: Component, comparison: Component):
@@ -197,5 +211,5 @@ class EditTransformationLink(QFrame):
     def enable(self):
         self.populate_combo_box()
 
-    def saveChanges(self):
+    def save_all_changes(self):
         self.signals.transformation_changed.emit()

--- a/nexus_constructor/transformation_view.py
+++ b/nexus_constructor/transformation_view.py
@@ -79,13 +79,16 @@ class EditTransformation(QGroupBox):
 
         self.transformation.ui_value = self.transformation_frame.value_spinbox.value()
         self.transformation.values = self.transformation_frame.magnitude_widget.value
-        if self.transformation_frame.name_line_edit.text() != self.transformation.name:
-            self.transformation.name = self.transformation_frame.name_line_edit.text()
         self.transformation.vector = QVector3D(
             *[spinbox.value() for spinbox in self.transformation_frame.spinboxes[:-1]]
         )
         self.transformation.units = self.transformation_frame.magnitude_widget.units
         self.model.signals.transformation_changed.emit()
+
+    def save_transformation_name(self):
+        if self.transformation_frame.name_line_edit.text() != self.transformation.name:
+            self.transformation.name = self.transformation_frame.name_line_edit.text()
+            self.model.signals.transformation_changed.emit()
 
 
 class EditTranslation(EditTransformation):
@@ -98,6 +101,10 @@ class EditTranslation(EditTransformation):
         self.transformation_frame.value_label.setText("Distance (m)")
         self.setTitle(TransformationType.TRANSLATION)
 
+        self.transformation_frame.name_line_edit.textChanged.connect(
+            self.save_transformation_name
+        )
+
 
 class EditRotation(EditTransformation):
     def __init__(self, parent: QWidget, transformation: Transformation, model: Model):
@@ -108,6 +115,10 @@ class EditRotation(EditTransformation):
         self.transformation_frame.vector_label.setText("Rotation Axis")
         self.transformation_frame.value_label.setText("Angle (°)")
         self.setTitle(TransformationType.ROTATION)
+
+        self.transformation_frame.name_line_edit.textChanged.connect(
+            self.save_transformation_name
+        )
 
 
 def links_back_to_component(reference: Component, comparison: Component):

--- a/tests/ui_tests/test_ui_transformation_view.py
+++ b/tests/ui_tests/test_ui_transformation_view.py
@@ -208,7 +208,7 @@ def test_UI_GIVEN_vector_updated_WHEN_saving_view_changes_THEN_model_is_updated(
     view.transformation_frame.y_spinbox.setValue(new_y)
     view.transformation_frame.z_spinbox.setValue(new_z)
 
-    view.saveChanges()
+    view.save_all_changes()
 
     assert transform.vector == QVector3D(new_x, new_y, new_z)
 
@@ -275,7 +275,7 @@ def test_UI_GIVEN_new_values_are_provided_WHEN_save_changes_is_called_THEN_trans
     new_x = 4
 
     view.transformation_frame.x_spinbox.setValue(new_x)
-    view.saveChanges()
+    view.save_all_changes()
     model.signals.transformation_changed.emit.assert_called_once()
     assert transform.vector == QVector3D(new_x, y, z)
 

--- a/tests/ui_tests/test_ui_transformation_view.py
+++ b/tests/ui_tests/test_ui_transformation_view.py
@@ -276,7 +276,6 @@ def test_UI_GIVEN_new_values_are_provided_WHEN_save_changes_is_called_THEN_trans
 
     view.transformation_frame.x_spinbox.setValue(new_x)
     view.save_all_changes()
-    model.signals.transformation_changed.emit.assert_called_once()
     assert transform.vector == QVector3D(new_x, y, z)
 
 

--- a/ui/transformation.py
+++ b/ui/transformation.py
@@ -18,46 +18,35 @@ if TYPE_CHECKING:
     from nexus_constructor.transformation_view import EditTransformation
 
 
-class Ui_Transformation:
-    def setupUi(self, Transformation: "EditTransformation"):
+class UiTransformation:
+    def __init__(self, Transformation: "EditTransformation"):
         Transformation.setObjectName("Transformation")
         Transformation.resize(361, 171)
-        self.frame_layout = QVBoxLayout(Transformation)
-        self.frame_layout.setContentsMargins(4, 4, 4, 4)
+
         self.main_layout = QVBoxLayout()
         self.main_layout.setSpacing(4)
+
+        self.frame_layout = QVBoxLayout(Transformation)
+        self.frame_layout.setContentsMargins(4, 4, 4, 4)
 
         self.name_layout = QHBoxLayout()
         self.name_layout.setSpacing(-1)
         self.name_label = QLabel("Name", Transformation)
         self._make_text_bold(self.name_label)
-
-        self.name_layout.addWidget(self.name_label)
         self.name_line_edit = QLineEdit(Transformation)
-
-        self.name_layout.addWidget(self.name_line_edit)
-        self.main_layout.addLayout(self.name_layout)
-
-        self._add_line()
 
         self.vector_label = QLabel("", Transformation)
         self._make_text_bold(self.vector_label)
-        self.main_layout.addWidget(self.vector_label)
-
-        self._set_up_vector_box(Transformation)
-
-        self._add_line()
 
         self.value_label = QLabel("")
         self._make_text_bold(self.value_label)
-        self.main_layout.addWidget(self.value_label)
 
         self.magnitude_widget = FieldWidget(hide_name_field=True)
         self.magnitude_widget.setFrameShape(QFrame.NoFrame)
         self.magnitude_widget.setMinimumHeight(40)
-        self.main_layout.addWidget(self.magnitude_widget)
 
         self.ui_placeholder_layout = QFormLayout()
+
         self.value_spinbox = QDoubleSpinBox(Transformation)
         self.value_spinbox.setToolTip("Placeholder value for 3D view to use")
         self.value_spinbox.setDecimals(8)
@@ -66,46 +55,60 @@ class Ui_Transformation:
             "Value to use in 3D view:", self.value_spinbox
         )
 
-        self.main_layout.addLayout(self.ui_placeholder_layout)
+        self.setup_ui(Transformation)
 
+    def setup_ui(self, transformation):
+        self.setup_name_layout()
+        self.setup_vector_layout(transformation)
+        self.setup_value_and_magnitude()
         self.set_spinbox_ranges()
 
         self.frame_layout.addLayout(self.main_layout)
 
-        self.retranslateUi(Transformation)
-        QMetaObject.connectSlotsByName(Transformation)
+        self.retranslate_ui(transformation)
+        QMetaObject.connectSlotsByName(transformation)
 
-    def _add_line(self):
-        line = QFrame()
-        line.setFrameShape((QFrame.HLine))
-        line.setFrameShadow(QFrame.Sunken)
-        self.main_layout.addWidget(line)
+    def setup_value_and_magnitude(self):
+        self.main_layout.addWidget(self.value_label)
+        self.main_layout.addWidget(self.magnitude_widget)
+        self.main_layout.addLayout(self.ui_placeholder_layout)
 
-    @staticmethod
-    def _make_text_bold(label: QLabel):
-        font = label.font()
-        font.setBold(True)
-        label.setFont(font)
+    def setup_vector_layout(self, transformation):
+        self.main_layout.addWidget(self.vector_label)
+        self._set_up_vector_box(transformation)
+        self._add_line()
 
-    def _set_up_vector_box(self, Transformation: "EditTransformation"):
+    def setup_name_layout(self):
+        self.name_layout.addWidget(self.name_label)
+        self.name_layout.addWidget(self.name_line_edit)
+        self.main_layout.addLayout(self.name_layout)
+        self._add_line()
+
+    def _set_up_vector_box(self, transformation):
         self.xyz_layout = QHBoxLayout()
 
         self.x_layout = QFormLayout()
-        self.x_spinbox = QDoubleSpinBox(Transformation)
+        self.x_spinbox = QDoubleSpinBox(transformation)
         self.x_layout.addRow("x:", self.x_spinbox)
         self.xyz_layout.addLayout(self.x_layout)
 
         self.y_layout = QFormLayout()
-        self.y_spinbox = QDoubleSpinBox(Transformation)
+        self.y_spinbox = QDoubleSpinBox(transformation)
         self.y_layout.addRow("y:", self.y_spinbox)
         self.xyz_layout.addLayout(self.y_layout)
 
         self.z_layout = QFormLayout()
-        self.z_spinbox = QDoubleSpinBox(Transformation)
+        self.z_spinbox = QDoubleSpinBox(transformation)
         self.z_layout.addRow("z:", self.z_spinbox)
         self.xyz_layout.addLayout(self.z_layout)
 
         self.main_layout.addLayout(self.xyz_layout)
+
+    def _add_line(self):
+        line = QFrame()
+        line.setFrameShape(QFrame.HLine)
+        line.setFrameShadow(QFrame.Sunken)
+        self.main_layout.addWidget(line)
 
     def set_spinbox_ranges(self):
         self.spinboxes = [
@@ -118,10 +121,17 @@ class Ui_Transformation:
             spinbox.setRange(-10000000, 10000000)
             spinbox.setDecimals(5)
 
-    def retranslateUi(self, Transformation):
-        Transformation.setWindowTitle(
+    @staticmethod
+    def _make_text_bold(label: QLabel):
+        font = label.font()
+        font.setBold(True)
+        label.setFont(font)
+
+    @staticmethod
+    def retranslate_ui(transformation):
+        transformation.setWindowTitle(
             QApplication.translate("Transformation", "GroupBox", None, -1)
         )
-        Transformation.setTitle(
+        transformation.setTitle(
             QApplication.translate("Transformation", "Translation", None, -1)
         )

--- a/ui/transformation.py
+++ b/ui/transformation.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from nexus_constructor.transformation_view import EditTransformation
 
 
-class Ui_Transformation(object):
+class Ui_Transformation:
     def setupUi(self, Transformation: "EditTransformation"):
         Transformation.setObjectName("Transformation")
         Transformation.resize(361, 171)


### PR DESCRIPTION
### Issue

ECDC-2435

### Description of work
This PR enables live update of value changes in transformations view. In addition some code clear up and enhancement has been done.

Easiest way to see if changes work:

- Change the `value` field next to `Scalar dataset` (under `Distance` if it is a `Translation`, or under `Angle` if it is a `Rotation`. `Vale to use in 3D view` should change simultaneously. Before the changes in this PR, you have to a an `Enter` to update `3D view` value.