### PR TITLE
Rearrange json utilities module

### DIFF
--- a/nexus_constructor/json/load_from_json.py
+++ b/nexus_constructor/json/load_from_json.py
@@ -1,14 +1,11 @@
 import json
-from typing import Dict, List, Optional, Tuple, Union
-
-import numpy as np
+from typing import Dict, Optional, Tuple
 
 from nexus_constructor.common_attrs import (
     PIXEL_SHAPE_GROUP_NAME,
     SHAPE_GROUP_NAME,
     CommonAttrs,
     CommonKeys,
-    NodeType,
 )
 from nexus_constructor.component_type import COMPONENT_TYPES
 from nexus_constructor.json.json_warnings import (
@@ -20,7 +17,11 @@ from nexus_constructor.json.json_warnings import (
 )
 from nexus_constructor.json.load_from_json_utils import (
     DEPENDS_ON_IGNORE,
+    _add_field_to_group,
+    _find_depends_on_path,
     _find_nx_class,
+    _find_shape_information,
+    _retrieve_children_list,
 )
 from nexus_constructor.json.shape_reader import ShapeReader
 from nexus_constructor.json.transform_id import TransformId
@@ -29,40 +30,10 @@ from nexus_constructor.json.transformation_reader import (
     get_component_and_transform_name,
 )
 from nexus_constructor.model.component import Component
-from nexus_constructor.model.dataset import Dataset
 from nexus_constructor.model.entry import Entry
-from nexus_constructor.model.group import TRANSFORMS_GROUP_NAME, Group
+from nexus_constructor.model.group import TRANSFORMS_GROUP_NAME
 from nexus_constructor.model.instrument import Instrument
-from nexus_constructor.model.stream import (
-    ADC_PULSE_DEBUG,
-    ARRAY_SIZE,
-    CHUNK_CHUNK_KB,
-    CHUNK_CHUNK_MB,
-    DATA_TYPE,
-    DATASET,
-    EDGE_TYPE,
-    ERROR_TYPE,
-    INDEX_EVERY_KB,
-    INDEX_EVERY_MB,
-    LINK,
-    SHAPE,
-    SOURCE,
-    STORE_LATEST_INTO,
-    TOPIC,
-    VALUE_UNITS,
-    EV42Stream,
-    F142Stream,
-    HS00Stream,
-    Link,
-    NS10Stream,
-    SENVStream,
-    Stream,
-    StreamGroup,
-    TDCTStream,
-    WriterModules,
-)
 from nexus_constructor.model.transformation import Transformation
-from nexus_constructor.model.value_type import VALUE_TYPE_TO_NP
 
 """
 The current implementation makes a couple of assumptions that may not hold true for all valid JSON descriptions of
@@ -78,182 +49,6 @@ CHILD_EXCLUDELIST = [
     TRANSFORMS_GROUP_NAME,
     CommonAttrs.DEPENDS_ON,
 ]
-
-
-def _retrieve_children_list(json_dict: Dict) -> List:
-    """
-    Attempts to retrieve the children from the JSON dictionary.
-    :param json_dict: The JSON dictionary loaded by the user.
-    :return: The children value is returned if it was found, otherwise an empty list is returned.
-    """
-    value = []
-    try:
-        entry = json_dict[CommonKeys.CHILDREN][0]
-        value = entry[CommonKeys.CHILDREN]
-    except (KeyError, IndexError, TypeError):
-        pass
-    return value
-
-
-def _find_shape_information(children: List[Dict]) -> Union[Dict, None]:
-    """
-    Tries to get the shape information from a component.
-    :param children: The list of dictionaries.
-    :return: The shape attribute if it could be found, otherwise None.
-    """
-    value = None
-    try:
-        for item in children:
-            if item[CommonKeys.NAME] in [SHAPE_GROUP_NAME, PIXEL_SHAPE_GROUP_NAME]:
-                value = item
-    except KeyError:
-        pass
-    return value
-
-
-def _add_field_to_group(item: Dict, group: Group):
-    child: Group
-    if CommonKeys.TYPE in item:
-        if item[CommonKeys.NAME] == TRANSFORMS_GROUP_NAME:
-            return
-        field_type = item[CommonKeys.TYPE]
-        child_name = item[CommonKeys.NAME]
-        if field_type == NodeType.GROUP:
-            child = _create_group(item, group)
-        else:
-            raise Exception(
-                f'Found unknown field type ("{field_type}") when loading JSON - {child_name}'
-            )
-        group[child_name] = child
-    elif CommonKeys.MODULE in item:
-        stream: Union[
-            Dataset,
-            Link,
-            NS10Stream,
-            SENVStream,
-            TDCTStream,
-            EV42Stream,
-            F142Stream,
-            HS00Stream,
-        ]
-        writer_module = item[CommonKeys.MODULE]
-        if writer_module == LINK:
-            stream = _create_link(item)
-        elif writer_module == DATASET:
-            if item[NodeType.CONFIG][CommonKeys.NAME] == CommonAttrs.DEPENDS_ON:
-                return
-            stream = _create_dataset(item, group)
-        else:
-            stream = _create_stream(item)
-        group.children.append(
-            stream
-        )  # Can't use the `[]` operator because streams do not have a name to use as a key
-    else:
-        raise Exception(
-            "Unable to add field as neither writer module type nor child type was found in the current node."
-        )
-
-
-def _find_depends_on_path(items: List[Dict], name: str) -> Optional[str]:
-    if not isinstance(items, list):
-        raise RuntimeError(
-            f'List of children in node with the name "{name}" is not a list.'
-        )
-    for item in items:
-        try:
-            config = item[NodeType.CONFIG]
-            if config[CommonKeys.NAME] != CommonAttrs.DEPENDS_ON:
-                continue
-            return config[CommonKeys.VALUES]
-        except KeyError:
-            pass  # Not all items has a config node, ignore those that do not.
-    return None
-
-
-def _create_stream(json_object: Dict) -> Stream:
-    """
-    Given a dictionary containing a stream, create a corresponding stream object to be used in the model.
-    :param json_object: JSON dictionary containing a stream.
-    :return: A stream object containing relevant data from the JSON.
-    """
-    stream_object = json_object[NodeType.CONFIG]
-    writer_module = json_object[CommonKeys.MODULE]
-    source = stream_object[SOURCE]
-    topic = stream_object[TOPIC]
-    # Common to ev42 and f142 stream objects
-    index_mb = (
-        stream_object[INDEX_EVERY_MB] if INDEX_EVERY_MB in stream_object else None
-    )
-    index_kb = (
-        stream_object[INDEX_EVERY_KB] if INDEX_EVERY_KB in stream_object else None
-    )
-    if writer_module == WriterModules.F142.value:
-        return __create_f142_stream(index_kb, index_mb, source, stream_object, topic)
-    if writer_module == WriterModules.EV42.value:
-        return __create_ev42_stream(index_kb, index_mb, source, stream_object, topic)
-    if writer_module == WriterModules.HS00.value:
-        data_type = stream_object[DATA_TYPE]
-        error_type = stream_object[ERROR_TYPE]
-        edge_type = stream_object[EDGE_TYPE]
-        shape = stream_object[SHAPE]
-        return HS00Stream(
-            source=source,
-            topic=topic,
-            data_type=data_type,
-            error_type=error_type,
-            edge_type=edge_type,
-            shape=shape,
-        )
-    if writer_module == WriterModules.NS10.value:
-        return NS10Stream(source=source, topic=topic)
-    if writer_module == WriterModules.SENV.value:
-        return SENVStream(source=source, topic=topic)
-    if writer_module == WriterModules.TDCTIME.value:
-        return TDCTStream(source=source, topic=topic)
-
-    return None
-
-
-def __create_ev42_stream(
-    index_kb: str, index_mb: str, source: str, stream_object: Dict, topic: str
-):
-    adc = stream_object[ADC_PULSE_DEBUG] if ADC_PULSE_DEBUG in stream_object else None
-    chunk_mb = (
-        stream_object[CHUNK_CHUNK_MB] if CHUNK_CHUNK_MB in stream_object else None
-    )
-    chunk_kb = (
-        stream_object[CHUNK_CHUNK_KB] if CHUNK_CHUNK_KB in stream_object else None
-    )
-    return EV42Stream(
-        source=source,
-        topic=topic,
-        adc_pulse_debug=adc,
-        nexus_indices_index_every_kb=index_kb,
-        nexus_indices_index_every_mb=index_mb,
-        nexus_chunk_chunk_mb=chunk_mb,
-        nexus_chunk_chunk_kb=chunk_kb,
-    )
-
-
-def __create_f142_stream(
-    index_kb: str, index_mb: str, source: str, stream_object: Dict, topic: str
-):
-    value_type = stream_object[CommonKeys.DATA_TYPE]
-    value_units = stream_object[VALUE_UNITS] if VALUE_UNITS in stream_object else None
-    array_size = stream_object[ARRAY_SIZE] if ARRAY_SIZE in stream_object else None
-    store_latest_into = (
-        stream_object[STORE_LATEST_INTO] if STORE_LATEST_INTO in stream_object else None
-    )
-    return F142Stream(
-        source=source,
-        topic=topic,
-        type=value_type,
-        value_units=value_units,
-        array_size=array_size,
-        nexus_indices_index_every_mb=index_mb,
-        nexus_indices_index_every_kb=index_kb,
-        store_latest_into=store_latest_into,
-    )
 
 
 class JSONReader:
@@ -455,58 +250,3 @@ class JSONReader:
             return False
 
         return True
-
-
-def _create_group(json_object: Dict, parent: Group) -> Group:
-    children = json_object[CommonKeys.CHILDREN]
-    name = json_object[CommonKeys.NAME]
-    group = Group(name=name, parent_node=parent)
-    for item in children:
-        if CommonKeys.MODULE in item:
-            group = StreamGroup(name=name, parent_node=parent)
-            break
-
-    for item in children:
-        _add_field_to_group(item, group)
-
-    _add_attributes(json_object, group)
-    return group
-
-
-def _get_data_type(json_object: Dict):
-    if CommonKeys.DATA_TYPE in json_object:
-        return json_object[CommonKeys.DATA_TYPE]
-    elif CommonKeys.TYPE in json_object:
-        return json_object[CommonKeys.TYPE]
-    raise KeyError
-
-
-def _create_dataset(json_object: Dict, parent: Group) -> Dataset:
-    value_type = _get_data_type(json_object[NodeType.CONFIG])
-    name = json_object[NodeType.CONFIG][CommonKeys.NAME]
-    values = json_object[NodeType.CONFIG][CommonKeys.VALUES]
-    if isinstance(values, list):
-        # convert to a numpy array using specified type
-        values = np.array(values, dtype=VALUE_TYPE_TO_NP[value_type])
-    ds = Dataset(name=name, values=values, type=value_type, parent_node=parent)
-    _add_attributes(json_object, ds)
-    return ds
-
-
-def _create_link(json_object: Dict) -> Link:
-    name = json_object[NodeType.CONFIG][CommonKeys.NAME]
-    target = json_object[NodeType.CONFIG][SOURCE]
-    return Link(name=name, target=target)
-
-
-def _add_attributes(json_object: Dict, model_object: Union[Group, Dataset]):
-    try:
-        attrs_list = json_object[CommonKeys.ATTRIBUTES]
-        for attribute in attrs_list:
-            attr_name = attribute[CommonKeys.NAME]
-            attr_values = attribute[CommonKeys.VALUES]
-            model_object.attributes.set_attribute_value(
-                attribute_name=attr_name, attribute_value=attr_values
-            )
-    except (KeyError, AttributeError):
-        pass

--- a/nexus_constructor/json/load_from_json_utils.py
+++ b/nexus_constructor/json/load_from_json_utils.py
@@ -1,8 +1,137 @@
-from typing import Any, Union
+from typing import Any, Dict, List, Optional, Union
 
-from nexus_constructor.common_attrs import CommonAttrs, CommonKeys
+import numpy as np
+
+from nexus_constructor.common_attrs import (
+    PIXEL_SHAPE_GROUP_NAME,
+    SHAPE_GROUP_NAME,
+    CommonAttrs,
+    CommonKeys,
+    NodeType,
+)
+from nexus_constructor.model.dataset import Dataset
+from nexus_constructor.model.group import TRANSFORMS_GROUP_NAME, Group
+from nexus_constructor.model.stream import (
+    ADC_PULSE_DEBUG,
+    ARRAY_SIZE,
+    CHUNK_CHUNK_KB,
+    CHUNK_CHUNK_MB,
+    DATA_TYPE,
+    DATASET,
+    EDGE_TYPE,
+    ERROR_TYPE,
+    INDEX_EVERY_KB,
+    INDEX_EVERY_MB,
+    LINK,
+    SHAPE,
+    SOURCE,
+    STORE_LATEST_INTO,
+    TOPIC,
+    VALUE_UNITS,
+    EV42Stream,
+    F142Stream,
+    HS00Stream,
+    Link,
+    NS10Stream,
+    SENVStream,
+    Stream,
+    StreamGroup,
+    TDCTStream,
+    WriterModules,
+)
+from nexus_constructor.model.value_type import VALUE_TYPE_TO_NP
 
 DEPENDS_ON_IGNORE = [None, "."]
+
+
+def _retrieve_children_list(json_dict: Dict) -> List:
+    """
+    Attempts to retrieve the children from the JSON dictionary.
+    :param json_dict: The JSON dictionary loaded by the user.
+    :return: The children value is returned if it was found, otherwise an empty list is returned.
+    """
+    value = []
+    try:
+        entry = json_dict[CommonKeys.CHILDREN][0]
+        value = entry[CommonKeys.CHILDREN]
+    except (KeyError, IndexError, TypeError):
+        pass
+    return value
+
+
+def _find_shape_information(children: List[Dict]) -> Union[Dict, None]:
+    """
+    Tries to get the shape information from a component.
+    :param children: The list of dictionaries.
+    :return: The shape attribute if it could be found, otherwise None.
+    """
+    value = None
+    try:
+        for item in children:
+            if item[CommonKeys.NAME] in [SHAPE_GROUP_NAME, PIXEL_SHAPE_GROUP_NAME]:
+                value = item
+    except KeyError:
+        pass
+    return value
+
+
+def _add_field_to_group(item: Dict, group: Group):
+    child: Group
+    if CommonKeys.TYPE in item:
+        if item[CommonKeys.NAME] == TRANSFORMS_GROUP_NAME:
+            return
+        field_type = item[CommonKeys.TYPE]
+        child_name = item[CommonKeys.NAME]
+        if field_type == NodeType.GROUP:
+            child = _create_group(item, group)
+        else:
+            raise Exception(
+                f'Found unknown field type ("{field_type}") when loading JSON - {child_name}'
+            )
+        group[child_name] = child
+    elif CommonKeys.MODULE in item:
+        stream: Union[
+            Dataset,
+            Link,
+            NS10Stream,
+            SENVStream,
+            TDCTStream,
+            EV42Stream,
+            F142Stream,
+            HS00Stream,
+        ]
+        writer_module = item[CommonKeys.MODULE]
+        if writer_module == LINK:
+            stream = _create_link(item)
+        elif writer_module == DATASET:
+            if item[NodeType.CONFIG][CommonKeys.NAME] == CommonAttrs.DEPENDS_ON:
+                return
+            stream = _create_dataset(item, group)
+        else:
+            stream = _create_stream(item)
+        group.children.append(
+            stream
+        )  # Can't use the `[]` operator because streams do not have a name to use as a key
+    else:
+        raise Exception(
+            "Unable to add field as neither writer module type nor child type was found in the current node."
+        )
+
+
+def _find_depends_on_path(items: List[Dict], name: str) -> Optional[str]:
+    if not isinstance(items, list):
+        raise RuntimeError(
+            f'List of children in node with the name "{name}" is not a list.'
+        )
+    for item in items:
+        try:
+            config = item[NodeType.CONFIG]
+            if config[CommonKeys.NAME] != CommonAttrs.DEPENDS_ON:
+                continue
+            return config[CommonKeys.VALUES]
+        except KeyError:
+            pass  # Not all items has a config node, ignore those that do not.
+    return None
 
 
 def _find_attribute_from_dict(attribute_name: str, entry: dict) -> Any:
@@ -46,3 +175,144 @@ def _find_nx_class(entry: Union[list, dict]) -> str:
     """
     nx_class = _find_attribute_from_list_or_dict(CommonAttrs.NX_CLASS, entry)
     return nx_class if nx_class is not None else ""
+
+
+def _create_stream(json_object: Dict) -> Stream:
+    """
+    Given a dictionary containing a stream, create a corresponding stream object to be used in the model.
+    :param json_object: JSON dictionary containing a stream.
+    :return: A stream object containing relevant data from the JSON.
+    """
+    stream_object = json_object[NodeType.CONFIG]
+    writer_module = json_object[CommonKeys.MODULE]
+    source = stream_object[SOURCE]
+    topic = stream_object[TOPIC]
+    # Common to ev42 and f142 stream objects
+    index_mb = (
+        stream_object[INDEX_EVERY_MB] if INDEX_EVERY_MB in stream_object else None
+    )
+    index_kb = (
+        stream_object[INDEX_EVERY_KB] if INDEX_EVERY_KB in stream_object else None
+    )
+    if writer_module == WriterModules.F142.value:
+        return __create_f142_stream(index_kb, index_mb, source, stream_object, topic)
+    if writer_module == WriterModules.EV42.value:
+        return __create_ev42_stream(index_kb, index_mb, source, stream_object, topic)
+    if writer_module == WriterModules.HS00.value:
+        data_type = stream_object[DATA_TYPE]
+        error_type = stream_object[ERROR_TYPE]
+        edge_type = stream_object[EDGE_TYPE]
+        shape = stream_object[SHAPE]
+        return HS00Stream(
+            source=source,
+            topic=topic,
+            data_type=data_type,
+            error_type=error_type,
+            edge_type=edge_type,
+            shape=shape,
+        )
+    if writer_module == WriterModules.NS10.value:
+        return NS10Stream(source=source, topic=topic)
+    if writer_module == WriterModules.SENV.value:
+        return SENVStream(source=source, topic=topic)
+    if writer_module == WriterModules.TDCTIME.value:
+        return TDCTStream(source=source, topic=topic)
+
+    return None
+
+
+def __create_ev42_stream(
+    index_kb: str, index_mb: str, source: str, stream_object: Dict, topic: str
+):
+    adc = stream_object[ADC_PULSE_DEBUG] if ADC_PULSE_DEBUG in stream_object else None
+    chunk_mb = (
+        stream_object[CHUNK_CHUNK_MB] if CHUNK_CHUNK_MB in stream_object else None
+    )
+    chunk_kb = (
+        stream_object[CHUNK_CHUNK_KB] if CHUNK_CHUNK_KB in stream_object else None
+    )
+    return EV42Stream(
+        source=source,
+        topic=topic,
+        adc_pulse_debug=adc,
+        nexus_indices_index_every_kb=index_kb,
+        nexus_indices_index_every_mb=index_mb,
+        nexus_chunk_chunk_mb=chunk_mb,
+        nexus_chunk_chunk_kb=chunk_kb,
+    )
+
+
+def __create_f142_stream(
+    index_kb: str, index_mb: str, source: str, stream_object: Dict, topic: str
+):
+    value_type = stream_object[CommonKeys.DATA_TYPE]
+    value_units = stream_object[VALUE_UNITS] if VALUE_UNITS in stream_object else None
+    array_size = stream_object[ARRAY_SIZE] if ARRAY_SIZE in stream_object else None
+    store_latest_into = (
+        stream_object[STORE_LATEST_INTO] if STORE_LATEST_INTO in stream_object else None
+    )
+    return F142Stream(
+        source=source,
+        topic=topic,
+        type=value_type,
+        value_units=value_units,
+        array_size=array_size,
+        nexus_indices_index_every_mb=index_mb,
+        nexus_indices_index_every_kb=index_kb,
+        store_latest_into=store_latest_into,
+    )
+
+
+def _create_group(json_object: Dict, parent: Group) -> Group:
+    children = json_object[CommonKeys.CHILDREN]
+    name = json_object[CommonKeys.NAME]
+    group = Group(name=name, parent_node=parent)
+    for item in children:
+        if CommonKeys.MODULE in item:
+            group = StreamGroup(name=name, parent_node=parent)
+            break
+
+    for item in children:
+        _add_field_to_group(item, group)
+
+    _add_attributes(json_object, group)
+    return group
+
+
+def _get_data_type(json_object: Dict):
+    if CommonKeys.DATA_TYPE in json_object:
+        return json_object[CommonKeys.DATA_TYPE]
+    elif CommonKeys.TYPE in json_object:
+        return json_object[CommonKeys.TYPE]
+    raise KeyError
+
+
+def _create_dataset(json_object: Dict, parent: Group) -> Dataset:
+    value_type = _get_data_type(json_object[NodeType.CONFIG])
+    name = json_object[NodeType.CONFIG][CommonKeys.NAME]
+    values = json_object[NodeType.CONFIG][CommonKeys.VALUES]
+    if isinstance(values, list):
+        # convert to a numpy array using specified type
+        values = np.array(values, dtype=VALUE_TYPE_TO_NP[value_type])
+    ds = Dataset(name=name, values=values, type=value_type, parent_node=parent)
+    _add_attributes(json_object, ds)
+    return ds
+
+
+def _create_link(json_object: Dict) -> Link:
+    name = json_object[NodeType.CONFIG][CommonKeys.NAME]
+    target = json_object[NodeType.CONFIG][SOURCE]
+    return Link(name=name, target=target)
+
+
+def _add_attributes(json_object: Dict, model_object: Union[Group, Dataset]):
+    try:
+        attrs_list = json_object[CommonKeys.ATTRIBUTES]
+        for attribute in attrs_list:
+            attr_name = attribute[CommonKeys.NAME]
+            attr_values = attribute[CommonKeys.VALUES]
+            model_object.attributes.set_attribute_value(
+                attribute_name=attr_name, attribute_value=attr_values
+            )
+    except (KeyError, AttributeError):
+        pass

--- a/tests/json/test_load_from_json.py
+++ b/tests/json/test_load_from_json.py
@@ -1,7 +1,6 @@
 import json
 from typing import Type
 
-import numpy as np
 import pytest
 from mock import mock_open, patch
 from PySide2.QtGui import QVector3D
@@ -11,18 +10,11 @@ from nexus_constructor.json.json_warnings import (
     JsonWarningsContainer,
     TransformDependencyMissing,
 )
-from nexus_constructor.json.load_from_json import (
-    JSONReader,
-    _add_attributes,
-    _create_dataset,
-    _create_link,
-    _retrieve_children_list,
-)
-from nexus_constructor.model.attributes import FieldAttribute
+from nexus_constructor.json.load_from_json import JSONReader
+from nexus_constructor.json.load_from_json_utils import _retrieve_children_list
 from nexus_constructor.model.component import Component
 from nexus_constructor.model.dataset import Dataset
-from nexus_constructor.model.group import Group
-from nexus_constructor.model.value_type import VALUE_TYPE_TO_NP, ValueTypes
+from nexus_constructor.model.value_type import ValueTypes
 
 
 @pytest.fixture(scope="function")
@@ -52,7 +44,7 @@ def nexus_json_dictionary() -> dict:
                 "NX_class":"NXinstrument"
               },
               "children":[
-    
+
               ]
             },
             {
@@ -69,7 +61,7 @@ def nexus_json_dictionary() -> dict:
                   "type":"group",
                   "name":"transformations",
                   "children":[
-    
+
                   ]
                 }
               ]
