### PR TITLE
ECDC-3041: Display depends_on in NeXus tree view

### DIFF
--- a/nexus_constructor/model/component.py
+++ b/nexus_constructor/model/component.py
@@ -106,6 +106,16 @@ class Component(Group):
             self.depends_on.deregister_dependent(self)
 
         self._depends_on = new_depends_on
+        try:
+            self[CommonAttrs.DEPENDS_ON] = Dataset(
+                parent_node=self,
+                name=CommonAttrs.DEPENDS_ON,
+                values=self._depends_on.absolute_path,
+            )
+        except AttributeError:
+            logging.debug(
+                f"NeXus Constructor cannot display depends_on for {self.name} in tree structure."
+            )
         if new_depends_on is not None:
             new_depends_on.register_dependent(self)
 
@@ -510,7 +520,7 @@ class Component(Group):
                 }
             )
         try:
-            if self.depends_on is not None:
+            if self.depends_on is not None and CommonAttrs.DEPENDS_ON not in self:
                 dictionary[CommonKeys.CHILDREN].append(
                     {
                         CommonKeys.MODULE: DATASET,

--- a/tests/model/test_component.py
+++ b/tests/model/test_component.py
@@ -69,10 +69,10 @@ def test_component_as_dict_contains_transformations():
     test_component.depends_on = zeroth_transform
     dictionary_output = test_component.as_dict([])
 
-    assert dictionary_output["children"][0]["name"] == TRANSFORMS_GROUP_NAME
+    assert dictionary_output["children"][1]["name"] == TRANSFORMS_GROUP_NAME
     child_names = [
         child["config"]["name"]
-        for child in dictionary_output["children"][0]["children"]
+        for child in dictionary_output["children"][1]["children"]
     ]
     assert zeroth_transform_name in child_names
     assert first_transform_name in child_names


### PR DESCRIPTION
### Issue

Closes https://jira.esss.lu.se/browse/ECDC-3041

### Description of work

Display depends_on in tree view.

### Acceptance Criteria 

UI test and unit tests work.

### UI tests

Test that depends on is displayed for components when creating them and adding transformations etc.

