### PR TITLE
ECDC-2737: respect dataset type when writing to JSON

### DIFF
--- a/nexus_constructor/model/module.py
+++ b/nexus_constructor/model/module.py
@@ -11,7 +11,12 @@ from nexus_constructor.model.attributes import Attributes
 if TYPE_CHECKING:
     from nexus_constructor.model.group import Group  # noqa: F401
 
-from nexus_constructor.model.value_type import ValueType
+from nexus_constructor.model.value_type import (
+    FLOAT_TYPES,
+    INT_TYPES,
+    ValueType,
+    ValueTypes,
+)
 
 ARRAY_SIZE = "array_size"
 VALUE_UNITS = "value_units"
@@ -144,10 +149,7 @@ class Dataset(FileWriterModule):
     def as_dict(self, error_collector: List[str]):
         values = self.values
         if np.isscalar(values):
-            try:
-                values = float(values)  # type: ignore
-            except ValueError:
-                pass
+            values = self._cast_to_type(values)
         elif isinstance(values, np.ndarray):
             values = values.tolist()
 
@@ -163,6 +165,17 @@ class Dataset(FileWriterModule):
                 error_collector
             )
         return return_dict
+
+    def _cast_to_type(self, data):
+        # Only cast to int, float or str so values can be
+        # serialised to json
+        if self.type in INT_TYPES:
+            data = int(data)
+        elif self.type in FLOAT_TYPES:
+            data = float(data)
+        elif self.type == ValueTypes.STRING:
+            data = str(data)
+        return data
 
 
 @attr.s

--- a/nexus_constructor/model/module.py
+++ b/nexus_constructor/model/module.py
@@ -11,7 +11,7 @@ from nexus_constructor.model.attributes import Attributes
 if TYPE_CHECKING:
     from nexus_constructor.model.group import Group  # noqa: F401
 
-from nexus_constructor.model.value_type import ValueType, cast_to_json_serialisable_type
+from nexus_constructor.model.value_type import JsonSerialisableType, ValueType
 
 ARRAY_SIZE = "array_size"
 VALUE_UNITS = "value_units"
@@ -162,7 +162,7 @@ class Dataset(FileWriterModule):
         return return_dict
 
     def _cast_to_type(self, data):
-        return cast_to_json_serialisable_type(self.type)(data)  # type: ignore
+        return JsonSerialisableType.from_type(self.type)(data)
 
 
 @attr.s

--- a/nexus_constructor/model/module.py
+++ b/nexus_constructor/model/module.py
@@ -162,7 +162,7 @@ class Dataset(FileWriterModule):
         return return_dict
 
     def _cast_to_type(self, data):
-        return cast_to_json_serialisable_type(data)(data)  # type: ignore
+        return cast_to_json_serialisable_type(self.type)(data)  # type: ignore
 
 
 @attr.s

--- a/nexus_constructor/model/module.py
+++ b/nexus_constructor/model/module.py
@@ -11,12 +11,7 @@ from nexus_constructor.model.attributes import Attributes
 if TYPE_CHECKING:
     from nexus_constructor.model.group import Group  # noqa: F401
 
-from nexus_constructor.model.value_type import (
-    FLOAT_TYPES,
-    INT_TYPES,
-    ValueType,
-    ValueTypes,
-)
+from nexus_constructor.model.value_type import ValueType, cast_to_json_serialisable_type
 
 ARRAY_SIZE = "array_size"
 VALUE_UNITS = "value_units"
@@ -167,15 +162,7 @@ class Dataset(FileWriterModule):
         return return_dict
 
     def _cast_to_type(self, data):
-        # Only cast to int, float or str so values can be
-        # serialised to json
-        if self.type in INT_TYPES:
-            data = int(data)
-        elif self.type in FLOAT_TYPES:
-            data = float(data)
-        elif self.type == ValueTypes.STRING:
-            data = str(data)
-        return data
+        return cast_to_json_serialisable_type(data)(data)  # type: ignore
 
 
 @attr.s

--- a/nexus_constructor/model/value_type.py
+++ b/nexus_constructor/model/value_type.py
@@ -48,12 +48,15 @@ INT_TYPES = [
 FLOAT_TYPES = [ValueTypes.FLOAT, ValueTypes.DOUBLE]
 
 
-cast_to_json_serialisable_type = (
-    lambda dtype: int
-    if dtype in INT_TYPES
-    else (
-        float
-        if dtype in FLOAT_TYPES
-        else (str if dtype == ValueTypes.STRING else lambda y: y)  # type: ignore
-    )
-)
+class JsonSerialisableType:
+    @classmethod
+    def from_type(cls, type):
+        if type in INT_TYPES + [ValueTypes.BYTE, ValueTypes.UBYTE]:
+            return int
+        elif type in FLOAT_TYPES:
+            return float
+        elif type == ValueTypes.STRING:
+            return str
+        else:
+            # Do nothing to data
+            return lambda arg: arg

--- a/nexus_constructor/model/value_type.py
+++ b/nexus_constructor/model/value_type.py
@@ -46,3 +46,14 @@ INT_TYPES = [
     ValueTypes.SHORT,
 ]
 FLOAT_TYPES = [ValueTypes.FLOAT, ValueTypes.DOUBLE]
+
+
+cast_to_json_serialisable_type = (
+    lambda dtype: int
+    if dtype in INT_TYPES
+    else (
+        float
+        if dtype in FLOAT_TYPES
+        else (str if dtype == ValueTypes.STRING else lambda y: y)  # type: ignore
+    )
+)


### PR DESCRIPTION
### Issue

Close ECDC-2737

### Description of work
- When writing to json, dataset's type is respected. 
