### PR TITLE
ECDC-2875 Constrict nx class suggestion when editing group

### DIFF
--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -371,8 +371,11 @@ class AddComponentDialog(Ui_AddComponentDialog, QObject):
         self.possible_fields = self.nx_component_classes[
             self.componentTypeComboBox.currentText()
         ]
-        possible_field_names, _ = zip(*self.possible_fields)
-        self.nx_class_changed.emit(possible_field_names)
+        try:
+            possible_field_names, _ = zip(*self.possible_fields)
+            self.nx_class_changed.emit(possible_field_names)
+        except ValueError:
+            self.nx_class_changed.emit([])
 
     def mesh_file_picker(self):
         """

--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -13,6 +13,7 @@ from nexus_constructor.component_tree_model import NexusTreeModel
 from nexus_constructor.component_type import (
     CHOPPER_CLASS_NAME,
     COMPONENT_TYPES,
+    NX_CLASSES,
     PIXEL_COMPONENT_TYPES,
     SLIT_CLASS_NAME,
 )
@@ -167,7 +168,16 @@ class AddComponentDialog(Ui_AddComponentDialog, QObject):
             )
         )
 
-        self.componentTypeComboBox.addItems(list(self.nx_component_classes.keys()))
+        if isinstance(self.component_to_edit, Component):
+            sorted_components = list(COMPONENT_TYPES)
+            sorted_components.sort()
+            self.componentTypeComboBox.addItems(sorted_components)
+        elif isinstance(self.component_to_edit, Group):
+            sorted_groups = list(NX_CLASSES - COMPONENT_TYPES)
+            sorted_groups.sort()
+            self.componentTypeComboBox.addItems(sorted_groups)
+        else:
+            self.componentTypeComboBox.addItems(list(self.nx_component_classes.keys()))
         self.componentTypeComboBox.currentIndexChanged.connect(
             self.change_pixel_options_visibility
         )

--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -13,6 +13,7 @@ from nexus_constructor.component_tree_model import NexusTreeModel
 from nexus_constructor.component_type import (
     CHOPPER_CLASS_NAME,
     COMPONENT_TYPES,
+    ENTRY_CLASS_NAME,
     NX_CLASSES,
     PIXEL_COMPONENT_TYPES,
     SLIT_CLASS_NAME,
@@ -27,6 +28,7 @@ from nexus_constructor.geometry.geometry_loader import load_geometry
 from nexus_constructor.geometry.pixel_data import PixelData, PixelGrid, PixelMapping
 from nexus_constructor.geometry.slit.slit_geometry import SlitGeometry
 from nexus_constructor.model.component import Component
+from nexus_constructor.model.entry import Entry
 from nexus_constructor.model.geometry import (
     BoxGeometry,
     CylindricalGeometry,
@@ -42,6 +44,7 @@ from nexus_constructor.ui_utils import (
     file_dialog,
     generate_unique_name,
     show_warning_dialog,
+    validate_combobox_edit,
     validate_line_edit,
 )
 from nexus_constructor.unit_utils import METRES
@@ -49,6 +52,7 @@ from nexus_constructor.validators import (
     GEOMETRY_FILE_TYPES,
     GeometryFileValidator,
     NameValidator,
+    NXClassValidator,
     OkValidator,
     UnitValidator,
 )
@@ -172,6 +176,8 @@ class AddComponentDialog(Ui_AddComponentDialog, QObject):
             sorted_components = list(COMPONENT_TYPES)
             sorted_components.sort()
             self.componentTypeComboBox.addItems(sorted_components)
+        elif isinstance(self.component_to_edit, Entry):
+            self.componentTypeComboBox.addItems([ENTRY_CLASS_NAME])
         elif isinstance(self.component_to_edit, Group):
             sorted_groups = list(NX_CLASSES - COMPONENT_TYPES)
             sorted_groups.sort()
@@ -192,16 +198,35 @@ class AddComponentDialog(Ui_AddComponentDialog, QObject):
             self.pixel_options.setupUi(self.pixelOptionsWidget)
         self.pixelOptionsWidget.ui = self.pixel_options
 
+        self.ok_validator = OkValidator(
+            self.noShapeRadioButton, self.meshRadioButton, self.pixel_options.validator
+        )
+
         if self.component_to_edit:
             parent_dialog.setWindowTitle(f"Edit group: {self.component_to_edit.name}")
             self.ok_button.setText("Edit group")
             self._fill_existing_entries()
             if self.get_pixel_visibility_condition() and self.pixel_options:
                 self.pixel_options.fill_existing_entries(self.component_to_edit)
+        else:
+            self.componentTypeComboBox.setEditable(True)
+            self.componentTypeComboBox.setCurrentText("")
+            self.componentTypeComboBox.setValidator(NXClassValidator())
+            self.componentTypeComboBox.validator().is_valid.connect(
+                partial(
+                    validate_combobox_edit,
+                    self.componentTypeComboBox,
+                    tooltip_on_reject="Nexus class not valid",
+                    tooltip_on_accept="Nexus class valid",
+                )
+            )
+            self.componentTypeComboBox.validator().is_valid.connect(
+                self.ok_validator.set_nx_class_valid
+            )
+            self.componentTypeComboBox.validator().validate(
+                self.componentTypeComboBox.currentText(), 0
+            )
 
-        self.ok_validator = OkValidator(
-            self.noShapeRadioButton, self.meshRadioButton, self.pixel_options.validator
-        )
         self.ok_validator.is_valid.connect(self.ok_button.setEnabled)
 
         self.nameLineEdit.validator().is_valid.connect(self.ok_validator.set_name_valid)
@@ -363,6 +388,8 @@ class AddComponentDialog(Ui_AddComponentDialog, QObject):
         )
 
     def on_nx_class_changed(self):
+        if not self.componentTypeComboBox.currentText():
+            return
         self.webEngineView.setUrl(
             QUrl(
                 f"http://download.nexusformat.org/sphinx/classes/base_classes/{self.componentTypeComboBox.currentText()}.html"

--- a/nexus_constructor/component_tree_view.py
+++ b/nexus_constructor/component_tree_view.py
@@ -97,7 +97,12 @@ class ComponentEditorDelegate(QStyledItemDelegate):
     def createEditor(
         self, parent: QWidget, option: QStyleOptionViewItem, index: QModelIndex
     ) -> QWidget:
-        frame = self._dict_frames[index]
+        if index in self._dict_frames:
+            frame = self._dict_frames[index]
+        else:
+            model = index.model()
+            value = model.data(index, Qt.DisplayRole)
+            frame = self.get_frame(value)
         if hasattr(frame, TRANSFORMATION_FRAME):
             frame.transformation_frame.enable()
         if hasattr(frame, MODULE_FRAME):

--- a/nexus_constructor/component_type.py
+++ b/nexus_constructor/component_type.py
@@ -101,6 +101,7 @@ NX_CLASSES = {
 }
 
 CHOPPER_CLASS_NAME = "NXdisk_chopper"
+ENTRY_CLASS_NAME = "NXentry"
 SOURCE_CLASS_NAME = "NXsource"
 SAMPLE_CLASS_NAME = "NXsample"
 SLIT_CLASS_NAME = "NXslit"

--- a/nexus_constructor/json/load_from_json.py
+++ b/nexus_constructor/json/load_from_json.py
@@ -12,6 +12,7 @@ from nexus_constructor.common_attrs import (
 )
 from nexus_constructor.component_type import (
     COMPONENT_TYPES,
+    ENTRY_CLASS_NAME,
     NX_CLASSES,
     SAMPLE_CLASS_NAME,
 )
@@ -294,7 +295,7 @@ class JSONReader:
             if (
                 parent_node
                 and isinstance(nexus_object, Dataset)
-                and parent_node.nx_class == "NXentry"
+                and parent_node.nx_class == ENTRY_CLASS_NAME
             ):
                 self.model.entry[nexus_object.name] = nexus_object
             if isinstance(nexus_object, Group) and not nexus_object.nx_class:

--- a/nexus_constructor/model/entry.py
+++ b/nexus_constructor/model/entry.py
@@ -1,6 +1,7 @@
 from copy import copy
 from typing import Any, Dict, List, Tuple
 
+from nexus_constructor.component_type import ENTRY_CLASS_NAME
 from nexus_constructor.model.group import Group
 from nexus_constructor.model.module import Dataset
 from nexus_constructor.model.value_type import ValueTypes
@@ -29,7 +30,7 @@ USERS_PLACEHOLDER = "$USERS$"
 class Entry(Group):
     def __init__(self):
         super().__init__(name="entry", parent_node=None)
-        self.nx_class = "NXentry"
+        self.nx_class = ENTRY_CLASS_NAME
         self._users_placeholder = False
 
     @property

--- a/nexus_constructor/ui_utils.py
+++ b/nexus_constructor/ui_utils.py
@@ -36,6 +36,31 @@ def file_dialog(is_save, caption, filter):
     return filename
 
 
+def validate_combobox_edit(
+    combobox_edit,
+    is_valid: bool,
+    tooltip_on_reject="",
+    tooltip_on_accept="",
+    suggestion_callable=None,
+):
+    """
+    Sets the combobox colour to red if field is invalid or white if valid. Also sets the tooltips, if provided.
+    :param combobox_edit: The combobox object to apply the validation to.
+    :param is_valid: Whether the combobox edit field contains valid text
+    :param suggestion_callable: A callable that returns the suggested alternative if not valid.
+    :param tooltip_on_accept: Tooltip to display combobox edit is valid.
+    :param tooltip_on_reject: Tooltip to display combobox edit is invalid.
+    :return: None.
+    """
+    colour = "#FFFFFF" if is_valid else "#f6989d"
+    combobox_edit.setStyleSheet(f"QComboBox {{ background-color: {colour} }}")
+    if "Suggestion" in tooltip_on_reject and callable(suggestion_callable):
+        tooltip_on_reject += suggestion_callable()
+    combobox_edit.setToolTip(
+        tooltip_on_accept
+    ) if is_valid else combobox_edit.setToolTip(tooltip_on_reject)
+
+
 def validate_line_edit(
     line_edit,
     is_valid: bool,

--- a/nexus_constructor/validators.py
+++ b/nexus_constructor/validators.py
@@ -12,6 +12,7 @@ from PySide2.QtWidgets import QComboBox, QRadioButton, QWidget
 from stl import mesh
 
 from nexus_constructor.common_attrs import SCALAR
+from nexus_constructor.component_type import NX_CLASSES
 from nexus_constructor.model.value_type import VALUE_TYPE_TO_NP
 from nexus_constructor.unit_utils import (
     units_are_expected_dimensionality,
@@ -52,6 +53,7 @@ class UnitValidator(QValidator):
     """
     Validator to ensure the the text entered is a valid unit of length.
     """
+
     ureg = pint.UnitRegistry()
 
     def __init__(self, expected_dimensionality=None):
@@ -130,6 +132,17 @@ class NameValidator(QValidator):
             self.is_valid.emit(False)
             return QValidator.Intermediate
 
+        self.is_valid.emit(True)
+        return QValidator.Acceptable
+
+    is_valid = Signal(bool)
+
+
+class NXClassValidator(QValidator):
+    def validate(self, input: str, pos: int):
+        if not input or input not in NX_CLASSES:
+            self.is_valid.emit(False)
+            return QValidator.Intermediate
         self.is_valid.emit(True)
         return QValidator.Acceptable
 
@@ -288,6 +301,7 @@ class OkValidator(QObject):
         self.name_is_valid = False
         self.file_is_valid = False
         self.units_are_valid = False
+        self.nx_class_is_valid = True
         self.no_geometry_button = no_geometry_button
         self.mesh_button = mesh_button
         self.pixel_validator = pixel_validator
@@ -305,12 +319,17 @@ class OkValidator(QObject):
         self.units_are_valid = is_valid
         self.validate_ok()
 
+    def set_nx_class_valid(self, is_valid):
+        self.nx_class_is_valid = is_valid
+        self.validate_ok()
+
     def validate_ok(self):
         """
         Validates the fields in order to dictate whether the OK button should be disabled or enabled.
         :return: None, but emits the isValid signal.
         """
         unacceptable = [
+            not self.nx_class_is_valid,
             not self.name_is_valid,
             not self.no_geometry_button.isChecked() and not self.units_are_valid,
             self.mesh_button.isChecked() and not self.file_is_valid,

--- a/tests/ui_tests/test_ui_add_component_window.py
+++ b/tests/ui_tests/test_ui_add_component_window.py
@@ -826,6 +826,9 @@ def test_UI_GIVEN_valid_input_WHEN_adding_component_with_no_shape_THEN_add_compo
     qtbot, template, add_component_dialog
 ):
 
+    # Setting a valid nexus class.
+    add_component_dialog.componentTypeComboBox.setCurrentText("NXsample")
+
     # Mimic the user entering a unique name in the text field
     enter_component_name(qtbot, template, add_component_dialog, UNIQUE_COMPONENT_NAME)
 
@@ -839,6 +842,8 @@ def test_UI_GIVEN_valid_input_WHEN_adding_component_with_no_shape_THEN_add_compo
 def test_UI_GIVEN_valid_input_WHEN_adding_component_with_mesh_shape_THEN_add_component_window_closes(
     qtbot, template, add_component_dialog
 ):
+    # Setting a valid nexus class.
+    add_component_dialog.componentTypeComboBox.setCurrentText("NXsample")
 
     # Mimic the user selecting a mesh shape
     systematic_button_press(qtbot, template, add_component_dialog.meshRadioButton)
@@ -868,6 +873,9 @@ def test_UI_GIVEN_valid_input_WHEN_adding_component_with_mesh_shape_THEN_add_com
 def test_UI_GIVEN_valid_input_WHEN_adding_component_with_cylinder_shape_THEN_add_component_window_closes(
     qtbot, template, add_component_dialog
 ):
+    # Setting a valid nexus class.
+    add_component_dialog.componentTypeComboBox.setCurrentText("NXsample")
+
     # Mimic the user selecting a mesh shape
     systematic_button_press(qtbot, template, add_component_dialog.CylinderRadioButton)
 
@@ -895,6 +903,8 @@ def test_UI_GIVEN_no_input_WHEN_adding_component_with_no_shape_THEN_add_componen
 def test_UI_GIVEN_valid_input_WHEN_adding_component_with_no_shape_THEN_add_component_button_is_enabled(
     qtbot, template, add_component_dialog
 ):
+    # Setting a valid nexus class.
+    add_component_dialog.componentTypeComboBox.setCurrentText("NXsample")
 
     # Mimic the user entering a unique name in the text field
     enter_component_name(qtbot, template, add_component_dialog, UNIQUE_COMPONENT_NAME)
@@ -963,6 +973,8 @@ def test_UI_GIVEN_valid_file_path_WHEN_adding_component_with_mesh_shape_THEN_fil
 def test_UI_GIVEN_valid_file_path_WHEN_adding_component_with_mesh_shape_THEN_add_component_button_is_enabled(
     qtbot, template, add_component_dialog
 ):
+    # Setting a valid nexus class.
+    add_component_dialog.componentTypeComboBox.setCurrentText("NXsample")
 
     # Mimic the user selecting a mesh shape
     systematic_button_press(qtbot, template, add_component_dialog.meshRadioButton)
@@ -1083,6 +1095,8 @@ def test_UI_GIVEN_valid_units_WHEN_adding_component_with_mesh_shape_THEN_units_b
 def test_UI_GIVEN_valid_units_WHEN_adding_component_with_mesh_shape_THEN_add_component_button_is_enabled(
     qtbot, template, add_component_dialog
 ):
+    # Setting a valid nexus class.
+    add_component_dialog.componentTypeComboBox.setCurrentText("NXsample")
 
     # Mimic the user selecting a mesh shape
     systematic_button_press(qtbot, template, add_component_dialog.meshRadioButton)
@@ -2221,6 +2235,9 @@ def test_UI_GIVEN_initial_component_THEN_webbrowser_url_contains_component_class
 def test_UI_GIVEN_change_of_component_type_THEN_webbrowser_url_is_updated_and_contains_component_class(
     qtbot, add_component_dialog, template
 ):
+    # Setting a valid nexus class.
+    add_component_dialog.componentTypeComboBox.setCurrentText("NXsample")
+
     current_nx_class = add_component_dialog.componentTypeComboBox.currentText()
 
     new_nx_class = add_component_dialog.componentTypeComboBox.itemText(3)


### PR DESCRIPTION
### Issue

Closes https://jira.esss.lu.se/browse/ECDC-2875

### Description of work

When an existing component or group is edited in the edit group window, it should only suggest nexus classes in the combo box that maintains the object type (i.e. either object type of class Component or Group) using COMPONENT_TYPES and NX_CLASSES sets.
