### PR TITLE
adding checks if unit and gap values exist

### DIFF
--- a/nexus_constructor/geometry/slit/slit_geometry.py
+++ b/nexus_constructor/geometry/slit/slit_geometry.py
@@ -34,12 +34,14 @@ class SlitGeometry:
             return ""
 
     def _create_vertices(self):
-        x_gap, y_gap = self._gaps
-        factor = calculate_unit_conversion_factor(self._units, METRES)
-        x_gap *= factor
-        y_gap *= factor
+        if self._units:
+            factor = calculate_unit_conversion_factor(self._units, METRES)
+        else:
+            factor = 1.0
 
+        x_gap, y_gap = self._gaps
         if x_gap:
+            x_gap *= factor
             x_1 = 0.0
             x_2 = -1.0
             half_side_length = x_gap * 2
@@ -50,6 +52,7 @@ class SlitGeometry:
             dx = 0
             half_side_length = 0.05
         if y_gap:
+            y_gap *= factor
             dy = y_gap / 2
             slit_thickness = y_gap * 2
         else:


### PR DESCRIPTION
### Description of work

Small fix to how the slit geometry is set. It caused issues in the cases where the x_gap and y_gap are nxlogs, not values.

### Acceptance Criteria 

Try adding a nxslit, or opening an old file with nxslits. It should be able to load it.


