### PR TITLE
Ecdc 3633 add component window to widget

### DIFF
--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -508,9 +508,6 @@ class AddComponentDialog(Ui_AddComponentDialog):
         self.fileLineEdit.setText(filename)
 
     def height_reset(self, height):
-#        minimumHeight = self.sizeHint().height()
-        print(self.shapeOptionsBox.sizeHint().height() + self.fieldsBox.sizeHint().height() + self.unitsbox.sizeHint().height() + height)
-        print(self.shapeOptionsBox.sizeHint().height())
         self.setFixedHeight(self.shapeOptionsBox.sizeHint().height() + self.fieldsBox.sizeHint().height() + self.unitsbox.sizeHint().height() + height)
 
     def show_cylinder_fields(self):

--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -65,6 +65,7 @@ class AddComponentDialog(Ui_AddComponentDialog):
         initial_edit: bool,
         nx_classes=None,
         tree_view_updater: Callable = None,
+        use_dialogs: bool = False
     ):
         self._tree_view_updater = tree_view_updater
         self._scene_widget = scene_widget
@@ -95,6 +96,7 @@ class AddComponentDialog(Ui_AddComponentDialog):
         self.valid_file_given = False
         self.pixel_options: PixelOptions = None
         self.setupUi()
+        self.use_dialogs = use_dialogs
 #        self.setModal(True)
         self.setWindowModality(Qt.WindowModal)
         if self.initial_edit:
@@ -114,6 +116,9 @@ class AddComponentDialog(Ui_AddComponentDialog):
             self._group_parent.children.remove(self._group_container.group)
 
     def _confirm_cancel(self) -> bool:
