### PR TITLE
removing nx_class from enumerator fieldtype

### DIFF
--- a/nexus_constructor/field_widget.py
+++ b/nexus_constructor/field_widget.py
@@ -338,8 +338,6 @@ class FieldWidget(QFrame):
                 show_attrs_edit=False,
             )
             self._set_up_value_validator(False)
-        elif self.field_type == FieldType.nx_class:
-            self.set_visibility(False, True, False, False)
 
     def _set_up_value_validator(self, is_link: bool):
         self.value_line_edit.setValidator(None)

--- a/nexus_constructor/validators.py
+++ b/nexus_constructor/validators.py
@@ -326,7 +326,6 @@ class FieldType(Enum):
     array_dataset = "Array dataset"
     kafka_stream = "Kafka stream"
     link = "Link"
-    nx_class = "NX class/group"
 
 
 class FieldValueValidator(QValidator):


### PR DESCRIPTION
### Issue

removes the possibility to select nexus group in field type through the add field in the add/edit component window when adding a field.

### Description of work

See issue above.
