### PR TITLE
ECDC-2434 Adding name validator to attributes

### DIFF
--- a/nexus_constructor/field_widget.py
+++ b/nexus_constructor/field_widget.py
@@ -259,11 +259,11 @@ class FieldWidget(QFrame):
             return None
 
         if self.field_type != FieldType.link:
-            for attr_tuple in self.attrs_dialog.get_attrs():
+            for name, value, dtype in self.attrs_dialog.get_attrs():
                 return_object.attributes.set_attribute_value(
-                    attribute_name=attr_tuple[0],
-                    attribute_value=attr_tuple[1],
-                    attribute_type=attr_tuple[2],
+                    attribute_name=name,
+                    attribute_value=value,
+                    attribute_type=dtype,
                 )
             if self.units and self.units is not None:
                 return_object.attributes.set_attribute_value(

--- a/nexus_constructor/field_widget.py
+++ b/nexus_constructor/field_widget.py
@@ -259,7 +259,7 @@ class FieldWidget(QFrame):
             return None
 
         if self.field_type != FieldType.link:
-            for attr_name, attr_tuple in self.attrs_dialog.get_attrs():
+            for attr_tuple in self.attrs_dialog.get_attrs():
                 return_object.attributes.set_attribute_value(
                     attribute_name=attr_tuple[0],
                     attribute_value=attr_tuple[1],

--- a/nexus_constructor/field_widget.py
+++ b/nexus_constructor/field_widget.py
@@ -259,11 +259,11 @@ class FieldWidget(QFrame):
             return None
 
         if self.field_type != FieldType.link:
-            for attr_name, attr_tuple in self.attrs_dialog.get_attrs().items():
+            for attr_name, attr_tuple in self.attrs_dialog.get_attrs():
                 return_object.attributes.set_attribute_value(
-                    attribute_name=attr_name,
-                    attribute_value=attr_tuple[0],
-                    attribute_type=attr_tuple[1],
+                    attribute_name=attr_tuple[0],
+                    attribute_value=attr_tuple[1],
+                    attribute_type=attr_tuple[2],
                 )
             if self.units and self.units is not None:
                 return_object.attributes.set_attribute_value(

--- a/nexus_constructor/validators.py
+++ b/nexus_constructor/validators.py
@@ -80,6 +80,32 @@ class UnitValidator(QValidator):
     is_valid = Signal(bool)
 
 
+class AttributeNameValidator(QValidator):
+    """
+    Validator to ensure that attributes are valid with respect to name.
+    """
+
+    def __init__(self, get_attr_names, invalid_names: List = None):
+        super().__init__()
+        self.invalid_names = ["units"]
+        if invalid_names:
+            self.invalid_names += invalid_names
+        self.get_attr_names = get_attr_names
+
+    def validate(self, input: str, pos: int):
+        attr_names = self.get_attr_names()
+        if not input or input in self.invalid_names:
+            self.is_valid.emit(False)
+            return QValidator.Intermediate
+        if attr_names.count(input) > 1:
+            self.is_valid.emit(False)
+            return QValidator.Intermediate
+        self.is_valid.emit(True)
+        return QValidator.Acceptable
+
+    is_valid = Signal(bool)
+
+
 class NameValidator(QValidator):
     """
     Validator to ensure item names are unique within a model that has a 'name' property

--- a/nexus_constructor/validators.py
+++ b/nexus_constructor/validators.py
@@ -1,7 +1,7 @@
 import os
 import re
 from enum import Enum
-from typing import List
+from typing import Callable, List
 
 import numpy as np
 import pint
@@ -85,7 +85,7 @@ class AttributeNameValidator(QValidator):
     Validator to ensure that attributes are valid with respect to name.
     """
 
-    def __init__(self, get_attr_names, invalid_names: List = None):
+    def __init__(self, get_attr_names: Callable, invalid_names: List = None):
         super().__init__()
         self.invalid_names = ["units"]
         if invalid_names:

--- a/tests/ui_tests/test_ui_field_attrs.py
+++ b/tests/ui_tests/test_ui_field_attrs.py
@@ -45,7 +45,7 @@ def test_GIVEN_existing_field_with_attr_WHEN_editing_component_THEN_both_field_a
     field_attributes_dialog.fill_existing_attrs(ds)
 
     assert len(field_attributes_dialog.get_attrs()) == 1
-    assert field_attributes_dialog.get_attrs()[attr_key][0] == str(attr_val)
+    assert field_attributes_dialog.get_attrs()[0][1] == str(attr_val)
 
 
 def test_GIVEN_existing_field_with_attr_which_is_in_excludelist_WHEN_editing_component_THEN_attr_is_not_filled_in(


### PR DESCRIPTION
### Issue

Closes https://jira.esss.lu.se/browse/ECDC-2434

### Description of work

Adding an attribute name validator to field attribute edits.

### Acceptance Criteria 

Instance of validator class emits is_valid as false if reoccuring name or if name is 'units'

### UI tests

Edit attributes for a field in the sample component and test different cases.

### Nominate for Group Code Review

Ebad