+        if not self.use_dialogs:
+            return True
+
         quit_msg = "Do you want to close the group editor?"
         reply = QMessageBox.question(
             self,

--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -97,7 +97,6 @@ class AddComponentDialog(Ui_AddComponentDialog):
         self.pixel_options: PixelOptions = None
         self.setupUi()
         self.use_dialogs = use_dialogs
-#        self.setModal(True)
         self.setWindowModality(Qt.WindowModal)
         if self.initial_edit:
             self.ok_button.setText("Add group")
@@ -510,6 +509,8 @@ class AddComponentDialog(Ui_AddComponentDialog):
 
     def height_reset(self, height):
 #        minimumHeight = self.sizeHint().height()
+        print(self.shapeOptionsBox.sizeHint().height() + self.fieldsBox.sizeHint().height() + self.unitsbox.sizeHint().height() + height)
+        print(self.shapeOptionsBox.sizeHint().height())
         self.setFixedHeight(self.shapeOptionsBox.sizeHint().height() + self.fieldsBox.sizeHint().height() + self.unitsbox.sizeHint().height() + height)
 
     def show_cylinder_fields(self):
@@ -530,7 +531,7 @@ class AddComponentDialog(Ui_AddComponentDialog):
         self.shapeOptionsBox.setVisible(False)
         if self.nameLineEdit.text():
             self.ok_button.setEnabled(True)
-        self.height_reset(0)
+        self.height_reset(-self.shapeOptionsBox.sizeHint().height())
 
     def show_mesh_fields(self):
         self.shapeOptionsBox.setVisible(True)
@@ -547,7 +548,6 @@ class AddComponentDialog(Ui_AddComponentDialog):
         self.shapeOptionsBox.setEnabled(not placeholder_state)
         self.addFieldPushButton.setEnabled(not placeholder_state)
         self.removeFieldPushButton.setEnabled(not placeholder_state)
-        self.height_reset(0)
 
     def generate_geometry_model(
         self, component: Component, pixel_data: PixelData = None

--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -98,6 +98,7 @@ class AddComponentDialog(Ui_AddComponentDialog):
         self.setupUi()
         self.use_dialogs = use_dialogs
         self.setWindowModality(Qt.WindowModal)
+        self.setHidden(False)
         if self.initial_edit:
             self.ok_button.setText("Add group")
             self.cancel_button.setVisible(True)
@@ -137,6 +138,7 @@ class AddComponentDialog(Ui_AddComponentDialog):
                 self._refresh_tree(group)
             else:
                 self._refresh_tree(self._group_to_edit_backup)
+            self.setHidden(True)
             self.close()
 
     def _cancel_edit_group(self):
@@ -626,7 +628,7 @@ class AddComponentDialog(Ui_AddComponentDialog):
         if not self.initial_edit:
             self.signals.transformation_changed.emit()
         self.model.signals.group_edited.emit(index, True)
-        self.hide()
+        self.setHidden(True)
 
     def keyPressEvent(self, arg__1: QKeyEvent) -> None:
         if arg__1.key() == Qt.Key_Escape:

--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -95,7 +95,7 @@ class AddComponentDialog(Ui_AddComponentDialog):
         self.valid_file_given = False
         self.pixel_options: PixelOptions = None
         self.setupUi()
-        self.setModal(True)
+#        self.setModal(True)
         self.setWindowModality(Qt.WindowModal)
         if self.initial_edit:
             self.ok_button.setText("Add group")
@@ -104,7 +104,7 @@ class AddComponentDialog(Ui_AddComponentDialog):
                 self._handle_class_change
             )
             self.cancel_button.clicked.connect(self._cancel_new_group)
-            self.rejected.connect(self._rejected)
+#            self.rejected.connect(self._rejected)
         else:
             self.cancel_button.setVisible(True)
             self.cancel_button.clicked.connect(self._cancel_edit_group)

--- a/nexus_constructor/add_component_window.py
+++ b/nexus_constructor/add_component_window.py
@@ -503,28 +503,36 @@ class AddComponentDialog(Ui_AddComponentDialog):
         self.cad_file_name = filename
         self.fileLineEdit.setText(filename)
 
+    def height_reset(self, height):
+#        minimumHeight = self.sizeHint().height()
+        self.setFixedHeight(self.shapeOptionsBox.sizeHint().height() + self.fieldsBox.sizeHint().height() + self.unitsbox.sizeHint().height() + height)
+
     def show_cylinder_fields(self):
         self.shapeOptionsBox.setVisible(True)
         self.geometryFileBox.setVisible(False)
         self.cylinderOptionsBox.setVisible(True)
         self.boxOptionsBox.setVisible(False)
+        self.height_reset(self.cylinderOptionsBox.sizeHint().height())
 
     def show_box_fields(self):
         self.shapeOptionsBox.setVisible(True)
         self.geometryFileBox.setVisible(False)
         self.cylinderOptionsBox.setVisible(False)
         self.boxOptionsBox.setVisible(True)
+        self.height_reset(self.boxOptionsBox.sizeHint().height())
 
     def show_no_geometry_fields(self):
         self.shapeOptionsBox.setVisible(False)
         if self.nameLineEdit.text():
             self.ok_button.setEnabled(True)
+        self.height_reset(0)
 
     def show_mesh_fields(self):
         self.shapeOptionsBox.setVisible(True)
         self.geometryFileBox.setVisible(True)
         self.cylinderOptionsBox.setVisible(False)
         self.boxOptionsBox.setVisible(False)
+        self.height_reset(self.geometryFileBox.sizeHint().height())
 
     def _disable_fields_and_buttons(self, placeholder_state: bool):
         self.noShapeRadioButton.setEnabled(not placeholder_state)
@@ -534,6 +542,7 @@ class AddComponentDialog(Ui_AddComponentDialog):
         self.shapeOptionsBox.setEnabled(not placeholder_state)
         self.addFieldPushButton.setEnabled(not placeholder_state)
         self.removeFieldPushButton.setEnabled(not placeholder_state)
+        self.height_reset(0)
 
     def generate_geometry_model(
         self, component: Component, pixel_data: PixelData = None

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -250,7 +250,8 @@ class MainWindow(Ui_MainWindow, QMainWindow):
             nx_classes=self.nx_classes,
             tree_view_updater=self._update_model,
         )
-        self.add_component_window.show()
+        self.main_grid_layout.addWidget(self.add_component_window)
+#        self.add_component_window.show()
 
     def _show_attributes_list_window(
         self, selected_object: Union[Group, FileWriterModule]

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -114,11 +114,7 @@ class MainWindow(Ui_MainWindow, QMainWindow):
             return
         new_group = Group("", parent_node=selected_component)
         selected_component.children.append(new_group)
-        try:
-            if not self.add_component_window.isVisible():
-                self.show_add_component_window(new_group, new_group=True)
-        except (RuntimeError, AttributeError):
-            self.show_add_component_window(new_group, new_group=True)
+        self.show_add_component_window(new_group, new_group=True)
 
     def show_edit_component_dialog(self):
         try:
@@ -254,8 +250,9 @@ class MainWindow(Ui_MainWindow, QMainWindow):
             nx_classes=self.nx_classes,
             tree_view_updater=self._update_model,
         )
-        self.main_grid_layout.addWidget(self.add_component_window)
-#        self.add_component_window.show()
+        if not self.add_component_window.isHidden():
+            self.main_grid_layout.addWidget(self.add_component_window)
+        self.add_component_window.setHidden(False)
 
     def _show_attributes_list_window(
         self, selected_object: Union[Group, FileWriterModule]

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -250,6 +250,7 @@ class MainWindow(Ui_MainWindow, QMainWindow):
             nx_classes=self.nx_classes,
             tree_view_updater=self._update_model,
         )
+        self.add_component_window.setMinimumHeight(self.add_component_window.sizeHint().height())
         self.main_grid_layout.addWidget(self.add_component_window)
 #        self.add_component_window.show()
 

--- a/nexus_constructor/main_window.py
+++ b/nexus_constructor/main_window.py
@@ -114,7 +114,11 @@ class MainWindow(Ui_MainWindow, QMainWindow):
             return
         new_group = Group("", parent_node=selected_component)
         selected_component.children.append(new_group)
-        self.show_add_component_window(new_group, new_group=True)
+        try:
+            if not self.add_component_window.isVisible():
+                self.show_add_component_window(new_group, new_group=True)
+        except (RuntimeError, AttributeError):
+            self.show_add_component_window(new_group, new_group=True)
 
     def show_edit_component_dialog(self):
         try:
@@ -250,7 +254,6 @@ class MainWindow(Ui_MainWindow, QMainWindow):
             nx_classes=self.nx_classes,
             tree_view_updater=self._update_model,
         )
