### PR TITLE
ECDC-2853: Improving and fixing stream widget editing in tree view

### DIFF
--- a/nexus_constructor/component_tree_view.py
+++ b/nexus_constructor/component_tree_view.py
@@ -97,11 +97,11 @@ class ComponentEditorDelegate(QStyledItemDelegate):
     def createEditor(
         self, parent: QWidget, option: QStyleOptionViewItem, index: QModelIndex
     ) -> QWidget:
-        model = index.model()
-        value = model.data(index, Qt.DisplayRole)
-        frame = self.get_frame(value)
+        frame = self._dict_frames[index]
         if hasattr(frame, TRANSFORMATION_FRAME):
             frame.transformation_frame.enable()
+        if hasattr(frame, MODULE_FRAME):
+            frame.module_frame.setEnabled(True)
         frame.setParent(parent)
         self.frameSize = frame.sizeHint()
         return frame

--- a/nexus_constructor/module_view.py
+++ b/nexus_constructor/module_view.py
@@ -85,11 +85,14 @@ class ModuleViewEditable(QGroupBox):
         elif self.module.writer_module in [
             StreamMode.value for StreamMode in StreamModules
         ]:
+            self.module.writer_module = self.field_widget.value.writer_module
+            self.setTitle(self.module.writer_module.upper())
             self.module.source = self.field_widget.value.source  # type: ignore
             self.module.topic = self.field_widget.value.topic  # type: ignore
             self.module.attributes.set_attribute_value(
                 CommonAttrs.UNITS, self.field_widget.units
             )
+            self._set_additional_options()
         elif self.module.writer_module == WriterModules.LINK.value:
             self.module.source = self.field_widget.value.source  # type: ignore
             self.module.name = self.field_widget.name
@@ -100,3 +103,16 @@ class ModuleViewEditable(QGroupBox):
                 CommonAttrs.UNITS, self.field_widget.units
             )
         self.model.signals.module_changed.emit()
+
+    def _set_additional_options(self):
+        if self.module.writer_module == StreamModules.ADAR.value:
+            array_size_table = self.field_widget.streams_widget.array_size_table
+            self.module.array_size = []
+            for i in range(array_size_table.columnCount()):
+                table_value = array_size_table.item(0, i)
+                if table_value:
+                    self.module.array_size.append(int(table_value.text()))
+        elif self.module.writer_module == StreamModules.F142.value:
+            self.field_widget.streams_widget.record_advanced_f142_values(self.module)
+        elif self.module.writer_module == StreamModules.EV42.value:
+            self.field_widget.streams_widget.record_advanced_ev42_values(self.module)

--- a/nexus_constructor/stream_fields_widget.py
+++ b/nexus_constructor/stream_fields_widget.py
@@ -17,6 +17,7 @@ from PySide2.QtWidgets import (
     QRadioButton,
     QSpinBox,
     QTableWidget,
+    QTableWidgetItem,
 )
 
 from nexus_constructor.array_dataset_table_widget import ValueDelegate
@@ -33,6 +34,7 @@ from nexus_constructor.model.module import (
     NS10Stream,
     SENVStream,
     StreamModule,
+    StreamModules,
     TDCTStream,
     WriterModules,
 )
@@ -138,9 +140,9 @@ class StreamFieldsWidget(QDialog):
 
         self.schema_combo.currentTextChanged.connect(self._schema_type_changed)
         if self._show_only_f142_stream:
-            self.schema_combo.addItems([WriterModules.F142.value])
+            self.schema_combo.addItems([StreamModules.F142.value])
         else:
-            self.schema_combo.addItems([e.value for e in WriterModules])
+            self.schema_combo.addItems([e.value for e in StreamModules])
 
         self.ok_button = QPushButton("OK")
         self.ok_button.clicked.connect(self.parent().close)
@@ -309,8 +311,8 @@ class StreamFieldsWidget(QDialog):
 
     def get_stream_module(self, parent) -> StreamModule:
         """
-        Create the stream group
-        :return: The created StreamGroup
+        Create the stream module
+        :return: The created stream module
         """
 
         source = self.source_line_edit.text()
@@ -332,7 +334,7 @@ class StreamFieldsWidget(QDialog):
             if array_size:
                 stream.array_size = array_size
             if self.advanced_options_enabled:
-                self._record_advanced_f142_values(stream)
+                self.record_advanced_f142_values(stream)
         elif current_schema == WriterModules.ADAR.value:
             array_size = []
             for i in range(self.array_size_table.columnCount()):
@@ -344,7 +346,7 @@ class StreamFieldsWidget(QDialog):
         elif current_schema == WriterModules.EV42.value:
             stream = EV42Stream(parent_node=parent, source=source, topic=topic)
             if self.advanced_options_enabled:
-                self._record_advanced_ev42_values(stream)
+                self.record_advanced_ev42_values(stream)
         elif current_schema == WriterModules.NS10.value:
             stream = NS10Stream(parent_node=parent, source=source, topic=topic)
         elif current_schema == WriterModules.SENV.value:
@@ -364,7 +366,7 @@ class StreamFieldsWidget(QDialog):
 
         return stream
 
-    def _record_advanced_f142_values(self, stream: F142Stream):
+    def record_advanced_f142_values(self, stream: F142Stream):
         """
         Save the advanced f142 properties to the stream data object.
         :param stream: The stream data object to be modified.
@@ -372,7 +374,7 @@ class StreamFieldsWidget(QDialog):
         stream.chunk_size = self.f142_chunk_size_spinner.value()
         stream.cue_interval = self.f142_cue_interval_spinner.value()
 
-    def _record_advanced_ev42_values(self, stream: EV42Stream):
+    def record_advanced_ev42_values(self, stream: EV42Stream):
         """
         Save the advanced ev42 properties to the stream data object.
         :param stream: The stream data object to be modified.
@@ -446,3 +448,6 @@ class StreamFieldsWidget(QDialog):
             self.fill_in_existing_f142_fields(field)
         elif schema == WriterModules.EV42.value:
             self.fill_in_existing_ev42_fields(field)
+        elif schema == WriterModules.ADAR.value:
+            for i, val in enumerate(field.array_size):
+                self.array_size_table.setItem(0, i, QTableWidgetItem(str(val)))

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -86,7 +86,7 @@ class Ui_MainWindow(object):
     def _set_up_titles(self, MainWindow):
         MainWindow.setWindowTitle("NeXus Constructor")
         self.tab_widget.setTabText(
-            self.tab_widget.indexOf(self.component_tree_view_tab), "Components"
+            self.tab_widget.indexOf(self.component_tree_view_tab), "Nexus Structure"
         )
         self.file_menu.setTitle("File")
         self.open_json_file_action.setText("Open Filewriter JSON file")


### PR DESCRIPTION
### Issue

Closes https://jira.esss.lu.se/browse/ECDC-2853

### Description of work

Fixing bug that made it impossible to edit Kafka streams in the tree view directly on mac.
Improvement to editing capabilities in tree view overall.

### Acceptance Criteria 

Editing Kafka streams directly in tree view should work better and be more flexible than before, in the tree view mode.

### UI tests

Try out by clicking and editing Kafka streams in the tree view instead of component editor.
