### PR TITLE
Ecdc 2979 drag drop groups

### DIFF
--- a/nexus_constructor/component_tree_model.py
+++ b/nexus_constructor/component_tree_model.py
@@ -130,13 +130,7 @@ class NexusTreeModel(QAbstractItemModel):
         elif isinstance(
             parent_item, (Transformation, FileWriterModule, LinkTransformation)
         ):
-            return (
-                Qt.ItemIsSelectable
-                | Qt.ItemIsEnabled
-                | Qt.ItemIsEditable
-                | Qt.ItemIsDragEnabled
-                | Qt.ItemIsDropEnabled
-            )
+            return Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsEditable
         return (
             Qt.ItemIsSelectable
             | Qt.ItemIsEnabled
@@ -172,9 +166,17 @@ class NexusTreeModel(QAbstractItemModel):
         if isinstance(drag_item, Group):
             if drop_item and drag_item.absolute_path in drop_item.absolute_path:
                 return False
-            if isinstance(drop_item, Component):
+            if (
+                isinstance(drop_item, Component)
+                and drop_item
+                and not drop_item.group_placeholder
+            ):
                 return True
-            elif isinstance(drop_item, Group):
+            elif (
+                isinstance(drop_item, Group)
+                and drop_item
+                and not drop_item.group_placeholder
+            ):
                 return True
             else:
                 return False

--- a/nexus_constructor/component_tree_model.py
+++ b/nexus_constructor/component_tree_model.py
@@ -169,9 +169,9 @@ class NexusTreeModel(QAbstractItemModel):
             return False
         if drag_item == drop_item and row == -1:
             return False
-        if drag_item.absolute_path in drop_item.absolute_path:
-            return False
         if isinstance(drag_item, Group):
+            if drop_item and drag_item.absolute_path in drop_item.absolute_path:
+                return False
             if isinstance(drop_item, Component):
                 return True
             elif isinstance(drop_item, Group):

--- a/nexus_constructor/component_tree_model.py
+++ b/nexus_constructor/component_tree_model.py
@@ -156,9 +156,6 @@ class NexusTreeModel(QAbstractItemModel):
 
     def mimeData(self, indexes):
         index = indexes[0]
-        print("--")
-        # print(index.internalPointer().absolute_path)
-        # print(type(index.internalPointer()))
         mimedata = QMimeData()
         data = QByteArray(pickle.dumps(index.internalPointer()))
         mimedata.setData("moving/group", data)
@@ -206,7 +203,6 @@ class NexusTreeModel(QAbstractItemModel):
                 name = child.name
                 old_absolute_path = old_prefix + "/" + name
                 new_absolute_path = new_prefix + "/" + name
-                print("from {} to {}".format(old_absolute_path, new_absolute_path))
                 self.path_translation_dict[new_absolute_path] = old_absolute_path
                 self.model.signals.path_name_changed.emit(
                     old_absolute_path, new_absolute_path

--- a/nexus_constructor/component_tree_model.py
+++ b/nexus_constructor/component_tree_model.py
@@ -212,13 +212,12 @@ class NexusTreeModel(QAbstractItemModel):
     def create_path_translation_dict(self, drag_child_item, drop_item):
         self.path_translation_dict = {}
         drag_child_name = drag_child_item.absolute_path
-        old_prefix = drag_child_name  # .replace('/'+drag_child_item.name, "")
+        old_prefix = drag_child_name
         new_prefix = drop_item.absolute_path + "/" + drag_child_item.name
         self.recursive_path_namer(drag_child_item, old_prefix, new_prefix)
 
     def dropMimeData(self, mimedata, action, row, column, parentIndex):
         if mimedata.hasFormat("moving/group"):
-            # selected_child_item = pickle.loads(mimedata.data("random/general"))
             drag_child_index = self._stored_index
             drag_child_item = self._stored_index.internalPointer()
             drag_child_name = drag_child_item.absolute_path

--- a/nexus_constructor/instrument_view/instrument_view.py
+++ b/nexus_constructor/instrument_view/instrument_view.py
@@ -179,6 +179,7 @@ class InstrumentView(QWidget):
             self.component_entities[new_path] = self.component_entities.pop(old_path)
         if old_path in self.components.keys():
             self.components[new_path] = self.components.pop(old_path)
+            self.transformations[new_path] = self.transformations.pop(old_path)
 
     def create_ground(self):
         """

--- a/nexus_constructor/instrument_view/instrument_view.py
+++ b/nexus_constructor/instrument_view/instrument_view.py
@@ -174,6 +174,12 @@ class InstrumentView(QWidget):
 
         self.view.camera().setViewCenter(self.current_camera_settings["viewcenter"])
 
+    def update_path_name(self, old_path: str, new_path: str):
+        if old_path in self.component_entities.keys():
+            self.component_entities[new_path] = self.component_entities.pop(old_path)
+        if old_path in self.components.keys():
+            self.components[new_path] = self.components.pop(old_path)
+
     def create_ground(self):
         """
         Method for creating the ground entity

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -61,6 +61,7 @@ class MainWindow(Ui_MainWindow, QMainWindow):
         )
         self.model.signals.component_selected.connect(self.sceneWidget.select_component)
         self.model.signals.entity_selected.connect(self.sceneWidget.select_entity)
+        self.model.signals.path_name_changed.connect(self.sceneWidget.update_path_name)
 
     def onOpenAboutWindow(self, instance):
         if self.checkWindowOpen(instance, self._registered_windows):

--- a/nexus_constructor/model/model.py
+++ b/nexus_constructor/model/model.py
@@ -22,6 +22,7 @@ class Signals(QObject):
     group_edited = Signal(QModelIndex, bool)
     component_selected = Signal(str)
     entity_selected = Signal("QVariant")
+    path_name_changed = Signal(str, str)
 
 
 class Model:

--- a/tests/test_component_tree_model.py
+++ b/tests/test_component_tree_model.py
@@ -208,7 +208,10 @@ def test_get_flags_component():
     index = test_component_tree_model.createIndex(0, 0, test_instrument.children[0])
 
     assert test_component_tree_model.flags(index) == (
-        Qt.ItemIsEnabled | Qt.ItemIsSelectable | Qt.ItemIsDropEnabled
+        Qt.ItemIsEnabled
+        | Qt.ItemIsSelectable
+        | Qt.ItemIsDropEnabled
+        | Qt.ItemIsDragEnabled
     )
 
 
@@ -222,7 +225,7 @@ def test_get_flags_component_info():
 
     assert (
         test_component_tree_model.flags(index)
-        == Qt.ItemIsEnabled | Qt.ItemIsDropEnabled
+        == Qt.ItemIsEnabled | Qt.ItemIsDropEnabled | Qt.ItemIsDragEnabled
     )
 
 
@@ -236,7 +239,11 @@ def test_get_flags_transformation_list():
     index = test_component_tree_model.createIndex(0, 0, transformation_group)
 
     assert (
-        test_component_tree_model.flags(index) == Qt.ItemIsEnabled | Qt.ItemIsSelectable
+        test_component_tree_model.flags(index)
+        == Qt.ItemIsEnabled
+        | Qt.ItemIsSelectable
+        | Qt.ItemIsDragEnabled
+        | Qt.ItemIsDropEnabled
     )
 
 
@@ -257,6 +264,7 @@ def test_get_flags_other():
         | Qt.ItemIsSelectable
         | Qt.ItemIsEditable
         | Qt.ItemIsDropEnabled
+        | Qt.ItemIsDragEnabled
     )
 
 


### PR DESCRIPTION
Added drag-and-drop functionality for moving groups and components in the treeview. This might break the drag and drop functionality from wherefore, in that case, it is probably in the function "mimeData" or "canDropMimeData" that the issue lies.