### PR TITLE
ECDC-2804 NXdetector bug fix regarding streams

### DIFF
--- a/nexus_constructor/component_tree_view.py
+++ b/nexus_constructor/component_tree_view.py
@@ -62,7 +62,7 @@ class ComponentEditorDelegate(QStyledItemDelegate):
             get_group_frame(frame, value)
         elif isinstance(value, TransformationsList):
             get_transformations_list_frame(frame)
-        elif isinstance(value, ComponentInfo):  # TODO: Call this GroupInfo.
+        elif isinstance(value, ComponentInfo):
             get_group_info_frame(frame, value)
         elif isinstance(value, Transformation):
             get_transformation_frame(frame, self.model, value)

--- a/nexus_constructor/field_utils.py
+++ b/nexus_constructor/field_utils.py
@@ -59,13 +59,14 @@ def update_existing_scalar_field(field: Dataset, new_ui_field: FieldWidget):
     __update_existing_dataset_field(field, new_ui_field)
 
 
-def update_existing_stream_field(field: Group, new_ui_field: "StreamFieldsWidget"):
+def update_existing_stream_field(
+    field: StreamModule, new_ui_field: "StreamFieldsWidget"
+):
     """
     Fill in a UI stream field for an existing stream field in the component group
     :param field: The dataset to copy into the value line edit
     :param new_ui_field: The new UI field to fill in with existing data
     """
-    new_ui_field.name = field.name
     new_ui_field.field_type = FieldType.kafka_stream
     new_ui_field.streams_widget.update_existing_stream_info(field)
     new_ui_field.attrs = field
@@ -94,6 +95,8 @@ def find_field_type(item: "ValueType", ignore_names=INVALID_FIELD_NAMES) -> Call
             return update_existing_scalar_field
         else:
             return update_existing_array_field
+    elif isinstance(item, StreamModule):
+        return update_existing_stream_field
     elif isinstance(item, Group):
         if item.children:
             if isinstance(item.children[0], StreamModule):

--- a/nexus_constructor/model/module.py
+++ b/nexus_constructor/model/module.py
@@ -41,7 +41,6 @@ class StreamModules(Enum):
     EV42 = "ev42"
     TDCTIME = "tdct"
     NS10 = "ns10"
-    HS00 = "hs00"
     SENV = "senv"
     ADAR = "ADAr"
 

--- a/nexus_constructor/model/module.py
+++ b/nexus_constructor/model/module.py
@@ -36,6 +36,16 @@ class WriterModules(Enum):
     ADAR = "ADAr"
 
 
+class StreamModules(Enum):
+    F142 = "f142"
+    EV42 = "ev42"
+    TDCTIME = "tdct"
+    NS10 = "ns10"
+    HS00 = "hs00"
+    SENV = "senv"
+    ADAR = "ADAr"
+
+
 @attr.s
 class FileWriterModule(ABC):
     attributes = attr.ib(type=Attributes, factory=Attributes, init=False)

--- a/nexus_constructor/module_view.py
+++ b/nexus_constructor/module_view.py
@@ -4,7 +4,7 @@ from nexus_constructor.common_attrs import CommonAttrs
 from nexus_constructor.field_utils import find_field_type
 from nexus_constructor.field_widget import FieldWidget
 from nexus_constructor.model.model import Model
-from nexus_constructor.model.module import WriterModules
+from nexus_constructor.model.module import StreamModules, WriterModules
 
 
 class ModuleView(QGroupBox):
@@ -23,6 +23,8 @@ class ModuleView(QGroupBox):
         if (
             self.module.writer_module == WriterModules.DATASET.value
             or self.module.writer_module == WriterModules.LINK.value
+            or self.module.writer_module
+            in [StreamMode.value for StreamMode in StreamModules]
         ):
             update_function = find_field_type(module, [])
             if update_function is not None:
@@ -37,6 +39,14 @@ class ModuleView(QGroupBox):
             self.module.name = self.field_widget.name
             self.module.values = self.field_widget.value.values  # type: ignore
             self.module.type = self.field_widget.dtype
+            self.module.attributes.set_attribute_value(
+                CommonAttrs.UNITS, self.field_widget.units
+            )
+        elif self.module.writer_module in [
+            StreamMode.value for StreamMode in StreamModules
+        ]:
+            self.module.source = self.field_widget.value.source  # type: ignore
+            self.module.topic = self.field_widget.value.topic  # type: ignore
             self.module.attributes.set_attribute_value(
                 CommonAttrs.UNITS, self.field_widget.units
             )

--- a/nexus_constructor/stream_fields_widget.py
+++ b/nexus_constructor/stream_fields_widget.py
@@ -21,6 +21,7 @@ from PySide2.QtWidgets import (
 
 from nexus_constructor.array_dataset_table_widget import ValueDelegate
 from nexus_constructor.common_attrs import ARRAY, SCALAR
+from nexus_constructor.model.group import Group
 from nexus_constructor.model.module import (
     ADC_PULSE_DEBUG,
     CHUNK_SIZE,
@@ -435,9 +436,8 @@ class StreamFieldsWidget(QDialog):
         Fill in stream fields and properties into the new UI field.
         :param field: The stream group
         """
-        field = field.children[
-            0
-        ]  # only the first stream in the stream group can be edited currently
+        if isinstance(field, Group):
+            field = field.children[0]
         schema = field.writer_module
         self.schema_combo.setCurrentText(schema)
         self.topic_line_edit.setText(field.topic)


### PR DESCRIPTION
### Issue

Closes ECDC-2804

### Description of work

Fixes bug when editing stream modules added directly to a component.
This is actually a more general bug than just for NXdetector. 

Test when adding component with a dataset that once you edit the component and add a stream module directly (without a group), the stream module is added correctly in the treeview (was previously added as an empty dataset).
Editing the component again should display the stream module correctly in the field list in the widget.