-        self.add_component_window.setMinimumHeight(self.add_component_window.sizeHint().height())
         self.main_grid_layout.addWidget(self.add_component_window)
 #        self.add_component_window.show()
 

--- a/ui/add_component.py
+++ b/ui/add_component.py
@@ -387,9 +387,6 @@ class Ui_AddComponentDialog(QWidget):
         self.unitsLineEdit.setText(
             QtWidgets.QApplication.translate("AddComponentDialog", "m", None, -1)
         )
-        self.fieldsBox.setTitle(
-            QtWidgets.QApplication.translate("AddComponentDialog", "Fields", None, -1)
-        )
         self.addFieldPushButton.setText(
             QtWidgets.QApplication.translate(
                 "AddComponentDialog", "Add field", None, -1

--- a/ui/add_component.py
+++ b/ui/add_component.py
@@ -13,7 +13,7 @@ class Ui_AddComponentDialog(QWidget):
 
     def setupUi(self):
         self.setObjectName("AddComponentDialog")
-        self.resize(1600, 900)
+#        self.resize(1600, 900)
         sizePolicy = QtWidgets.QSizePolicy(
             QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Preferred
         )
@@ -21,6 +21,8 @@ class Ui_AddComponentDialog(QWidget):
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.sizePolicy().hasHeightForWidth())
         self.setSizePolicy(sizePolicy)
+        self.setMaximumHeight(820)
+        self.setMinimumHeight(400)
         self.gridLayout_3 = QtWidgets.QGridLayout(self)
         self.gridLayout_3.setObjectName("gridLayout_3")
         self.buttonLayout = QtWidgets.QHBoxLayout()

--- a/ui/add_component.py
+++ b/ui/add_component.py
@@ -1,12 +1,12 @@
 from PySide6 import QtCore, QtWidgets
 from PySide6.QtWebEngineWidgets import QWebEngineView
-from PySide6.QtWidgets import QDialog
+from PySide6.QtWidgets import QWidget
 
 from nexus_constructor.model import GroupContainer
 from nexus_constructor.widgets import ClassDropDownList, GroupNameEdit
 
 
-class Ui_AddComponentDialog(QDialog):
+class Ui_AddComponentDialog(QWidget):
     def __init__(self, parent: QtWidgets.QWidget, container: GroupContainer):
         super().__init__(parent)
         self._group_container = container

--- a/ui/add_component.py
+++ b/ui/add_component.py
@@ -22,7 +22,7 @@ class Ui_AddComponentDialog(QWidget):
         sizePolicy.setHeightForWidth(self.sizePolicy().hasHeightForWidth())
         self.setSizePolicy(sizePolicy)
         self.setMaximumHeight(820)
-        self.setMinimumHeight(400)
+        self.setMinimumHeight(100)
         self.gridLayout_3 = QtWidgets.QGridLayout(self)
         self.gridLayout_3.setObjectName("gridLayout_3")
         self.buttonLayout = QtWidgets.QHBoxLayout()

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -32,7 +32,7 @@ class Ui_MainWindow(object):
         self.main_grid_layout.setSizeConstraint(QLayout.SetDefaultConstraint)
 
         self.tab_widget = QTabWidget(self.central_widget)
-        self.tab_widget.setMinimumSize(QSize(500, 0))
+        self.tab_widget.setMinimumSize(QSize(800, 0))
         self._set_up_component_tree_view()
         self.splitter.addWidget(self.tab_widget)
 
@@ -47,7 +47,7 @@ class Ui_MainWindow(object):
         self.splitter.setStretchFactor(1, 1)
 
     def _set_up_3d_view(self):
-        self.sceneWidget.setMinimumSize(QSize(600, 0))
+        self.sceneWidget.setMinimumSize(QSize(800, 0))
         self.splitter.addWidget(self.sceneWidget)
 
     def _set_up_component_tree_view(self):


### PR DESCRIPTION
### Issue
We want to move the add component window from being a window to being a widget.  The behaviour should be similar, but NOT block the navigation of the tree or other components.  The behaviour should otherwise be the same.

### Description of work
QDialog is a child of QWidget, so that is simple to change.  However, the window object is normally deleted, and that is something we want to avoid, so instead we use the hidden attribute.  The height of the window changes based on what it is populated with.

### Acceptance Criteria 
Files associated with the 'add component' window

### UI tests
All tests still valid

### Nominate for Group Code Review

- [ ] Nominate for code review 
