### PR TITLE
address warnings with python 3.9

### DIFF
--- a/nexus_constructor/treeview_utils.py
+++ b/nexus_constructor/treeview_utils.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from collections import Callable
+from collections.abc import Callable
 
 from PySide2.QtCore import QModelIndex, Qt
 from PySide2.QtGui import QColor, QIcon

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -338,7 +338,7 @@ def test_GIVEN_floating_point_value_WHEN_using_numpy_validator_with_integer_as_d
 
 
 def test_GIVEN_alphabetical_chars_WHEN_using_numpy_validator_with_float_as_dtype_THEN_false_signal_is_emitted():
-    validator = NumpyDTypeValidator(np.float)
+    validator = NumpyDTypeValidator(np.float64)
     validator.is_valid = Mock()
 
     assert validator.validate("test", 0) == QValidator.Intermediate


### PR DESCRIPTION
ECDC-2699

does not address all potential issues, but removes some warnings and should be backwards compatible down to python 3.3