### PR TITLE
ECDC-3019: Do not capitalize fw modules

### DIFF
--- a/nexus_constructor/component_tree_model.py
+++ b/nexus_constructor/component_tree_model.py
@@ -49,7 +49,7 @@ class NexusTreeModel(QAbstractItemModel):
         for item in abs_path:
             sub_tree_root = sub_tree_root[item]
         if not sub_tree_root.parent_node:
-            return None
+            return self.createIndex(0, 0, self.model.entry)
         return self.index_from_component(sub_tree_root)
 
     def columnCount(self, parent: QModelIndex) -> int:

--- a/nexus_constructor/module_view.py
+++ b/nexus_constructor/module_view.py
@@ -13,9 +13,7 @@ STATIC_DATASETS = "dataset"
 class ModuleView(QGroupBox):
     def __init__(self, module, parent: QWidget):
         super().__init__(
-            module.writer_module.upper()
-            if module.writer_module == STATIC_DATASETS
-            else module.writer_module,
+            module.writer_module,
             parent,
         )
         self.setFixedHeight(65)
@@ -56,9 +54,7 @@ class ModuleView(QGroupBox):
 class ModuleViewEditable(QGroupBox):
     def __init__(self, module, parent: QWidget, model: Model):
         super().__init__(
-            module.writer_module.upper()
-            if module.writer_module == STATIC_DATASETS
-            else module.writer_module,
+            module.writer_module,
             parent,
         )
         layout = QVBoxLayout()
@@ -104,11 +100,7 @@ class ModuleViewEditable(QGroupBox):
             StreamMode.value for StreamMode in StreamModules
         ]:
             self.module.writer_module = self.field_widget.value.writer_module
-            self.setTitle(
-                self.module.writer_module.upper()
-                if self.module.writer_module == STATIC_DATASETS
-                else self.module.writer_module
-            )
+            self.setTitle(self.module.writer_module)
             self.module.source = self.field_widget.value.source  # type: ignore
             self.module.topic = self.field_widget.value.topic  # type: ignore
             self.module.attributes.set_attribute_value(


### PR DESCRIPTION
### Issue

Closes ECDC-3019

### Description of work

Do not capitalize FW modules


