### PR TITLE
 ECDC-3503-Fix-for-MacOS-dark-mode-breaks-presentation-in-Linux

### DIFF
--- a/nexus-constructor.py
+++ b/nexus-constructor.py
@@ -75,7 +75,8 @@ if __name__ == "__main__":
     if "help" in parser.parse_args():
         exit(0)
     logging.basicConfig(level=logging.INFO)
-    QApplication.setStyle("Fusion")
+    if sys.platform == "darwin":
+        QApplication.setStyle("Fusion")  # this helps macOS but causes Linux GUI to be unusable
     QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
     surfaceFormat = QSurfaceFormat()
     surfaceFormat.setSwapInterval(1)


### PR DESCRIPTION
### Issue

Closes  ECDC-3503-Fix-for-MacOS-dark-mode-breaks-presentation-in-Linux 

Ultimately this will be better fixed with a global stylesheet, but outside of the scope of this ticket

### Description of work

Added If on fusion presentation, which was the GUI change implemented

### Acceptance Criteria 

GUI is usable in Linux

### UI tests

No changes (automated testing did not catch this and passed with validation)

### Nominate for Group Code Review

- [danesss] Nominate for code review 
