### PR TITLE
ECDC-2844 Removing the stream in parent of parent in edit group dialogue

### DIFF
--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -665,8 +665,10 @@ def add_fields_to_component(
     for i in range(fields_widget.count()):
         widget = fields_widget.itemWidget(fields_widget.item(i))
         try:
-            if not isinstance(widget.value, Dataset):
-                component.children.append(widget.value)
+            if not isinstance(widget.value, (Link, Dataset)):
+                stream_module = deepcopy(widget.value)
+                stream_module.parent_node = component
+                component.children.append(stream_module)
             else:
                 component[widget.name] = widget.value
         except ValueError as error:

--- a/nexus_constructor/component_tree_view.py
+++ b/nexus_constructor/component_tree_view.py
@@ -48,6 +48,7 @@ class ComponentEditorDelegate(QStyledItemDelegate):
             Transformation,
             LinkTransformation,
             TransformationsList,
+            FileWriterModule,
         ],
     ):
         frame = QFrame()

--- a/nexus_constructor/field_utils.py
+++ b/nexus_constructor/field_utils.py
@@ -97,17 +97,6 @@ def find_field_type(item: "ValueType", ignore_names=INVALID_FIELD_NAMES) -> Call
             return update_existing_array_field
     elif isinstance(item, StreamModule):
         return update_existing_stream_field
-    elif isinstance(item, Group):
-        if item.children:
-            if isinstance(item.children[0], StreamModule):
-                return update_existing_stream_field
-            elif isinstance(item, Link):
-                return update_existing_link_field
-            elif isinstance(item, FileWriterModule):
-                if np.isscalar(item.values):
-                    return update_existing_scalar_field
-                else:
-                    return update_existing_array_field
     elif isinstance(item, Link):
         return update_existing_link_field
     else:

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -52,6 +52,7 @@ class MainWindow(Ui_MainWindow, QMainWindow):
         )
 
         self._update_views()
+        self.simple_tree_view.triggered.emit()
 
     def onOpenAboutWindow(self, instance):
         if self.checkWindowOpen(instance, self._registered_windows):

--- a/nexus_constructor/module_view.py
+++ b/nexus_constructor/module_view.py
@@ -34,6 +34,9 @@ class ModuleView(QGroupBox):
         self.layout.setAlignment(Qt.AlignLeft)
         self.setLayout(self.layout)
 
+    def save_module_changes(self):
+        pass
+
     @staticmethod
     def _get_label(content):
         label = QLabel(content)

--- a/tests/ui_tests/test_ui_add_component_window.py
+++ b/tests/ui_tests/test_ui_add_component_window.py
@@ -1799,7 +1799,7 @@ def test_UI_GIVEN_component_with_multiple_fields_WHEN_editing_component_THEN_all
     assert widget2.value.values == str(field_value2)
 
 
-def test_UI_GIVEN_component_with_basic_f142_field_WHEN_editing_component_THEN_topic_and_source_are_correct(
+def test_UI_GIVEN_group_with_basic_f142_field_WHEN_editing_component_THEN_topic_and_source_are_correct(
     qtbot,
 ):
     component, model, treeview_model = create_group_with_component(
@@ -1819,13 +1819,10 @@ def test_UI_GIVEN_component_with_basic_f142_field_WHEN_editing_component_THEN_to
 
     stream_group.children.append(stream)
 
-    field_name1 = "stream1"
-    component[field_name1] = stream_group
-
     dialog = AddComponentDialog(
         model,
         treeview_model,
-        component_to_edit=component,
+        component_to_edit=stream_group,
         nx_classes=NX_CLASS_DEFINITIONS,
     )
     dialog.pixel_options = Mock(spec=PixelOptions)

--- a/tests/ui_tests/test_ui_transformation_view.py
+++ b/tests/ui_tests/test_ui_transformation_view.py
@@ -8,7 +8,6 @@ from pytestqt.qtbot import QtBot  # noqa: F401
 
 from nexus_constructor.field_attrs import _get_human_readable_type
 from nexus_constructor.model.component import Component
-from nexus_constructor.model.group import Group
 from nexus_constructor.model.model import Model
 from nexus_constructor.model.module import Dataset, F142Stream, Link
 from nexus_constructor.transformation_view import EditRotation, EditTranslation
@@ -127,16 +126,12 @@ def test_UI_GIVEN_stream_group_as_angle_WHEN_creating_rotation_THEN_ui_is_filled
 
     transform = component.add_rotation(QVector3D(x, y, z), 0, name="test")
 
-    stream_group = Group("stream_group")
-
     topic = "test_topic"
     source = "source1"
     type = "double"
-    stream = F142Stream(parent_node=stream_group, topic=topic, source=source, type=type)
+    stream = F142Stream(parent_node=transform, topic=topic, source=source, type=type)
 
-    stream_group["stream"] = stream
-
-    transform.values = stream_group
+    transform.values = stream
 
     view = EditRotation(parent=None, transformation=transform, model=None)
     qtbot.addWidget(view)

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -1,3 +1,5 @@
+from platform import system
+
 from PySide2.QtCore import QMetaObject, QObject, QRect, QSize
 from PySide2.QtGui import QKeySequence
 from PySide2.QtWidgets import (
@@ -14,6 +16,8 @@ from PySide2.QtWidgets import (
 
 from nexus_constructor.instrument_view.instrument_view import InstrumentView
 from ui.treeview_tab import ComponentTreeViewTab
+
+MAC_OS = "Darwin"
 
 
 class Ui_MainWindow(object):
@@ -74,6 +78,8 @@ class Ui_MainWindow(object):
         self.show_action_labels.setCheckable(True)
         self.simple_tree_view = QAction(MainWindow)
         self.simple_tree_view.setCheckable(True)
+        if system() == MAC_OS:
+            self.simple_tree_view.setChecked(True)
         self.about_window = QAction(MainWindow)
         self.view_menu.addAction(self.about_window)
         self.view_menu.addAction(self.show_action_labels)


### PR DESCRIPTION
### Issue

Closes ECDC-2844 (https://jira.esss.lu.se/browse/ECDC-2844)

### Description of work

Do not display stream module in parent of parent when editing a group containing streams.

### Acceptance Criteria 

No stream module child of group child when editing group.

### UI tests

Create a Group "A" (arbitrary which nx_class).
Put an NXlog group as child of that group and add a stream module to the group.
When editing Group "A", stream module widget should not be visible in edit group window.
