### PR TITLE
Remove size attribute from Dataset

### DIFF
--- a/nexus_constructor/component_tree_model.py
+++ b/nexus_constructor/component_tree_model.py
@@ -207,7 +207,7 @@ class ComponentTreeModel(QAbstractItemModel):
     def _create_new_transformation(
         parent_component, transformation_list, transformation_type
     ):
-        values = Dataset(name="", type=ValueTypes.DOUBLE, size=[1], values="")
+        values = Dataset(name="", type=ValueTypes.DOUBLE, values="")
         if transformation_type == TransformationType.TRANSLATION:
             new_transformation = parent_component.add_translation(
                 name=generate_unique_name(

--- a/nexus_constructor/field_widget.py
+++ b/nexus_constructor/field_widget.py
@@ -237,7 +237,6 @@ class FieldWidget(QFrame):
             val = self.value_line_edit.text()
             return_object = Dataset(
                 name=self.name,
-                size=[1],
                 type=dtype,
                 values=val,
             )
@@ -246,7 +245,6 @@ class FieldWidget(QFrame):
             array = np.squeeze(self.table_view.model.array)
             return_object = Dataset(
                 name=self.name,
-                size=array.size,
                 type=dtype,
                 values=array,
             )

--- a/nexus_constructor/json/transformation_reader.py
+++ b/nexus_constructor/json/transformation_reader.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple, Union, List
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from PySide2.QtGui import QVector3D
 
@@ -55,7 +55,6 @@ def _create_transformation_dataset(
     """
     return Dataset(
         name,
-        size=[1],
         type=dtype,
         values=angle_or_magnitude,
     )

--- a/nexus_constructor/model/component.py
+++ b/nexus_constructor/model/component.py
@@ -41,9 +41,9 @@ from nexus_constructor.model.geometry import (
     OFFGeometry,
     OFFGeometryNexus,
 )
-from nexus_constructor.model.stream import DATASET
 from nexus_constructor.model.group import TRANSFORMS_GROUP_NAME, Group
 from nexus_constructor.model.helpers import _generate_incremental_name
+from nexus_constructor.model.stream import DATASET
 from nexus_constructor.model.transformation import Transformation
 from nexus_constructor.model.value_type import ValueTypes
 from nexus_constructor.transformations_list import TransformationsList
@@ -199,7 +199,7 @@ class Component(Group):
         vector: QVector3D,
         name: str = None,
         depends_on: Transformation = None,
-        values: Dataset = Dataset(name="", values=0, type=ValueTypes.DOUBLE, size="1"),
+        values: Dataset = Dataset(name="", values=0, type=ValueTypes.DOUBLE),
     ) -> Transformation:
         """
         Note, currently assumes translation is in metres
@@ -225,7 +225,7 @@ class Component(Group):
         angle: float,
         name: str = None,
         depends_on: Transformation = None,
-        values: Dataset = Dataset(name="", values=0, type=ValueTypes.DOUBLE, size="1"),
+        values: Dataset = Dataset(name="", values=0, type=ValueTypes.DOUBLE),
     ) -> Transformation:
         """
         Note, currently assumes angle is in degrees
@@ -261,7 +261,6 @@ class Component(Group):
             name=name,
             parent_node=self.get_transforms_group(),
             type=values.type,
-            size=values.size,
             values=values,
         )
         transform.transform_type = transformation_type

--- a/nexus_constructor/model/dataset.py
+++ b/nexus_constructor/model/dataset.py
@@ -6,7 +6,7 @@ import numpy as np
 from nexus_constructor.common_attrs import CommonAttrs, CommonKeys, NodeType
 from nexus_constructor.model.attributes import Attributes
 from nexus_constructor.model.helpers import get_absolute_path
-from nexus_constructor.model.value_type import ValueType
+from nexus_constructor.model.value_type import ValueType, ValueTypes
 
 if TYPE_CHECKING:
     from nexus_constructor.model.group import Group  # noqa: F401
@@ -16,8 +16,7 @@ if TYPE_CHECKING:
 class Dataset:
     name = attr.ib(type=str)
     values = attr.ib(type=Union[List[ValueType], ValueType])
-    type = attr.ib(type=str)
-    size = attr.ib(factory=tuple)
+    type = attr.ib(type=str, default=ValueTypes.DOUBLE)
     parent_node = attr.ib(type="Group", default=None)
     attributes = attr.ib(type=Attributes, factory=Attributes, init=False)
 

--- a/nexus_constructor/model/group.py
+++ b/nexus_constructor/model/group.py
@@ -92,11 +92,7 @@ class Group:
         self.attributes.set_attribute_value(CommonAttrs.NX_CLASS, new_nx_class)
 
     def set_field_value(self, name: str, value: Any, dtype: str):
-        try:
-            size = value.shape
-        except AttributeError:
-            size = [1]
-        self[name] = Dataset(name=name, size=size, type=dtype, values=value)
+        self[name] = Dataset(name=name, type=dtype, values=value)
 
     def get_field_value(self, name: str):
         return self[name].values

--- a/tests/geometry/test_disk_chopper_checker.py
+++ b/tests/geometry/test_disk_chopper_checker.py
@@ -31,8 +31,8 @@ from tests.geometry.chopper_test_helpers import (  # noqa: F401
 
 def create_dataset(name: str, dtype: str, val: Any):
     if np.isscalar(val):
-        return Dataset(name=name, size=[1], type=dtype, values=str(val))
-    return Dataset(name=name, size=val.size, type=dtype, values=val)
+        return Dataset(name=name, type=dtype, values=str(val))
+    return Dataset(name=name, type=dtype, values=val)
 
 
 @pytest.fixture(scope="function")

--- a/tests/model/test_component.py
+++ b/tests/model/test_component.py
@@ -44,7 +44,6 @@ def test_component_set_field_with_numpy_array_correctly_sets_field_value():
     field_dataset = comp["field1"]
     assert field_dataset.name == field_name
     assert np.array_equal(field_dataset.values, field_value)
-    assert field_dataset.size == (2, 1)
     assert field_dataset.type == dtype
 
 
@@ -60,7 +59,6 @@ def test_component_set_field_with_scalar_value_correctly_sets_field_value():
 
     assert field_dataset.name == field_name
     assert field_dataset.values == data
-    assert field_dataset.size == [1]
     assert field_dataset.type == dtype
 
 

--- a/tests/model/test_component_fields.py
+++ b/tests/model/test_component_fields.py
@@ -36,7 +36,6 @@ def test_GIVEN_single_scalar_field_and_float_WHEN_adding_fields_to_component_THE
 
     field_value = Dataset(
         name=field_name,
-        size=field_value_raw.size,
         type=field_dtype,
         values=field_value_raw,
     )
@@ -61,7 +60,6 @@ def test_GIVEN_single_scalar_field_and_string_WHEN_adding_fields_to_component_TH
 
     field_value = Dataset(
         name=field_name,
-        size=[1],
         type=str,
         values=field_value_raw,
     )

--- a/tests/model/test_dataset.py
+++ b/tests/model/test_dataset.py
@@ -4,9 +4,7 @@ from nexus_constructor.model.value_type import ValueTypes
 
 def test_dataset_as_dict_contains_expected_keys():
     input_name = "test_dataset"
-    test_dataset = Dataset(
-        name=input_name, size="[1]", type=ValueTypes.STRING, values="the_value"
-    )
+    test_dataset = Dataset(name=input_name, type=ValueTypes.STRING, values="the_value")
     dictionary_output = test_dataset.as_dict()
     for expected_key in ("module", "config"):
         assert expected_key in dictionary_output.keys()

--- a/tests/model/test_transformations.py
+++ b/tests/model/test_transformations.py
@@ -12,7 +12,7 @@ def create_transform(
     ui_value=42.0,
     vector=QVector3D(1.0, 0.0, 0.0),
     type="Translation",
-    values=Dataset(name="", values=None, type=ValueTypes.DOUBLE, size=[1]),
+    values=Dataset(name="", values=None, type=ValueTypes.DOUBLE),
 ):
     translation = Transformation(
         name=name,
@@ -20,7 +20,6 @@ def create_transform(
         values=values,
         type=ValueTypes.STRING,
         parent_component=None,
-        size=[1],
     )
 
     translation.vector = vector

--- a/tests/test_link_transformation.py
+++ b/tests/test_link_transformation.py
@@ -13,7 +13,7 @@ def test_new_component_returns_none_as_linked_component():
 def test_end_of_depends_on_chain_of_component_is_linked_to_other_component():
     # GIVEN component has depends_on chain with multiple transformations
     component = Component(name="test_component")
-    values = Dataset(name="", type=ValueTypes.INT, size=[1], values=[42])
+    values = Dataset(name="", type=ValueTypes.INT, values=[42])
     transforms_2 = component.add_translation(
         name="transform2",
         vector=QVector3D(0, 0, 1.0),  # default to beam direction

--- a/tests/test_remove_from_dependee_chain.py
+++ b/tests/test_remove_from_dependee_chain.py
@@ -9,7 +9,6 @@ from nexus_constructor.model.value_type import ValueTypes
 values = Dataset(
     name="scalar_value",
     type=ValueTypes.DOUBLE,
-    size=[1],
     values=90.0,
     parent_node=None,
 )

--- a/tests/ui_tests/test_main_window_utils.py
+++ b/tests/ui_tests/test_main_window_utils.py
@@ -583,9 +583,7 @@ def test_GIVEN_unknown_transformation_type_WHEN_adding_transformation_THEN_raise
 
 
 def create_transformation(trans_type: TransformationType):
-    t = Transformation(
-        name="transformation", type=ValueTypes.DOUBLE, size=[1], values=8
-    )
+    t = Transformation(name="transformation", type=ValueTypes.DOUBLE, values=8)
     t.transform_type = trans_type
     t.vector = QVector3D(1, 0, 0)
     t.values = Dataset(name="", values=0, type=ValueTypes.DOUBLE)

--- a/tests/ui_tests/test_ui_field_attrs.py
+++ b/tests/ui_tests/test_ui_field_attrs.py
@@ -39,7 +39,7 @@ def test_GIVEN_existing_field_with_attr_WHEN_editing_component_THEN_both_field_a
     qtbot, attr_val, field_attributes_dialog
 ):
     attr_key = "testattr"
-    ds = Dataset(name="test", size="1", type=ValueTypes.STRING, values="")
+    ds = Dataset(name="test", type=ValueTypes.STRING, values="")
     ds.attributes.set_attribute_value(attr_key, attr_val)
 
     field_attributes_dialog.fill_existing_attrs(ds)
@@ -54,7 +54,7 @@ def test_GIVEN_existing_field_with_attr_which_is_in_excludelist_WHEN_editing_com
     attr_key = "units"
     attr_val = "m"
 
-    ds = Dataset(name="test", size="1", type=ValueTypes.STRING, values="")
+    ds = Dataset(name="test", type=ValueTypes.STRING, values="")
     ds.attributes.set_attribute_value(attr_key, attr_val)
 
     field_attributes_dialog.fill_existing_attrs(ds)

--- a/tests/ui_tests/test_ui_transformation_view.py
+++ b/tests/ui_tests/test_ui_transformation_view.py
@@ -25,15 +25,11 @@ def create_corresponding_value_dataset(value: Any):
     type = _get_human_readable_type(value)
 
     if np.isscalar(value):
-        size = 1
         value = str(value)
-    else:
-        size = len(value)
 
     return Dataset(
         name=name,
         type=type,
-        size=[size],
         values=value,
     )
 


### PR DESCRIPTION
### Description of work

* After consulting with @SkyToGround we decided to remove `size` attribute from `Dataset` class, since it is inferred from array by the FileWriter. `type` attribute is made `optional` and default to `double`
* Fixed a bunch of tests.