### PR TITLE
Main window IndexError exception handling

### DIFF
--- a/nexus_constructor/field_widget.py
+++ b/nexus_constructor/field_widget.py
@@ -229,7 +229,7 @@ class FieldWidget(QFrame):
                 validate_line_edit,
                 self.field_name_edit,
                 tooltip_on_accept="Field name is valid.",
-                tooltip_on_reject="Field name is not valid",
+                tooltip_on_reject="Field name is not valid.",
             )
         )
 
@@ -237,7 +237,7 @@ class FieldWidget(QFrame):
         self.edit_button.setText("View")
         self.streams_widget.ok_button.setDisabled(True)
         self.streams_widget.ok_button.setVisible(False)
-        self.streams_widget.cancel_button.setText("finished viewing")
+        self.streams_widget.cancel_button.setText("Finished viewing")
         self.streams_widget.schema_combo.currentTextChanged.connect(
             self.streams_widget._schema_type_changed
         )

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -98,12 +98,15 @@ class MainWindow(Ui_MainWindow, QMainWindow):
         self.show_add_component_window(new_group, new_group=True)
 
     def show_edit_component_dialog(self):
-        selected_component = (
-            self.component_tree_view_tab.component_tree_view.selectedIndexes()[
-                0
-            ].internalPointer()
-        )
-        self.show_add_component_window(selected_component, False)
+        try:
+            selected_component = (
+                self.component_tree_view_tab.component_tree_view.selectedIndexes()[
+                    0
+                ].internalPointer()
+            )
+            self.show_add_component_window(selected_component, False)
+        except IndexError:
+            print("Select a valid group in the NeXus tree view before editing.")
 
     def save_to_filewriter_json(self):
         filename = file_dialog(True, "Save File writer JSON File", JSON_FILE_TYPES)


### PR DESCRIPTION
Fix try catch when throwing index error when trying to edit a group when nothing is selected in the NeXus tree view.