### PR TITLE
ECDC-2375 Add sensible default data type for field in nexus class object

### DIFF
--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -361,7 +361,8 @@ class AddComponentDialog(Ui_AddComponentDialog, QObject):
         self.possible_fields = self.nx_component_classes[
             self.componentTypeComboBox.currentText()
         ]
-        self.nx_class_changed.emit(self.possible_fields)
+        possible_field_names, _ = zip(*self.possible_fields)
+        self.nx_class_changed.emit(possible_field_names)
 
     def mesh_file_picker(self):
         """

--- a/nexus_constructor/component_type.py
+++ b/nexus_constructor/component_type.py
@@ -136,8 +136,8 @@ nexus_dtype_dict = {
     "NX_FLOAT": "double",
     "NX_INT": "int64",
     "NX_NUMBER": "double",
-    "NX_POSINT": "uint32",
-    "NX_UINT": "uint32",
+    "NX_POSINT": "uint64",
+    "NX_UINT": "uint64",
 }
 
 

--- a/nexus_constructor/component_type.py
+++ b/nexus_constructor/component_type.py
@@ -132,7 +132,8 @@ def make_dictionary_of_class_definitions(
 
 nexus_dtype_dict = {
     "NX_CHAR": "string",
-    "NX_FLOAT": "float",
+    "NX_DATE_TIME": "string",
+    "NX_FLOAT": "double",
     "NX_INT": "int32",
     "NX_NUMBER": "float",
     "NX_POSINT": "uint32",
@@ -157,13 +158,13 @@ def _create_base_class_dict(
             for field in fields:
                 data_type = "string"
                 if "@type" in field:
-                    data_type = nexus_dtype_dict.get(field["@type"], "string")
+                    data_type = nexus_dtype_dict.get(field["@type"], "double")
                 class_fields.append((field["@name"], data_type))
 
         except Exception:
             data_type = "string"
             if "@type" in fields:
-                data_type = nexus_dtype_dict.get(fields["@type"], "string")
+                data_type = nexus_dtype_dict.get(fields["@type"], "double")
             class_fields.append((fields["@name"], data_type))
     except KeyError:
         pass

--- a/nexus_constructor/component_type.py
+++ b/nexus_constructor/component_type.py
@@ -134,7 +134,7 @@ nexus_dtype_dict = {
     "NX_CHAR": "string",
     "NX_DATE_TIME": "string",
     "NX_FLOAT": "double",
-    "NX_INT": "int32",
+    "NX_INT": "int64",
     "NX_NUMBER": "double",
     "NX_POSINT": "uint32",
     "NX_UINT": "uint32",

--- a/nexus_constructor/component_type.py
+++ b/nexus_constructor/component_type.py
@@ -130,6 +130,16 @@ def make_dictionary_of_class_definitions(
     return all_class_definitions, component_definitions
 
 
+nexus_dtype_dict = {
+    "NX_CHAR": "string",
+    "NX_FLOAT": "float",
+    "NX_INT": "int32",
+    "NX_NUMBER": "float",
+    "NX_POSINT": "uint32",
+    "NX_UINT": "uint32",
+}
+
+
 def _create_base_class_dict(
     xml_text, not_allowed, class_definitions, component_definitions
 ):
@@ -145,9 +155,16 @@ def _create_base_class_dict(
         fields = xml_definition["field"]
         try:
             for field in fields:
-                class_fields.append(field["@name"])
+                data_type = "string"
+                if "@type" in field:
+                    data_type = nexus_dtype_dict.get(field["@type"], "string")
+                class_fields.append((field["@name"], data_type))
+
         except Exception:
-            class_fields.append(fields["@name"])
+            data_type = "string"
+            if "@type" in fields:
+                data_type = nexus_dtype_dict.get(fields["@type"], "string")
+            class_fields.append((fields["@name"], data_type))
     except KeyError:
         pass
     class_definitions[nx_class_name] = class_fields

--- a/nexus_constructor/component_type.py
+++ b/nexus_constructor/component_type.py
@@ -135,7 +135,7 @@ nexus_dtype_dict = {
     "NX_DATE_TIME": "string",
     "NX_FLOAT": "double",
     "NX_INT": "int32",
-    "NX_NUMBER": "float",
+    "NX_NUMBER": "double",
     "NX_POSINT": "uint32",
     "NX_UINT": "uint32",
 }

--- a/nexus_constructor/field_widget.py
+++ b/nexus_constructor/field_widget.py
@@ -78,15 +78,20 @@ class FieldWidget(QFrame):
     def __init__(
         self,
         node_parent,
-        possible_field_names=None,
+        possible_fields=None,
         parent: QListWidget = None,
         hide_name_field: bool = False,
         show_only_f142_stream: bool = False,
     ):
         super(FieldWidget, self).__init__(parent)
 
-        if possible_field_names is None:
-            possible_field_names = []
+        possible_field_names = []
+        self.default_field_types_dict = {}
+        if possible_fields:
+            possible_field_names, default_field_types = zip(*possible_fields)
+            self.default_field_types_dict = dict(
+                zip(possible_field_names, default_field_types)
+            )
         self._show_only_f142_stream = show_only_f142_stream
         self._node_parent = node_parent
 
@@ -97,6 +102,8 @@ class FieldWidget(QFrame):
             self.parent().parent().destroyed.connect(self.attrs_dialog.close)
 
         self.field_name_edit = FieldNameLineEdit(possible_field_names)
+        if self.default_field_types_dict:
+            self.field_name_edit.textChanged.connect(self.update_default_type)
         self.hide_name_field = hide_name_field
         if hide_name_field:
             self.name = str(uuid.uuid4())
@@ -290,6 +297,11 @@ class FieldWidget(QFrame):
     @units.setter
     def units(self, new_units: str):
         self.units_line_edit.setText(new_units)
+
+    def update_default_type(self):
+        self.value_type_combo.setCurrentText(
+            self.default_field_types_dict.get(self.field_name_edit.text(), "string")
+        )
 
     def eventFilter(self, watched: QObject, event: QEvent) -> bool:
         if event.type() == QEvent.MouseButtonPress:

--- a/nexus_constructor/field_widget.py
+++ b/nexus_constructor/field_widget.py
@@ -300,7 +300,7 @@ class FieldWidget(QFrame):
 
     def update_default_type(self):
         self.value_type_combo.setCurrentText(
-            self.default_field_types_dict.get(self.field_name_edit.text(), "string")
+            self.default_field_types_dict.get(self.field_name_edit.text(), "double")
         )
 
     def eventFilter(self, watched: QObject, event: QEvent) -> bool:

--- a/tests/test_component_types.py
+++ b/tests/test_component_types.py
@@ -68,7 +68,7 @@ def test_GIVEN_a_valid_base_class_containing_name_key_and_name_field_WHEN_creati
     component_base_classes = dict()
     _create_base_class_dict(xml, None, base_classes, component_base_classes)
     assert class_name in base_classes.keys()
-    assert "name" in base_classes[class_name]
+    assert ("name", "string") in base_classes[class_name]
 
 
 def test_GIVEN_a_valid_base_class_with_no_fields_WHEN_creating_base_class_dict_THEN_dict_contains_empty_list_for_value():

--- a/tests/ui_tests/test_ui_fields.py
+++ b/tests/ui_tests/test_ui_fields.py
@@ -8,6 +8,8 @@ from nexus_constructor.field_widget import FieldWidget
 from nexus_constructor.stream_fields_widget import StreamFieldsWidget
 from tests.test_utils import NX_CLASS_DEFINITIONS
 
+POSSIBLE_FIELDS = [("test", "string")]
+
 
 @pytest.fixture
 def stream_fields_widget(qtbot, model, template):
@@ -30,7 +32,7 @@ def test_ui_field_GIVEN_field_has_units_filled_in_ui_WHEN_getting_field_group_TH
     qtbot,
 ):
     listwidget = QListWidget()
-    field = FieldWidget(None, ["test"], listwidget)
+    field = FieldWidget(None, POSSIBLE_FIELDS, listwidget)
     field_name = "test"
     field.name = field_name
     field.value_line_edit.setText("1")
@@ -47,7 +49,7 @@ def test_ui_field_GIVEN_field_does_not_have_units_filled_in_ui_WHEN_getting_fiel
     qtbot,
 ):
     listwidget = QListWidget()
-    field = FieldWidget(None, ["test"], listwidget)
+    field = FieldWidget(None, POSSIBLE_FIELDS, listwidget)
     field_name = "test"
     field.name = field_name
     field.value_line_edit.setText("1")
@@ -63,7 +65,7 @@ def test_ui_stream_field_GIVEN_f142_is_selected_WHEN_combo_is_changed_THEN_value
 ):
     listwidget = QListWidget()
     listwidget.field_name_edit = QLabel()
-    field = FieldWidget(None, ["test"], listwidget)
+    field = FieldWidget(None, POSSIBLE_FIELDS, listwidget)
     field_name = "test"
     field.name = field_name
 
@@ -81,7 +83,7 @@ def test_ui_stream_field_GIVEN_f142_is_selected_WHEN_advanced_options_are_clicke
 ):
     listwidget = QListWidget()
     listwidget.field_name_edit = QLabel()
-    field = FieldWidget(None, ["test"], listwidget)
+    field = FieldWidget(None, POSSIBLE_FIELDS, listwidget)
     field_name = "test"
     field.name = field_name
 
@@ -103,7 +105,7 @@ def test_ui_stream_field_GIVEN_ev42_is_selected_WHEN_advanced_options_are_clicke
 ):
     listwidget = QListWidget()
     listwidget.field_name_edit = QLabel()
-    field = FieldWidget(None, ["test"], listwidget)
+    field = FieldWidget(None, POSSIBLE_FIELDS, listwidget)
     field_name = "test"
     field.name = field_name
 


### PR DESCRIPTION
### Issue

Closes ECDC-2375 (https://jira.esss.lu.se/browse/ECDC-2375)

### Description of work

NeXus definitions specify NX_FLOAT, NX_CHAR etc for each field. 
This information is used to select an appropriate default for the type combo box for fields in the add component window. Default is double (as filewriter) if nothing sensible can be used.


### Acceptance Criteria 

Unit tests pass.
Works as intended.