@@ -124,7 +116,7 @@ def json_dict_with_component():
                       "type":"group",
                       "name":"transformations",
                       "children":[
-    
+
                       ]
                     }
                   ]
@@ -146,7 +138,7 @@ def json_dict_with_component():
                   "type":"group",
                   "name":"transformations",
                   "children":[
-    
+
                   ]
                 }
               ]
@@ -295,7 +287,7 @@ def test_GIVEN_json_with_missing_value_WHEN_loading_from_json_THEN_json_loader_r
                 "NX_class":"NXinstrument"
               },
               "children":[
-    
+
               ]
             },
             {
@@ -312,7 +304,7 @@ def test_GIVEN_json_with_missing_value_WHEN_loading_from_json_THEN_json_loader_r
                   "type":"group",
                   "name":"transformations",
                   "children":[
-    
+
                   ]
                 }
               ]
@@ -476,100 +468,3 @@ def test_GIVEN_json_with_transformation_depending_on_non_existent_transform_WHEN
     assert contains_warning_of_type(
         json_reader.warnings, TransformDependencyMissing
     ), "Expected a warning due to depends_on pointing to a non-existent transform"
-
-
-@pytest.mark.parametrize(
-    "test_input",
-    (
-        {},
-        {
-            "module": "dataset",
-            "config": {"values": 0},
-        },
-        {"attributes": []},
-    ),  # noqa E231
-)
-def test_GIVEN_empty_dictionary_or_dictionary_with_no_attributes_WHEN_adding_attributes_THEN_returns_nothing(
-    test_input,
-):
-    dataset = Dataset(name="ds", values=123, type=ValueTypes.INT)
-    _add_attributes(test_input, dataset)
-    assert not dataset.attributes
-
-
-def test_GIVEN_dictionary_containing_attribute_WHEN_adding_attributes_THEN_attribute_object_is_created():
-    key = "units"
-    value = "m"
-    test_dict = {"attributes": [{"name": key, "values": value}]}
-    dataset = Dataset(name="ds", values=123, type=ValueTypes.INT)
-    _add_attributes(test_dict, dataset)
-    assert len(dataset.attributes) == 1
-    assert isinstance(dataset.attributes[0], FieldAttribute)
-    assert dataset.attributes[0].name == key
-    assert dataset.attributes[0].values == value
-
-
-def test_GIVEN_dictionary_containing_attributes_WHEN_adding_attributes_THEN_attribute_objects_are_created():
-    key1 = "units"
-    val1 = "m"
-    key2 = "testkey"
-    val2 = "testval"
-    test_dict = {
-        "attributes": [{"name": key1, "values": val1}, {"name": key2, "values": val2}]
-    }
-    dataset = Dataset(name="ds", values=123, type=ValueTypes.INT)
-    _add_attributes(test_dict, dataset)
-    assert len(dataset.attributes) == 2
-    assert dataset.attributes[0].name == key1
-    assert dataset.attributes[0].values == val1
-    assert dataset.attributes[1].name == key2
-    assert dataset.attributes[1].values == val2
-
-
-def test_GIVEN_link_json_WHEN_adding_link_THEN_link_object_is_created():
-    name = "link1"
-    target = "/entry/instrument/detector1"
-    test_dict = {
-        "module": "link",
-        "config": {"name": name, "source": target},
-    }
-    link = _create_link(test_dict)
-    assert link.name == name
-    assert link.target == target
-
-
-def test_GIVEN_dataset_with_string_value_WHEN_adding_dataset_THEN_dataset_object_is_created_with_correct_dtype():
-    name = "description"
-    values = "a description"
-    parent = Group(name="test")
-    test_dict = {
-        "module": "dataset",
-        "config": {"type": ValueTypes.STRING, "values": values, "name": name},
-    }
-
-    ds = _create_dataset(test_dict, parent)
-
-    assert ds.name == name
-    assert ds.values == values
-    assert ds.parent_node == parent
-    assert ds.type == ValueTypes.STRING
-
-
-def test_GIVEN_dataset_with_array_value_WHEN_adding_dataset_THEN_dataset_object_is_created_with_numpy_array_as_value():
-    name = "an_array"
-    values = [1.1, 2.2, 3.3, 4.4]
-    dtype = ValueTypes.FLOAT
-
-    np_array = np.array(values, dtype=VALUE_TYPE_TO_NP[dtype])
-
-    test_dict = {
-        "module": "dataset",
-        "config": {"type": dtype, "values": values, "name": name},
-    }
-    parent = Group(name="test")
-    ds = _create_dataset(test_dict, parent)
-
-    assert ds.name == name
-    assert np.array_equal(ds.values, np_array)
-    assert ds.parent_node == parent
-    assert ds.type == dtype

