### PR TITLE
ECDC-2738 Remove component list

### DIFF
--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -131,8 +131,7 @@ class AddComponentDialog(Ui_AddComponentDialog, QObject):
         self.noShapeRadioButton.setChecked(True)
         self.show_no_geometry_fields()
 
-        component_list = self.instrument.component_list.copy()
-
+        component_list = self.instrument.get_components()
         if self.component_to_edit:
             for item in component_list:
                 if item.name == self.component_to_edit.name:
@@ -333,7 +332,7 @@ class AddComponentDialog(Ui_AddComponentDialog, QObject):
         """
         return generate_unique_name(
             self.componentTypeComboBox.currentText().lstrip("NX"),
-            self.instrument.component_list,
+            self.instrument.get_components(),
         )
 
     def on_nx_class_changed(self):
@@ -489,6 +488,7 @@ class AddComponentDialog(Ui_AddComponentDialog, QObject):
         add_fields_to_component(component, self.fieldsListWidget)
 
         self.component_model.add_component(component)
+        self.instrument[component.name] = component
         return component.shape
 
     def edit_existing_component(

--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -488,7 +488,6 @@ class AddComponentDialog(Ui_AddComponentDialog, QObject):
         add_fields_to_component(component, self.fieldsListWidget)
 
         self.component_model.add_component(component)
-        self.instrument[component.name] = component
         return component.shape
 
     def edit_existing_component(

--- a/nexus_constructor/component_tree_model.py
+++ b/nexus_constructor/component_tree_model.py
@@ -83,6 +83,7 @@ class ComponentTreeModel(QAbstractItemModel):
     def add_component(self, new_component: Component):
         self.beginInsertRows(QModelIndex(), len(self.components), len(self.components))
         self.components.append(new_component)
+        self.model.entry.instrument[new_component.name] = new_component
         self.endInsertRows()
 
     def _remove_link(self, index: QModelIndex):
@@ -151,6 +152,7 @@ class ComponentTreeModel(QAbstractItemModel):
         for transform in transforms:
             transform.remove_from_dependee_chain()
         self.components.remove(component)
+        del self.model.entry.instrument[component.name]
         self.endRemoveRows()
         self.model.signals.component_removed.emit(component.name)
 

--- a/nexus_constructor/component_tree_model.py
+++ b/nexus_constructor/component_tree_model.py
@@ -26,7 +26,7 @@ class ComponentTreeModel(QAbstractItemModel):
     def __init__(self, model: Model, parent=None):
         super().__init__(parent)
         self.model = model
-        self.components = self.model.entry.instrument.component_list
+        self.components = self.model.entry.instrument.get_components()
 
     def columnCount(self, parent: QModelIndex) -> int:
         return 1

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -117,7 +117,7 @@ class MainWindow(Ui_MainWindow, QMainWindow):
 
     def _update_transformations_3d_view(self):
         self.sceneWidget.clear_all_transformations()
-        for component in self.model.entry.instrument.component_list:
+        for component in self.model.entry.instrument.get_components():
             self.sceneWidget.add_transformation(component.name, component.qtransform)
 
     def _update_views(self):
@@ -127,7 +127,7 @@ class MainWindow(Ui_MainWindow, QMainWindow):
         self._update_3d_view_with_component_shapes()
 
     def _update_3d_view_with_component_shapes(self):
-        for component in self.model.entry.instrument.component_list:
+        for component in self.model.entry.instrument.get_components():
             shape, positions = component.shape
             self.sceneWidget.add_component(component.name, shape, positions)
             self.sceneWidget.add_transformation(component.name, component.qtransform)

--- a/nexus_constructor/model/instrument.py
+++ b/nexus_constructor/model/instrument.py
@@ -1,6 +1,7 @@
-from typing import Any, Dict, List
+from typing import List
 
-from nexus_constructor.common_attrs import INSTRUMENT_NAME, CommonKeys
+from nexus_constructor.common_attrs import INSTRUMENT_NAME
+from nexus_constructor.component_type import COMPONENT_TYPES
 from nexus_constructor.model.component import Component
 from nexus_constructor.model.group import Group
 
@@ -11,19 +12,13 @@ class Instrument(Group):
     def __init__(self, parent_node=None):
         super().__init__(name=INSTRUMENT_NAME, parent_node=parent_node)
         self.nx_class = "NXinstrument"
-
         self.sample = Component(SAMPLE_NAME, parent_node=self)
         self.sample.nx_class = "NXsample"
-        self.component_list = [self.sample]
 
-    def as_dict(self, error_collector: List[str]) -> Dict[str, Any]:
-        dictionary = super(Instrument, self).as_dict(error_collector)
-        # Put components (other than sample) in children
-        dictionary[CommonKeys.CHILDREN].extend(
-            [
-                component.as_dict(error_collector)
-                for component in self.component_list
-                if component.name != SAMPLE_NAME
-            ]
-        )
-        return dictionary
+    def get_components(self) -> List:
+        component_list = []
+        for child in self.children:
+            if isinstance(child, Group) and child.nx_class in COMPONENT_TYPES:
+                component_list.append(child)
+        component_list.append(self.sample)
+        return component_list

--- a/nexus_constructor/transformation_view.py
+++ b/nexus_constructor/transformation_view.py
@@ -168,7 +168,7 @@ class EditTransformationLink(QFrame):
         self.link_frame.transformations_combo_box.clear()
         self.link_frame.transformations_combo_box.addItem("(None)", userData=None)
         self.link_frame.transformations_combo_box.setCurrentIndex(0)
-        components = self.instrument.component_list
+        components = self.instrument.get_components()
         for current_component in components:
             transformations = current_component.transforms
             self.link_frame.transformations_combo_box.addItem(

--- a/tests/model/test_instrument.py
+++ b/tests/model/test_instrument.py
@@ -16,8 +16,8 @@ def test_instrument_as_dict_contains_components():
     test_instrument = Instrument()
     zeroth_test_component_name = "Component_A"
     first_test_component_name = "Component_B"
-    test_instrument.component_list.append(Component(zeroth_test_component_name, []))
-    test_instrument.component_list.append(Component(first_test_component_name, []))
+    test_instrument.children.append(Component(zeroth_test_component_name, []))
+    test_instrument.children.append(Component(first_test_component_name, []))
     dictionary_output = test_instrument.as_dict([])
 
     child_names = [child["name"] for child in dictionary_output["children"]]

--- a/tests/ui_tests/test_ui_add_component_window.py
+++ b/tests/ui_tests/test_ui_add_component_window.py
@@ -392,7 +392,7 @@ def get_new_component_from_dialog(dialog: AddComponentDialog, name: str) -> Comp
     :param name: The name of the component that is being searched for.
     :return: The component.
     """
-    for component in dialog.instrument.component_list:
+    for component in dialog.instrument.get_components():
         if component.name == name:
             return component
 


### PR DESCRIPTION
### Issue

ECDC-2738

### Description of work

Remove component list from instrument class. This fixes the issue with copies of components when a json is loaded, edited and saved again.
