### PR TITLE
ECDC-2746: Error loading amor json

### DIFF
--- a/nexus_constructor/json/load_from_json.py
+++ b/nexus_constructor/json/load_from_json.py
@@ -242,7 +242,12 @@ class JSONReader:
                 and parent_node.nx_class == "NXentry"
             ):
                 self.model.entry[nexus_object.name] = nexus_object
-            if isinstance(nexus_object, Group) and nexus_object.nx_class == "NXuser":
+            if isinstance(nexus_object, Group) and not nexus_object.nx_class:
+                self._add_object_warning(
+                    f"valid {CommonAttrs.NX_CLASS}",
+                    parent_node,
+                )
+            elif isinstance(nexus_object, Group) and nexus_object.nx_class == "NXuser":
                 self.model.entry[nexus_object.name] = nexus_object
 
         return nexus_object

--- a/nexus_constructor/model/attributes.py
+++ b/nexus_constructor/model/attributes.py
@@ -27,11 +27,8 @@ class Attributes(list):
         )
 
     def get_attribute_value(self, attribute_name: str):
-        item = _get_item(self, attribute_name)
-        if contains_attribute(attribute_name):
+        if self.contains_attribute(attribute_name):
             return _get_item(self, attribute_name).values
-        return None       
-            return item.values
         return None
 
     def contains_attribute(self, attribute_name):

--- a/nexus_constructor/model/attributes.py
+++ b/nexus_constructor/model/attributes.py
@@ -28,7 +28,9 @@ class Attributes(list):
 
     def get_attribute_value(self, attribute_name: str):
         item = _get_item(self, attribute_name)
-        if item:
+        if contains_attribute(attribute_name):
+            return _get_item(self, attribute_name).values
+        return None       
             return item.values
         return None
 

--- a/nexus_constructor/model/attributes.py
+++ b/nexus_constructor/model/attributes.py
@@ -27,7 +27,10 @@ class Attributes(list):
         )
 
     def get_attribute_value(self, attribute_name: str):
-        return _get_item(self, attribute_name).values
+        item = _get_item(self, attribute_name)
+        if item:
+            return item.values
+        return None
 
     def contains_attribute(self, attribute_name):
         result = _get_item(self, attribute_name)

--- a/nexus_constructor/model/group.py
+++ b/nexus_constructor/model/group.py
@@ -67,7 +67,10 @@ class Group:
 
     @property
     def nx_class(self):
-        return self.attributes.get_attribute_value(CommonAttrs.NX_CLASS)
+        try:
+            return self.attributes.get_attribute_value(CommonAttrs.NX_CLASS)
+        except AttributeError:
+            return None
 
     @nx_class.setter
     def nx_class(self, new_nx_class: str):

--- a/nexus_constructor/model/group.py
+++ b/nexus_constructor/model/group.py
@@ -67,10 +67,7 @@ class Group:
 
     @property
     def nx_class(self):
-        try:
-            return self.attributes.get_attribute_value(CommonAttrs.NX_CLASS)
-        except AttributeError:
-            return None
+        return self.attributes.get_attribute_value(CommonAttrs.NX_CLASS)
 
     @nx_class.setter
     def nx_class(self, new_nx_class: str):


### PR DESCRIPTION
### Issue

Does not close the ticket.

### Description of work

Adding handling for the case when the group lacks a proper nexus class when loading a json and putting a warning.

### Acceptance Criteria 

load the amor json file and see that the warning is there for those cases.

### UI tests

load the amor json file.