--- a/tests/json/test_load_from_json_utils.py
+++ b/tests/json/test_load_from_json_utils.py
@@ -1,6 +1,16 @@
+import numpy as np
 import pytest
 
-from nexus_constructor.json.load_from_json_utils import _find_nx_class
+from nexus_constructor.json.load_from_json_utils import (
+    _add_attributes,
+    _create_dataset,
+    _create_link,
+    _find_nx_class,
+)
+from nexus_constructor.model.attributes import FieldAttribute
+from nexus_constructor.model.dataset import Dataset
+from nexus_constructor.model.group import Group
+from nexus_constructor.model.value_type import VALUE_TYPE_TO_NP, ValueTypes
 
 
 @pytest.mark.parametrize("class_attribute", [[{"name": "NX_class"}], [{"name": "123"}]])
@@ -19,3 +29,100 @@ def test_GIVEN_nx_class_in_different_formats_WHEN_reading_class_information_THEN
 ):
 
     assert _find_nx_class(class_attribute) == "NXmonitor"
+
+
+@pytest.mark.parametrize(
+    "test_input",
+    (
+        {},
+        {
+            "module": "dataset",
+            "config": {"values": 0},
+        },
+        {"attributes": []},
+    ),  # noqa E231
+)
+def test_GIVEN_empty_dictionary_or_dictionary_with_no_attributes_WHEN_adding_attributes_THEN_returns_nothing(
+    test_input,
+):
+    dataset = Dataset(name="ds", values=123, type=ValueTypes.INT)
+    _add_attributes(test_input, dataset)
+    assert not dataset.attributes
+
+
+def test_GIVEN_dictionary_containing_attribute_WHEN_adding_attributes_THEN_attribute_object_is_created():
+    key = "units"
+    value = "m"
+    test_dict = {"attributes": [{"name": key, "values": value}]}
+    dataset = Dataset(name="ds", values=123, type=ValueTypes.INT)
+    _add_attributes(test_dict, dataset)
+    assert len(dataset.attributes) == 1
+    assert isinstance(dataset.attributes[0], FieldAttribute)
+    assert dataset.attributes[0].name == key
+    assert dataset.attributes[0].values == value
+
+
+def test_GIVEN_dictionary_containing_attributes_WHEN_adding_attributes_THEN_attribute_objects_are_created():
+    key1 = "units"
+    val1 = "m"
+    key2 = "testkey"
+    val2 = "testval"
+    test_dict = {
+        "attributes": [{"name": key1, "values": val1}, {"name": key2, "values": val2}]
+    }
+    dataset = Dataset(name="ds", values=123, type=ValueTypes.INT)
+    _add_attributes(test_dict, dataset)
+    assert len(dataset.attributes) == 2
+    assert dataset.attributes[0].name == key1
+    assert dataset.attributes[0].values == val1
+    assert dataset.attributes[1].name == key2
+    assert dataset.attributes[1].values == val2
+
+
+def test_GIVEN_dataset_with_string_value_WHEN_adding_dataset_THEN_dataset_object_is_created_with_correct_dtype():
+    name = "description"
+    values = "a description"
+    parent = Group(name="test")
+    test_dict = {
+        "module": "dataset",
+        "config": {"type": ValueTypes.STRING, "values": values, "name": name},
+    }
+
+    ds = _create_dataset(test_dict, parent)
+
+    assert ds.name == name
+    assert ds.values == values
+    assert ds.parent_node == parent
+    assert ds.type == ValueTypes.STRING
+
+
+def test_GIVEN_dataset_with_array_value_WHEN_adding_dataset_THEN_dataset_object_is_created_with_numpy_array_as_value():
+    name = "an_array"
+    values = [1.1, 2.2, 3.3, 4.4]
+    dtype = ValueTypes.FLOAT
+
+    np_array = np.array(values, dtype=VALUE_TYPE_TO_NP[dtype])
+
+    test_dict = {
+        "module": "dataset",
+        "config": {"type": dtype, "values": values, "name": name},
+    }
+    parent = Group(name="test")
+    ds = _create_dataset(test_dict, parent)
+
+    assert ds.name == name
+    assert np.array_equal(ds.values, np_array)
+    assert ds.parent_node == parent
+    assert ds.type == dtype
+
+
+def test_GIVEN_link_json_WHEN_adding_link_THEN_link_object_is_created():
+    name = "link1"
+    target = "/entry/instrument/detector1"
+    test_dict = {
+        "module": "link",
+        "config": {"name": name, "source": target},
+    }
+    link = _create_link(test_dict)
+    assert link.name == name
+    assert link.target == target

--- a/tests/json/test_shape_reader.py
+++ b/tests/json/test_shape_reader.py
@@ -15,9 +15,9 @@ from nexus_constructor.common_attrs import (
     NodeType,
 )
 from nexus_constructor.json.json_warnings import JsonWarningsContainer
-from nexus_constructor.json.load_from_json import _get_data_type
 from nexus_constructor.json.load_from_json_utils import (
     _find_attribute_from_list_or_dict,
+    _get_data_type,
 )
 from nexus_constructor.json.shape_reader import (
     DETECTOR_NUMBER,


### PR DESCRIPTION
### Description of work

* Moved most of the utilities functions from `load_from_json.py` that can be used in other parts of json module to `load_from_json_utils.py`
* Rearranged tests accordingly.

